### PR TITLE
feat(codex): Codex CLI multi-account coexistence

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -39,9 +39,58 @@
 .claude-r06/todos
 
 # Codex runtime data
+# config.toml is intentionally unmanaged (Codex writes trust_level etc. dynamically);
+# auth.json holds login tokens and must never be added to the source tree.
+.codex/.codex-global-state.json
 .codex/.personality_migration
+.codex/.tmp
+.codex/auth.json
+.codex/cache
+.codex/config.toml
+.codex/goals_*.sqlite*
+.codex/history.jsonl
+.codex/installation_id
+.codex/log
+.codex/logs_*.sqlite*
+.codex/memories
+.codex/memories_*.sqlite*
+.codex/models_cache.json
+.codex/plugins
+.codex/session_index.jsonl
+.codex/sessions
+.codex/shell_snapshots
 .codex/skills/.system
+.codex/sqlite
+.codex/state_*.sqlite*
 .codex/tmp
+.codex/vendor_imports
+.codex/version.json
+
+# Codex runtime data (work account)
+.codex-r06/.codex-global-state.json
+.codex-r06/.personality_migration
+.codex-r06/.tmp
+.codex-r06/auth.json
+.codex-r06/cache
+.codex-r06/config.toml
+.codex-r06/goals_*.sqlite*
+.codex-r06/history.jsonl
+.codex-r06/installation_id
+.codex-r06/log
+.codex-r06/logs_*.sqlite*
+.codex-r06/memories
+.codex-r06/memories_*.sqlite*
+.codex-r06/models_cache.json
+.codex-r06/plugins
+.codex-r06/session_index.jsonl
+.codex-r06/sessions
+.codex-r06/shell_snapshots
+.codex-r06/skills/.system
+.codex-r06/sqlite
+.codex-r06/state_*.sqlite*
+.codex-r06/tmp
+.codex-r06/vendor_imports
+.codex-r06/version.json
 
 # AWS cache
 .aws/cli

--- a/home/.chezmoitemplates/codex-shared-config.toml
+++ b/home/.chezmoitemplates/codex-shared-config.toml
@@ -1,0 +1,6 @@
+personality = "pragmatic"
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
+
+[features]
+multi_agent = true

--- a/home/dot_codex-r06/private_shared.config.toml.tmpl
+++ b/home/dot_codex-r06/private_shared.config.toml.tmpl
@@ -1,0 +1,1 @@
+{{ includeTemplate "codex-shared-config.toml" . }}

--- a/home/dot_codex-r06/symlink_AGENTS.md.tmpl
+++ b/home/dot_codex-r06/symlink_AGENTS.md.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/AGENTS.md

--- a/home/dot_codex-r06/symlink_skills.tmpl
+++ b/home/dot_codex-r06/symlink_skills.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.agents/skills

--- a/home/dot_codex/private_shared.config.toml.tmpl
+++ b/home/dot_codex/private_shared.config.toml.tmpl
@@ -1,0 +1,1 @@
+{{ includeTemplate "codex-shared-config.toml" . }}

--- a/home/dot_config/sheldon/plugins.toml
+++ b/home/dot_config/sheldon/plugins.toml
@@ -42,6 +42,11 @@ local = "~/.config/zsh"
 use = ["claude.zsh"]
 apply = ["defer"]
 
+[plugins.codex-helpers]
+local = "~/.config/zsh"
+use = ["codex.zsh"]
+apply = ["defer"]
+
 [plugins.functions]
 local = "~/.config/zsh"
 use = ["functions.zsh"]

--- a/home/dot_config/zsh/codex.zsh
+++ b/home/dot_config/zsh/codex.zsh
@@ -1,0 +1,11 @@
+# Codex CLI multi-account helpers (shared by ~/.codex and ~/.codex-r06).
+# Personal account uses the default ~/.codex (no CODEX_HOME set); the work
+# account sets CODEX_HOME=~/.codex-r06 for that invocation only.
+# `--profile shared` layers $CODEX_HOME/shared.config.toml (chezmoi-managed SSOT)
+# on top of the dynamically-written config.toml.
+#
+# NOTE: Running bare `codex` (without these aliases) does NOT load
+#       shared.config.toml, so the SSOT static config is not applied.
+#       Always use `cdx` / `cdx-r06` to pick an account with the SSOT config.
+alias cdx='codex --profile shared'
+alias cdx-r06='CODEX_HOME=$HOME/.codex-r06 codex --profile shared'

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -55,7 +55,7 @@ load helpers/setup
 }
 
 @test "zsh modules exist" {
-  local modules=(git docker claude functions completions wtp)
+  local modules=(git docker claude codex functions completions wtp)
   for mod in "${modules[@]}"; do
     [ -f "${HOME_DIR}/dot_config/zsh/${mod}.zsh" ]
   done
@@ -90,6 +90,17 @@ load helpers/setup
 @test "claude and codex skills are symlinked" {
   [ -f "${HOME_DIR}/dot_claude/symlink_skills.tmpl" ]
   [ -f "${HOME_DIR}/dot_codex/symlink_skills.tmpl" ]
+}
+
+@test "codex-r06 work profile sources exist" {
+  [ -f "${HOME_DIR}/dot_codex-r06/symlink_AGENTS.md.tmpl" ]
+  [ -f "${HOME_DIR}/dot_codex-r06/symlink_skills.tmpl" ]
+  [ -f "${HOME_DIR}/dot_codex-r06/private_shared.config.toml.tmpl" ]
+}
+
+@test "codex shared config SSOT exists" {
+  [ -f "${HOME_DIR}/.chezmoitemplates/codex-shared-config.toml" ]
+  [ -f "${HOME_DIR}/dot_codex/private_shared.config.toml.tmpl" ]
 }
 
 @test "claude-r06 work profile symlinks exist" {

--- a/tests/zsh_syntax.bats
+++ b/tests/zsh_syntax.bats
@@ -18,6 +18,10 @@ load helpers/setup
   zsh -n "${HOME_DIR}/dot_config/zsh/claude.zsh"
 }
 
+@test "zsh syntax: codex.zsh" {
+  zsh -n "${HOME_DIR}/dot_config/zsh/codex.zsh"
+}
+
 @test "zsh syntax: functions.zsh" {
   zsh -n "${HOME_DIR}/dot_config/zsh/functions.zsh"
 }


### PR DESCRIPTION
## Overview

Enables using two Codex CLI accounts (personal and work) side by side, mirroring the existing Claude Code `.claude-r06` / `cld-r06` approach.

Codex stores its login in a single `$CODEX_HOME/auth.json` and overwrites it on every `codex login`, so account isolation requires separating `CODEX_HOME` itself rather than switching profiles.

## Design

- **CODEX_HOME separation** — personal account uses the default `~/.codex`; the work account uses `~/.codex-r06`, selected per-invocation via the `cdx-r06` alias.
- **Profile layering for static settings** — `config.toml` stays unmanaged because Codex writes `trust_level` etc. dynamically (managing it would cause constant `chezmoi diff` drift). Static SSOT settings (`model`, `personality`, `model_reasoning_effort`, `[features]`) live in `shared.config.toml` and are layered on top of the base config via `--profile shared`. Verified on codex-cli 0.139.0 that `--profile shared` loads `$CODEX_HOME/shared.config.toml`.
- **SSOT, DRY** — the static config is defined once in `.chezmoitemplates/codex-shared-config.toml` and `includeTemplate`-d into both homes' `shared.config.toml`.
- **Shared assets** — `AGENTS.md` and `skills` are symlinked into `~/.codex-r06`, pointing at the same `~/AGENTS.md` and `~/.agents/skills` as the personal account.

## Changes

| File | Purpose |
|---|---|
| `home/.chezmoitemplates/codex-shared-config.toml` | SSOT static config (new `.chezmoitemplates` dir) |
| `home/dot_codex/private_shared.config.toml.tmpl` | Personal `~/.codex/shared.config.toml` |
| `home/dot_codex-r06/` | Work account symlinks (`AGENTS.md`, `skills`) + `shared.config.toml` |
| `home/dot_config/zsh/codex.zsh` | `cdx` / `cdx-r06` aliases (`--profile shared`) |
| `home/dot_config/sheldon/plugins.toml` | Register `codex.zsh` for deferred loading |
| `home/.chezmoiignore` | Exclude Codex runtime data (`auth.json`, `config.toml`, sqlite, sessions, ...) for `.codex` and `.codex-r06` |
| `tests/files.bats`, `tests/zsh_syntax.bats` | Coverage for the new sources |

## Usage

```sh
cdx        # personal account (~/.codex)
cdx-r06    # work account (~/.codex-r06)
```

One-time setup for the work account: `CODEX_HOME=$HOME/.codex-r06 codex login`.

> [!NOTE]
> Running bare `codex` (without the aliases) does not load `shared.config.toml`, so the SSOT static config is not applied. Always use `cdx` / `cdx-r06`.

## Verification

- `make test` — 47 Bats tests pass (lint + shellcheck + zsh syntax)
- `chezmoi managed | grep codex` — only the 6 managed files are tracked; `auth.json` / sqlite / sessions are correctly excluded
- `chezmoi cat ~/.codex/shared.config.toml` and `~/.codex-r06/shared.config.toml` render the SSOT correctly
- Reviewed by two independent agents (code-quality + chezmoi-correctness): both APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
