### PR TITLE
ci: optimize workflow concurrency and cut macOS runner contention

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,48 @@
+name: Benchmark
+
+on:
+  schedule:
+    # Weekly on Monday 00:00 UTC
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: macos-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: brew install chezmoi sheldon starship
+
+      - name: Setup sheldon
+        run: |
+          mkdir -p ~/.config/sheldon ~/.config/zsh
+          cp home/dot_config/sheldon/plugins.toml ~/.config/sheldon/plugins.toml
+          cp home/dot_config/zsh/*.zsh ~/.config/zsh/
+          for f in home/dot_config/zsh/*.zsh.tmpl; do
+            [ -e "$f" ] || continue
+            chezmoi execute-template -f "$f" > ~/.config/zsh/"$(basename "${f%.tmpl}")"
+          done
+          # shellcheck disable=SC2016  # literal sheldon init line; must not expand
+          echo 'eval "$(sheldon source)"' > ~/.zshrc
+          sheldon lock
+
+      - name: Benchmark zsh startup
+        run: |
+          echo "=== Zsh Startup Benchmark ==="
+          for _ in $(seq 1 10); do
+            /usr/bin/time zsh -i -c exit 2>&1
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ on:
       - '.github/workflows/ci.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -62,7 +66,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
@@ -73,42 +77,9 @@ jobs:
           persist-credentials: false
 
       - name: Install dependencies
-        run: brew install bats-core chezmoi shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats shellcheck zsh
 
       - name: Run Bats tests
         run: bats tests/*.bats
-
-  benchmark:
-    name: Benchmark
-    runs-on: macos-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    needs: test
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Install dependencies
-        run: brew install chezmoi sheldon starship
-
-      - name: Setup sheldon
-        run: |
-          mkdir -p ~/.config/sheldon ~/.config/zsh
-          cp home/dot_config/sheldon/plugins.toml ~/.config/sheldon/plugins.toml
-          cp home/dot_config/zsh/*.zsh ~/.config/zsh/
-          for f in home/dot_config/zsh/*.zsh.tmpl; do
-            [ -e "$f" ] || continue
-            chezmoi execute-template -f "$f" > ~/.config/zsh/"$(basename "${f%.tmpl}")"
-          done
-          echo 'eval "$(sheldon source)"' > ~/.zshrc
-          sheldon lock
-
-      - name: Benchmark zsh startup
-        run: |
-          echo "=== Zsh Startup Benchmark ==="
-          for i in $(seq 1 10); do
-            /usr/bin/time zsh -i -c exit 2>&1
-          done

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,10 @@ on:
   merge_group:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/setup-pr.yml
+++ b/.github/workflows/setup-pr.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
     types: [opened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## Summary

Optimizes GitHub Actions workflow concurrency to stop superseded runs from piling up, and removes macOS runners from the per-push CI path. Triggered by a real incident: merging 21 Renovate PRs in a burst created a backlog of concurrent runs (each `ci.yml` push spawned an independent run with macOS jobs, none cancelled), saturating the macOS runner pool and starving an open PR's validation job.

## Root cause

| Workflow | Before | Problem |
|----------|--------|---------|
| `ci.yml` | no `concurrency` | every push/PR ran independently; 21 merges → up to 13 queued main runs, each with macOS `test`/`benchmark` jobs |
| `codeql.yml` | no `concurrency` | superseded runs not cancelled |
| `setup-pr.yml` | no `concurrency` | (minor) |
| `setup-validation.yml` | already had `concurrency` | collapsed to 1 main run correctly — confirms the fix works |

## Changes

- **Add `concurrency` groups with `cancel-in-progress: true`** to `ci.yml`, `codeql.yml`, and `setup-pr.yml`. Group key `${{ github.workflow }}-${{ github.ref }}`:
  - On `main`, all pushes share one group → a merge burst collapses to the latest run. Safe here because `main` is cumulative and only HEAD correctness matters (no per-deploy gating).
  - On PRs, each PR ref is isolated; a new commit cancels its own prior run.
- **Move the `Test` job from `macos-latest` to `ubuntu-latest`.** The bats suite (`files.bats`/`shellcheck.bats`/`zsh_syntax.bats`) only needs `bats`/`shellcheck`/`zsh` — no macOS-specific behavior. Dependencies switched from `brew` to `apt`.
- **Split the macOS-only `Benchmark` job out of `ci.yml` into a dedicated `benchmark.yml`** triggered weekly (cron) and via `workflow_dispatch`, removing macOS from the per-push CI path entirely.

After this, macOS runners are consumed only by `setup-validation` (already concurrency-guarded) and the weekly benchmark.

## Verification

- `actionlint` — clean on all four workflows
- `make lint` — passed (shellcheck + shfmt + zsh syntax)
- `make test` — passed (36 bats tests)

## Notes

- This does **not** touch the pre-existing `setup-validation` failures tracked in #104 (Ubuntu brew Cask API bug; macOS `python` `lib` directory). Investigation during this work confirmed `python@3.14.5` (#108) does **not** fix the macOS side — mise selects a `freethreaded ... install_only_stripped` CPython build that lacks `lib/`. That is a flavor-selection issue, separate from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
