### PR TITLE
fix(ci): render chezmoi templates in benchmark sheldon setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,13 +92,17 @@ jobs:
           persist-credentials: false
 
       - name: Install dependencies
-        run: brew install sheldon starship
+        run: brew install chezmoi sheldon starship
 
       - name: Setup sheldon
         run: |
           mkdir -p ~/.config/sheldon ~/.config/zsh
           cp home/dot_config/sheldon/plugins.toml ~/.config/sheldon/plugins.toml
           cp home/dot_config/zsh/*.zsh ~/.config/zsh/
+          for f in home/dot_config/zsh/*.zsh.tmpl; do
+            [ -e "$f" ] || continue
+            chezmoi execute-template -f "$f" > ~/.config/zsh/"$(basename "${f%.tmpl}")"
+          done
           echo 'eval "$(sheldon source)"' > ~/.zshrc
           sheldon lock
 


### PR DESCRIPTION
## Summary
- Add `chezmoi` to benchmark job dependencies
- Render `.zsh.tmpl` files via `chezmoi execute-template` in the sheldon setup step
- Fixes `sheldon lock` failure caused by missing `aliases.zsh` (renamed to `aliases.zsh.tmpl` in PR #22)

## Test plan
- [x] `make lint` passes locally
- [x] `make test` passes locally
- [ ] CI Benchmark job passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)