### PR TITLE
ci(setup-validation): guard ruby install without baseruby (#126)

### DIFF
--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -318,3 +318,51 @@ jobs:
           fi
           echo "OK: zsh starts cleanly"
         timeout-minutes: 2
+
+  # Regression guard for #122: in an environment with no baseruby on PATH, a ruby
+  # source build deadlocks because ruby-build's configure probe re-enters the mise
+  # shim for the in-progress version and blocks on the install lock. Standard runners
+  # ship a system ruby and never reproduce this, so we run on a minimal container with
+  # no ruby and assert `mise install ruby` finishes (precompiled) instead of hanging.
+  ruby-no-baseruby-guard:
+    name: Guard ruby install without baseruby
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Install minimal prerequisites
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends ca-certificates curl git xz-utils
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Assert no baseruby on PATH
+        run: |
+          if command -v ruby >/dev/null 2>&1; then
+            echo "ERROR: ruby found on PATH ($(command -v ruby)); this guard must run without a baseruby."
+            exit 1
+          fi
+          echo "OK: no ruby on PATH."
+
+      - name: Install mise
+        run: |
+          curl -fsSL https://mise.run | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install ruby via mise (precompiled; must not deadlock)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # Use the repo's mise config (with [settings] ruby.compile = false) as the active config.
+          cp home/dot_config/mise/config.toml ./mise.toml
+          mise trust ./mise.toml
+          # With ruby.compile = false, mise fetches a precompiled build and finishes quickly.
+          # If that setting regresses, the source build deadlocks (see #122); the timeout then
+          # kills it so this job fails fast instead of hanging indefinitely.
+          timeout --kill-after=30s 300 mise install ruby
+          mise ls ruby
+        timeout-minutes: 10

--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -328,6 +328,7 @@ jobs:
     name: Guard ruby install without baseruby
     runs-on: ubuntu-latest
     container: ubuntu:24.04
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -365,4 +366,3 @@ jobs:
           # kills it so this job fails fast instead of hanging indefinitely.
           timeout --kill-after=30s 300 mise install ruby
           mise ls ruby
-        timeout-minutes: 10


### PR DESCRIPTION
## Summary

Adds the regression guard requested in #126: a CI job that reproduces the fresh-install condition
behind the #122 ruby source-build deadlock — an environment with **no baseruby on PATH** — so the
fix (`ruby.compile = false`) cannot silently regress.

Standard CI runners (macOS, Ubuntu) ship a system ruby and therefore never reproduce the deadlock,
which left the #122 fix unguarded in CI. This job runs on a minimal `ubuntu:24.04` container (no
system ruby) and asserts that `mise install ruby` completes via a precompiled build instead of
hanging.

## How it guards

- Runs on `container: ubuntu:24.04` and first asserts `ruby` is **not** on PATH.
- Installs mise, points it at the repo's `home/dot_config/mise/config.toml` (which carries
  `[settings] ruby.compile = false`), and runs `mise install ruby` under a 300s timeout.
- With precompiled ruby enforced, the install finishes quickly → job passes.
- If `ruby.compile = false` is ever removed/overridden, ruby-build's configure probe re-enters the
  mise shim with no baseruby and deadlocks; the timeout kills it → job fails fast (no indefinite
  hang).
- The ruby version is taken from the active mise config (no hardcoded version, stays in sync).

## Changes

- `.github/workflows/setup-validation.yml`: add the `ruby-no-baseruby-guard` job.

## Verification

- `make lint` ✅ / `make test` ✅ (36 bats tests pass)
- `actionlint` ✅ (no findings)

## Notes

- Per the agreed design, this is the **positive guard only** (no intentional `compile=true` hang
  reproduction), to avoid fragility against upstream mise changes (e.g. precompiled becoming the
  default in 2026.8.0).

Closes #126
