### PR TITLE
fix(mise): use precompiled ruby to avoid source-build deadlock (#122)

### DIFF
--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -40,3 +40,7 @@ gemini-cli = "0.45.0"
 # selects freethreaded+install_only_stripped, which omits lib/ and fails with
 # "Python installation is missing a `lib` directory" on fresh installs (see #121, #104).
 python.precompiled_flavor = "install_only"
+# Use precompiled ruby; a source build deadlocks on fresh installs without a
+# baseruby on PATH, because ruby-build's configure probe re-enters the mise
+# shim for the in-progress version and blocks on the install lock (see #122).
+ruby.compile = false


### PR DESCRIPTION
## Summary

Fixes the ruby half of #123 (sub-issue #122): on a fresh `chezmoi apply` in an environment with no
usable baseruby on PATH, `mise install` deadlocks while compiling ruby from source. ruby-build's
`./configure` baseruby probe invokes the mise `ruby` shim, which tries to auto-install the
in-progress version and blocks on the mise install lock — hanging indefinitely.

This sets `ruby.compile = false` as a **persisted mise setting** in `config.toml`, so ruby installs
from a precompiled build instead of compiling from source. This removes the deadlock entirely, is
much faster, and is inherited by every consumer (runtime setup script, interactive `mise install`,
CI). Precompiled becomes the mise default in 2026.8.0 anyway.

## Changes

- `home/dot_config/mise/config.toml`: add `ruby.compile = false` to `[settings]`.

## Verification

- `make lint` ✅ / `make test` ✅ (36 bats tests pass)
- Verified `config.toml [settings] ruby.compile = false` is honored by mise (`mise settings
  ruby.compile` → `false`).
- Verified the precompiled ruby asset for the pinned version exists for **macOS arm64**
  (`ruby-<ver>.macos.tar.gz` → `Mach-O arm64`) and linux x86_64/arm64, so forcing precompiled is
  safe across the targeted platforms.

## Notes

- **Stacked on top of #124** (#121). Base branch is `fix/121-mise-python-precompiled-flavor`; GitHub
  will retarget this PR to `main` automatically once #124 merges.
- The #122 deadlock cannot be reproduced on standard CI runners (they have a system ruby / baseruby),
  so correctness here rests on the evidence above rather than a CI repro. A follow-up to add a
  no-baseruby regression job is proposed separately.

Closes #122
