### PR TITLE
fix(mise): pin precompiled cpython flavor to ship lib/ on fresh apply (#121)

### DIFF
--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -92,10 +92,6 @@ jobs:
       - name: Apply dotfiles with chezmoi
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          # Force a precompiled CPython flavor that ships lib/ (see #104).
-          # Latest mise otherwise selects freethreaded+install_only_stripped,
-          # which omits lib/ and fails: "Python installation is missing a `lib` directory".
-          MISE_PYTHON_PRECOMPILED_FLAVOR: install_only
         run: |
           mkdir -p ~/.config/chezmoi
           cp home/.chezmoi.toml ~/.config/chezmoi/chezmoi.toml
@@ -245,10 +241,6 @@ jobs:
       - name: Apply dotfiles with chezmoi
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          # Force a precompiled CPython flavor that ships lib/ (see #104).
-          # Latest mise otherwise selects freethreaded+install_only_stripped,
-          # which omits lib/ and fails: "Python installation is missing a `lib` directory".
-          MISE_PYTHON_PRECOMPILED_FLAVOR: install_only
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           mkdir -p ~/.config/chezmoi

--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -34,3 +34,9 @@ zoxide = "0.9.9"
 
 # npm backend
 gemini-cli = "0.45.0"
+
+[settings]
+# Pin precompiled CPython to a flavor that ships lib/; latest mise otherwise
+# selects freethreaded+install_only_stripped, which omits lib/ and fails with
+# "Python installation is missing a `lib` directory" on fresh installs (see #121, #104).
+python.precompiled_flavor = "install_only"


### PR DESCRIPTION
## Summary

Fixes the python half of #123 (sub-issue #121): on a fresh `chezmoi apply`, `mise install` selected
the `freethreaded + install_only_stripped` CPython flavor, which omits `lib/` and fails with
`Python installation is missing a 'lib' directory`.

This pins the precompiled CPython flavor to `install_only` as a **persisted mise setting** in
`config.toml`, so every consumer inherits it: the runtime setup script
(`run_onchange_after_12-setup-mise.sh.tmpl`), an interactive `mise install`, and CI. This satisfies
the acceptance criterion that the fix live in the runtime path, not only CI.

The CI workaround (`MISE_PYTHON_PRECOMPILED_FLAVOR` env, added in #119) is now redundant and removed
from both setup-validation jobs. Because adding `[settings]` changes the `config.toml` hash, the mise
cache key is busted and CI performs a fresh `mise install` — so this PR's green CI is itself the
end-to-end proof that the `config.toml` setting drives correct asset selection.

## Changes

- `home/dot_config/mise/config.toml`: add `[settings]` with `python.precompiled_flavor = "install_only"`.
- `.github/workflows/setup-validation.yml`: remove the now-redundant `MISE_PYTHON_PRECOMPILED_FLAVOR`
  env from both the macOS and Ubuntu jobs.

## Verification

- `make lint` ✅ / `make test` ✅ (36 bats tests pass)
- Verified locally that `config.toml [settings]` is honored by mise (`mise settings
  python.precompiled_flavor` → `install_only`) and that the env var maps to the same setting key.
- CI (setup-validation, macOS + Ubuntu) exercises a fresh `mise install` under the new setting.

## Notes

- This is the **first** PR of a stacked pair for #123. The ruby fix (#122) stacks on top of this branch.

Closes #121
