### PR TITLE
fix(ci): refresh Homebrew before bundle to dodge cask API crash on Ubuntu

### DIFF
--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -204,6 +204,11 @@ jobs:
             NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           fi
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          # Refresh Homebrew on cache hits: the cached install otherwise pins an
+          # old snapshot whose cask API parser crashes with
+          # "undefined method 'first' for nil" (cask.rb) when brew bundle checks
+          # cask conflicts for formulas like aqua/lychee. See #104.
+          brew update --force --quiet
           brew --version
 
       - name: Install Homebrew formulas only


### PR DESCRIPTION
## Summary

Fixes the **Ubuntu** side of #104: `Validate dotfiles setup (Ubuntu)` fails at `brew bundle` with

```
undefined method 'first' for nil
  .../Homebrew/api/cask.rb:181:in 'generate_cask_struct_hash'
`brew bundle` failed! Failed to fetch aqua, lychee
```

## Root cause

`aqua` and `lychee` are **formulae**, but `brew bundle` loads same-named **casks** to emit a conflict warning (`warn_if_cask_conflicts`). The cask API parser in the cached Homebrew crashes on that path.

The Ubuntu job **caches the entire Linuxbrew install** (`/home/linuxbrew/.linuxbrew`) and the install step is skipped on a cache hit — so an **old, buggy Homebrew snapshot is pinned** across runs and keeps crashing. The macOS job is unaffected (it caches only bottles, not the Homebrew code, and already passes).

## Change

Run `brew update --force --quiet` after restoring the cache (in the "Install Homebrew (Linuxbrew)" step) so the Homebrew code and taps are refreshed to a version that parses the cask API correctly. The bottle cache benefit is preserved (only the git repos/API are refreshed).

Scoped to the Ubuntu job; full Linux coverage (including aqua/lychee) is retained — no formulae are excluded.

## Verification

This PR edits `setup-validation.yml`, so it triggers the Setup Validation workflow itself — the Ubuntu job result on this PR is the verification.

Refs #104
Closes #104 (once the Ubuntu job is green here; the macOS side was already fixed by #119)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
