### PR TITLE
feat(chezmoi): add Claude Code install lifecycle script

### DIFF
--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -68,6 +68,7 @@ jobs:
             home/run_once_before_00-install-prerequisites.sh.tmpl \
             home/run_onchange_before_10-brew-bundle.sh.tmpl \
             home/run_once_after_11-validate-1password.sh.tmpl \
+            home/run_once_after_13-install-claude-code.sh.tmpl \
             home/run_once_after_30-setup-fonts.sh.tmpl \
             home/run_once_after_90-other-apps.sh.tmpl; do
             if [ -f "$f" ]; then
@@ -225,7 +226,8 @@ jobs:
             home/dot_agents/skills/daily-planning/SKILL.md.tmpl \
             home/run_once_before_00-install-prerequisites.sh.tmpl \
             home/run_onchange_before_10-brew-bundle.sh.tmpl \
-            home/run_once_after_11-validate-1password.sh.tmpl; do
+            home/run_once_after_11-validate-1password.sh.tmpl \
+            home/run_once_after_13-install-claude-code.sh.tmpl; do
             if [ -f "$f" ]; then
               mv "$f" /tmp/chezmoi-excluded/
               echo "Excluded: $f"

--- a/home/run_once_after_13-install-claude-code.sh.tmpl
+++ b/home/run_once_after_13-install-claude-code.sh.tmpl
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+if command -v claude &>/dev/null; then
+  echo "==> Claude Code is already installed: $(claude --version 2>/dev/null || echo 'unknown version')"
+  exit 0
+fi
+
+echo "==> Installing Claude Code..."
+
+if ! curl -fsSL https://claude.ai/install.sh | bash; then
+  echo "WARNING: Claude Code installation failed."
+  echo "You can install it manually with: curl -fsSL https://claude.ai/install.sh | bash"
+  exit 0
+fi
+
+if command -v claude &>/dev/null; then
+  echo "==> Claude Code installed successfully: $(claude --version 2>/dev/null || echo 'unknown version')"
+else
+  echo "WARNING: claude command not found in PATH. You may need to restart your shell."
+fi

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -64,6 +64,7 @@ load helpers/setup
   [ -f "${HOME_DIR}/run_onchange_before_10-brew-bundle.sh.tmpl" ]
   [ -f "${HOME_DIR}/run_onchange_after_20-macos-defaults.sh.tmpl" ]
   [ -f "${HOME_DIR}/run_onchange_after_40-setup-sheldon.sh.tmpl" ]
+  [ -f "${HOME_DIR}/run_once_after_13-install-claude-code.sh.tmpl" ]
   [ -f "${HOME_DIR}/run_once_after_90-other-apps.sh.tmpl" ]
 }
 


### PR DESCRIPTION
## Summary

- Add chezmoi lifecycle script (`run_once_after_13`) to install Claude Code via official install script (`curl -fsSL https://claude.ai/install.sh | bash`)
- Skip installation if `claude` command already exists (idempotent)
- Fail gracefully with WARNING on install failure (non-blocking to overall setup)
- Exclude script from CI setup-validation workflows (macOS and Ubuntu)
- Add Bats test for script file existence

## Background

Claude Code is already used in this dotfiles repository for AI agent configuration (`dot_claude/`, `dot_agents/skills/`), but the CLI tool itself was not part of the automated setup flow. Users had to manually install Claude Code after running `chezmoi apply`.

## Changes

| File | Change |
|------|--------|
| `home/run_once_after_13-install-claude-code.sh.tmpl` | New lifecycle script for Claude Code installation |
| `.github/workflows/setup-validation.yml` | Exclude new script from macOS and Ubuntu CI jobs |
| `tests/files.bats` | Add file existence check in lifecycle scripts test |

## Test plan

- [x] `make lint` passes (shellcheck + shfmt)
- [x] `make test-bats` passes (all 34 tests)
- [x] `chezmoi apply` installs Claude Code on a clean machine
- [ ] CI setup-validation passes without executing the install script

🤖 Generated with [Claude Code](https://claude.com/claude-code)
