### PR TITLE
feat(chezmoi): add run_once script to set login shell to zsh on Linux

### DIFF
--- a/home/run_once_after_50-set-login-shell.sh.tmpl
+++ b/home/run_once_after_50-set-login-shell.sh.tmpl
@@ -9,7 +9,12 @@ if [[ -z "$ZSH_PATH" ]]; then
   exit 0
 fi
 
-CURRENT_SHELL="$(getent passwd "$(whoami)" | cut -d: -f7)"
+CURRENT_SHELL="$(getent passwd "$(whoami)" 2>/dev/null | cut -d: -f7 || awk -F: -v user="$(whoami)" '$1 == user {print $NF}' /etc/passwd || true)"
+if [[ -z "$CURRENT_SHELL" ]]; then
+  echo "WARNING: Could not determine current login shell. Skipping."
+  echo "Run manually: chsh -s '$ZSH_PATH'"
+  exit 0
+fi
 if [[ "$CURRENT_SHELL" == "$ZSH_PATH" ]]; then
   echo "==> Login shell is already zsh ($ZSH_PATH). Skipping."
   exit 0
@@ -20,6 +25,11 @@ echo "==> Changing login shell to zsh ($ZSH_PATH)..."
 # Ensure zsh is listed in /etc/shells
 if ! grep -qx "$ZSH_PATH" /etc/shells 2>/dev/null; then
   echo "==> Adding $ZSH_PATH to /etc/shells..."
+  if ! sudo -n true 2>/dev/null; then
+    echo "WARNING: sudo requires a password. Cannot add zsh to /etc/shells."
+    echo "Run manually: echo '$ZSH_PATH' | sudo tee -a /etc/shells && chsh -s '$ZSH_PATH'"
+    exit 0
+  fi
   if ! echo "$ZSH_PATH" | sudo tee -a /etc/shells >/dev/null; then
     echo "WARNING: Failed to add zsh to /etc/shells."
     echo "Run manually: echo '$ZSH_PATH' | sudo tee -a /etc/shells && chsh -s '$ZSH_PATH'"

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -65,6 +65,7 @@ load helpers/setup
   [ -f "${HOME_DIR}/run_onchange_after_20-macos-defaults.sh.tmpl" ]
   [ -f "${HOME_DIR}/run_onchange_after_40-setup-sheldon.sh.tmpl" ]
   [ -f "${HOME_DIR}/run_once_after_13-install-claude-code.sh.tmpl" ]
+  [ -f "${HOME_DIR}/run_once_after_50-set-login-shell.sh.tmpl" ]
   [ -f "${HOME_DIR}/run_once_after_90-other-apps.sh.tmpl" ]
 }
 


### PR DESCRIPTION
## Summary

- Add a `run_once` chezmoi lifecycle script that automatically changes the login shell to zsh on Linux
- Skips on macOS since zsh is already the default shell
- Idempotent: skips if zsh is already the login shell

Closes #48

## Changes

- **`home/run_once_after_50-set-login-shell.sh.tmpl`** (new file)
  - Linux-only via chezmoi template guard (`{{ if eq .chezmoi.os "linux" }}`)
  - Detects zsh path and verifies it is installed
  - Checks current login shell via `getent passwd`
  - Ensures zsh is listed in `/etc/shells` before running `chsh`
  - Gracefully handles failures (warns and exits 0 so `chezmoi apply` continues)

## Test plan

- [x] `make lint` passes (shellcheck + shfmt)
- [x] `make test` passes (bats)
- [ ] Verify on a fresh Linux environment that the login shell is changed to zsh after `chezmoi apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
