### PR TITLE
fix(ci): pin python precompiled flavor to install_only in setup-validation

### DIFF
--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -92,6 +92,10 @@ jobs:
       - name: Apply dotfiles with chezmoi
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # Force a precompiled CPython flavor that ships lib/ (see #104).
+          # Latest mise otherwise selects freethreaded+install_only_stripped,
+          # which omits lib/ and fails: "Python installation is missing a `lib` directory".
+          MISE_PYTHON_PRECOMPILED_FLAVOR: install_only
         run: |
           mkdir -p ~/.config/chezmoi
           cp home/.chezmoi.toml ~/.config/chezmoi/chezmoi.toml
@@ -236,6 +240,10 @@ jobs:
       - name: Apply dotfiles with chezmoi
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # Force a precompiled CPython flavor that ships lib/ (see #104).
+          # Latest mise otherwise selects freethreaded+install_only_stripped,
+          # which omits lib/ and fails: "Python installation is missing a `lib` directory".
+          MISE_PYTHON_PRECOMPILED_FLAVOR: install_only
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           mkdir -p ~/.config/chezmoi


### PR DESCRIPTION
## Summary

Fixes the macOS side of #104: the `Validate dotfiles setup (macOS)` job fails with

```
mise ERROR Failed to install core:python@3.14.x: Python installation is missing a `lib` directory
download: cpython-3.14.x+...-aarch64-apple-darwin-freethreaded-install_only_stripped.tar.gz
```

## Root cause

This is a **CI-only mise regression**, not a version or local-config problem:

- On the dev machine (pinned mise `2026.4.14`), `python@3.14.4` installs correctly **with** a `lib/` directory.
- In CI, mise is freshly downloaded at **latest** during the run and selects the **`freethreaded` + `install_only_stripped`** precompiled CPython flavor. The `*_stripped` archive omits `lib/`, which mise's `core:python` plugin requires, so install fails on every retry.
- Because the trigger is the **build flavor**, bumping the version (#108: `3.14.5`) does **not** help — `3.14.4` and `3.14.5` fail identically.

## Change

Set `MISE_PYTHON_PRECOMPILED_FLAVOR=install_only` on the "Apply dotfiles with chezmoi" step (where `mise install` runs) in **both** the macOS and Ubuntu jobs of `setup-validation.yml`. `install_only` is the standard archive that ships `lib/`.

Scoped to CI only — the working local config (`home/dot_config/mise/config.toml`) is left untouched.

## Verification

This PR edits `setup-validation.yml`, so it triggers the Setup Validation workflow itself — the macOS job result on this PR is the verification. `actionlint` is clean.

## Follow-ups (not in this PR)

- The **Ubuntu** failure in #104 (Homebrew Cask API bug failing `aqua`/`lychee`) is unrelated and still open.
- Once the macOS job is green here, **#108** (`python@3.14.5`, currently held/blocked by #104) can be merged.

Refs #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
