### PR TITLE
Operationalize ghq in dotfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,13 +99,20 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: true
+          # persist-credentials must stay false (ghalint policy 013); the
+          # push step below uses an ephemeral token URL instead.
+          persist-credentials: false
+
+      - name: Install zsh (required by the sync target's syntax check)
+        run: sudo apt-get update && sudo apt-get install -y zsh
 
       - name: Run sync-ghq-completion
         run: make sync-ghq-completion
 
       - name: Commit & push if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if git diff --quiet home/dot_config/zsh/completions/_ghq; then
             echo "No change to _ghq; skipping commit."
@@ -116,4 +123,6 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add home/dot_config/zsh/completions/_ghq
           git commit -m "chore: sync _ghq completion for ghq v${version}"
-          git push
+          # Push with an ephemeral token URL — credentials are never written
+          # back to .git/config (ghalint policy 013).
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,41 @@ jobs:
 
       - name: Run Bats tests
         run: bats tests/*.bats
+
+  sync-ghq-completion:
+    name: Sync ghq completion
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Same-repo PRs only: fork PRs would receive a read-only GITHUB_TOKEN
+    # (so the push step would fail anyway), but skipping them up front avoids
+    # executing fork-side Makefile code in CI.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+
+      - name: Run sync-ghq-completion
+        run: make sync-ghq-completion
+
+      - name: Commit & push if changed
+        run: |
+          if git diff --quiet home/dot_config/zsh/completions/_ghq; then
+            echo "No change to _ghq; skipping commit."
+            exit 0
+          fi
+          version=$(grep -E '^ghq[[:space:]]*=' home/dot_config/mise/config.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Unexpected ghq version format: $version"
+            exit 1
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add home/dot_config/zsh/completions/_ghq
+          git commit -m "chore: sync _ghq completion for ghq v${version}"
+          git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,7 @@ jobs:
             echo "No change to _ghq; skipping commit."
             exit 0
           fi
-          version=$(grep -E '^ghq[[:space:]]*=' home/dot_config/mise/config.toml | sed -E 's/.*"([^"]+)".*/\1/')
-          if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "ERROR: Unexpected ghq version format: $version"
-            exit 1
-          fi
+          version=$(scripts/ghq-version.sh)
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add home/dot_config/zsh/completions/_ghq

--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -161,8 +161,8 @@ jobs:
 
       - name: Verify ghq config applied
         run: |
-          ghq_root=$(git config --type path --global --get ghq.root)
-          ghq_user=$(git config --global --get ghq.user)
+          ghq_root=$(git config --type path --global --get ghq.root || true)
+          ghq_user=$(git config --global --get ghq.user || true)
           if [ "$ghq_root" != "$HOME/ghq" ]; then
             echo "ghq.root mismatch: expected $HOME/ghq, got $ghq_root"
             exit 1
@@ -328,8 +328,8 @@ jobs:
 
       - name: Verify ghq config applied
         run: |
-          ghq_root=$(git config --type path --global --get ghq.root)
-          ghq_user=$(git config --global --get ghq.user)
+          ghq_root=$(git config --type path --global --get ghq.root || true)
+          ghq_user=$(git config --global --get ghq.user || true)
           if [ "$ghq_root" != "$HOME/ghq" ]; then
             echo "ghq.root mismatch: expected $HOME/ghq, got $ghq_root"
             exit 1

--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Verify zsh modules deployed
         run: |
-          for mod in aliases git docker claude functions completions wtp; do
+          for mod in aliases git docker claude functions completions wtp ghq; do
             f=~/.config/zsh/${mod}.zsh
             if [ -f "$f" ]; then
               echo "OK: $f"
@@ -158,6 +158,24 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Verify ghq config applied
+        run: |
+          ghq_root=$(git config --type path --global --get ghq.root)
+          ghq_user=$(git config --global --get ghq.user)
+          if [ "$ghq_root" != "$HOME/ghq" ]; then
+            echo "ghq.root mismatch: expected $HOME/ghq, got $ghq_root"
+            exit 1
+          fi
+          if [ "$ghq_user" != "kryota-dev" ]; then
+            echo "ghq.user mismatch: expected kryota-dev, got $ghq_user"
+            exit 1
+          fi
+          if [ ! -f ~/.config/zsh/completions/_ghq ]; then
+            echo "MISSING: ~/.config/zsh/completions/_ghq"
+            exit 1
+          fi
+          echo "OK: ghq config (root=$ghq_root, user=$ghq_user) and _ghq completion deployed"
 
       - name: Verify zsh shell starts
         run: |
@@ -298,7 +316,7 @@ jobs:
 
       - name: Verify zsh modules deployed
         run: |
-          for mod in aliases git docker claude functions completions wtp; do
+          for mod in aliases git docker claude functions completions wtp ghq; do
             f=~/.config/zsh/${mod}.zsh
             if [ -f "$f" ]; then
               echo "OK: $f"
@@ -307,6 +325,24 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Verify ghq config applied
+        run: |
+          ghq_root=$(git config --type path --global --get ghq.root)
+          ghq_user=$(git config --global --get ghq.user)
+          if [ "$ghq_root" != "$HOME/ghq" ]; then
+            echo "ghq.root mismatch: expected $HOME/ghq, got $ghq_root"
+            exit 1
+          fi
+          if [ "$ghq_user" != "kryota-dev" ]; then
+            echo "ghq.user mismatch: expected kryota-dev, got $ghq_user"
+            exit 1
+          fi
+          if [ ! -f ~/.config/zsh/completions/_ghq ]; then
+            echo "MISSING: ~/.config/zsh/completions/_ghq"
+            exit 1
+          fi
+          echo "OK: ghq config (root=$ghq_root, user=$ghq_user) and _ghq completion deployed"
 
       - name: Verify zsh shell starts
         run: |

--- a/Makefile
+++ b/Makefile
@@ -42,30 +42,38 @@ sheldon-lock:
 
 ## Sync vendored _ghq completion from the mise-pinned upstream ghq version
 sync-ghq-completion:
-	@version=$$(grep -E '^ghq[[:space:]]*=' home/dot_config/mise/config.toml | sed -E 's/.*"([^"]+)".*/\1/'); \
-	if [ -z "$$version" ]; then \
-		echo "ERROR: Could not extract ghq version from home/dot_config/mise/config.toml"; \
-		exit 1; \
-	fi; \
-	if ! printf '%s' "$$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
-		echo "ERROR: Unexpected ghq version format: $$version"; \
-		exit 1; \
-	fi; \
+	@version=$$(scripts/ghq-version.sh) || exit 1; \
 	echo "Syncing _ghq from x-motemen/ghq@v$$version..."; \
 	url="https://raw.githubusercontent.com/x-motemen/ghq/v$$version/misc/zsh/_ghq"; \
 	tmpfile=$$(mktemp); \
+	tmpout=$$(mktemp); \
 	if ! curl -fsSL "$$url" -o "$$tmpfile"; then \
 		echo "ERROR: failed to fetch $$url"; \
-		rm -f "$$tmpfile"; \
+		rm -f "$$tmpfile" "$$tmpout"; \
 		exit 1; \
 	fi; \
+	if [ ! -s "$$tmpfile" ]; then \
+		echo "ERROR: fetched _ghq is empty"; \
+		rm -f "$$tmpfile" "$$tmpout"; \
+		exit 1; \
+	fi; \
+	case "$$(head -n1 "$$tmpfile")" in \
+		'#compdef ghq'*) ;; \
+		*) echo "ERROR: fetched file does not start with '#compdef ghq'"; rm -f "$$tmpfile" "$$tmpout"; exit 1 ;; \
+	esac; \
 	mkdir -p home/dot_config/zsh/completions; \
 	{ \
 		head -n1 "$$tmpfile"; \
 		echo "# vendored: x-motemen/ghq@v$$version misc/zsh/_ghq"; \
 		echo "# Run 'make sync-ghq-completion' to refresh."; \
 		tail -n +2 "$$tmpfile"; \
-	} > home/dot_config/zsh/completions/_ghq; \
+	} > "$$tmpout"; \
+	if ! zsh -n "$$tmpout" 2>/dev/null; then \
+		echo "ERROR: vendored _ghq fails zsh syntax check"; \
+		rm -f "$$tmpfile" "$$tmpout"; \
+		exit 1; \
+	fi; \
+	mv "$$tmpout" home/dot_config/zsh/completions/_ghq; \
 	rm -f "$$tmpfile"; \
 	echo "Done."
 
@@ -89,6 +97,7 @@ lint:
 	@echo "==> Checking zsh syntax..."
 	@for f in home/dot_config/zsh/*.zsh; do zsh -n "$$f" || exit 1; done
 	@for f in home/dot_config/zsh/*.zsh.tmpl; do sed '/{{/d' "$$f" | zsh -n || exit 1; done
+	@if [ -f home/dot_config/zsh/completions/_ghq ]; then zsh -n home/dot_config/zsh/completions/_ghq || exit 1; fi
 	@echo "==> All lint checks passed."
 
 ## Show shfmt formatting suggestions (template files need manual fixes)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all apply init diff verify update watch test lint fmt benchmark dump-brewfile help
+.PHONY: all apply init diff verify update watch test lint fmt benchmark dump-brewfile sync-ghq-completion help
 
 # Default target
 all: apply
@@ -39,6 +39,35 @@ watch:
 ## Re-lock sheldon plugins
 sheldon-lock:
 	@sheldon lock
+
+## Sync vendored _ghq completion from the mise-pinned upstream ghq version
+sync-ghq-completion:
+	@version=$$(grep -E '^ghq[[:space:]]*=' home/dot_config/mise/config.toml | sed -E 's/.*"([^"]+)".*/\1/'); \
+	if [ -z "$$version" ]; then \
+		echo "ERROR: Could not extract ghq version from home/dot_config/mise/config.toml"; \
+		exit 1; \
+	fi; \
+	if ! printf '%s' "$$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "ERROR: Unexpected ghq version format: $$version"; \
+		exit 1; \
+	fi; \
+	echo "Syncing _ghq from x-motemen/ghq@v$$version..."; \
+	url="https://raw.githubusercontent.com/x-motemen/ghq/v$$version/misc/zsh/_ghq"; \
+	tmpfile=$$(mktemp); \
+	if ! curl -fsSL "$$url" -o "$$tmpfile"; then \
+		echo "ERROR: failed to fetch $$url"; \
+		rm -f "$$tmpfile"; \
+		exit 1; \
+	fi; \
+	mkdir -p home/dot_config/zsh/completions; \
+	{ \
+		head -n1 "$$tmpfile"; \
+		echo "# vendored: x-motemen/ghq@v$$version misc/zsh/_ghq"; \
+		echo "# Run 'make sync-ghq-completion' to refresh."; \
+		tail -n +2 "$$tmpfile"; \
+	} > home/dot_config/zsh/completions/_ghq; \
+	rm -f "$$tmpfile"; \
+	echo "Done."
 
 # ========================================
 # Testing

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all apply init diff verify update watch test lint fmt benchmark dump-brewfile sync-ghq-completion help
+.PHONY: all apply init diff verify update watch test lint fmt benchmark dump-brewfile sheldon-lock sync-ghq-completion help
 
 # Default target
 all: apply

--- a/home/.chezmoi.toml
+++ b/home/.chezmoi.toml
@@ -1,4 +1,5 @@
 [data]
+  name = "kryota-dev"
   email = "50436249+kryota-dev@users.noreply.github.com"
   signingkey = "~/.ssh/ssh-key.pub"
   ghq_user = "kryota-dev"

--- a/home/.chezmoi.toml
+++ b/home/.chezmoi.toml
@@ -1,6 +1,7 @@
 [data]
   email = "50436249+kryota-dev@users.noreply.github.com"
   signingkey = "~/.ssh/ssh-key.pub"
+  ghq_user = "kryota-dev"
 
 [diff]
   exclude = ["scripts"]

--- a/home/dot_config/sheldon/plugins.toml
+++ b/home/dot_config/sheldon/plugins.toml
@@ -61,3 +61,8 @@ apply = ["defer"]
 local = "~/.config/zsh"
 use = ["completions.zsh"]
 apply = ["defer"]
+
+[plugins.ghq]
+local = "~/.config/zsh"
+use = ["ghq.zsh"]
+apply = ["defer"]

--- a/home/dot_config/zsh/completions.zsh
+++ b/home/dot_config/zsh/completions.zsh
@@ -4,5 +4,10 @@ fpath=(${HOME}/.config/zsh/completions $fpath)
 # Docker CLI completions
 fpath=(${HOME}/.docker/completions $fpath)
 
+# Drop duplicates on re-source / nested shell. fpath is tied to FPATH
+# (typeset -U on either deduplicates both), so this is safe to do once
+# before compinit.
+typeset -U fpath FPATH
+
 autoload -Uz compinit
 compinit

--- a/home/dot_config/zsh/completions.zsh
+++ b/home/dot_config/zsh/completions.zsh
@@ -1,3 +1,6 @@
+# Local completions (vendored from upstream tools)
+fpath=(${HOME}/.config/zsh/completions $fpath)
+
 # Docker CLI completions
 fpath=(${HOME}/.docker/completions $fpath)
 

--- a/home/dot_config/zsh/completions/_ghq
+++ b/home/dot_config/zsh/completions/_ghq
@@ -1,0 +1,110 @@
+#compdef ghq ghq-dev
+# vendored: x-motemen/ghq@v1.10.1 misc/zsh/_ghq
+# Run 'make sync-ghq-completion' to refresh.
+
+function _ghq () {
+    local context curcontext=$curcontext state line
+    declare -A opt_args
+    local ret=1
+
+    _arguments -C \
+        '(-h --help)'{-h,--help}'[show help]' \
+        '(-v --version)'{-v,--version}'[print the version]' \
+        '1: :__ghq_commands' \
+        '*:: :->args' \
+        && ret=0
+
+    case $state in
+        (args)
+            case $words[1] in
+                (get)
+                    _arguments -C \
+                        '(-u --update)'{-u,--update}'[Update local repository if cloned already]' \
+                        '-p[Clone with SSH]' \
+                        '--shallow[Do a shallow clone]' \
+                        '(-l --look)'{-l,--look}'[Look after get]' \
+                        '--vcs[Specify vcs backend for cloning]' \
+                        '(-s --silent)'{-s,--silent}'[Clone or update silently]' \
+                        '--no-recursive[Prevent recursive fetching]' \
+                        '--bare[Do a bare clone]' \
+                        '(-b --branch)'{-b,--branch}'[Specify branch name]' \
+                        '(-P --parallel)'{-P,--parallel}'[Import parallelly]' \
+                        '--partial[Do a partial clone]: :(blobless treeless)' \
+                        '(-)*:: :->null_state' \
+                        && ret=0
+                    ;;
+                (list)
+                    _arguments -C \
+                        '(-e --exact)'{-e,--exact}'[Perform an exact match]' \
+                        '--vcs[Specify vcs backend for matching]' \
+                        '(-p --full-path)'{-p,--full-path}'[Print full paths]' \
+                        '--unique[Print unique subpaths]' \
+                        '--bare[Query bare repositories]' \
+                        '(-)*:: :->null_state' \
+                        && ret=0
+                    ;;
+                (root)
+                    _arguments -C \
+                        '--all[Show all roots]' \
+                        '(-)*:: :->null_state' \
+                        && ret=0
+                    ;;
+                (create)
+                    _arguments -C \
+                        '--vcs[Specify vcs backend explicitly]' \
+                        '--bare[Create a bare repository]' \
+                        '(-)*:: :->null_state' \
+                        && ret=0
+                    ;;
+                (rm)
+                    _arguments -C \
+                        '--dry-run[Do not remove actually]' \
+                        '--bare[Remove a bare repository]' \
+                        '(-)*: :__ghq_all_repositories' \
+                        && ret=0
+                    ;;
+                (migrate)
+                    _arguments -C \
+                        '-y[Skip confirmation prompt]' \
+                        '--dry-run[Show what would happen without moving]' \
+                        ':repository directory:_directories' \
+                        && ret=0
+                    ;;
+                (help|h)
+                    __ghq_commands && ret=0
+                    ;;
+            esac
+            ;;
+    esac
+
+    return ret
+}
+
+__ghq_repositories () {
+    local -a _repos
+    _repos=( ${(@f)"$(_call_program repositories ghq list --unique)"} )
+    _describe -t repositories Repositories _repos
+}
+
+__ghq_all_repositories () {
+    local -a _repos
+    _repos=( ${(@f)"$(_call_program repositories ghq list)"} )
+    _describe -t repositories Repositories _repos
+}
+
+__ghq_commands () {
+    local -a _c
+    _c=(
+        'get:Clone/sync with a remote repository'
+        'list:List local repositories'
+        'rm:Remove local repository'
+        'create:Create a new repository'
+        'migrate:Migrate existing repository to ghq-managed directory'
+        "root:Show repositories' root"
+        'help:Show a list of commands or help for one command'
+    )
+
+    _describe -t commands Commands _c
+}
+
+_ghq "$@"

--- a/home/dot_config/zsh/ghq.zsh
+++ b/home/dot_config/zsh/ghq.zsh
@@ -1,0 +1,18 @@
+# `cd <path>` is committed via zle accept-line so the command lands in zsh
+# history (Ctrl-R / atuin discoverable). `ghq list --full-path` is multi-root
+# safe; `${(q)…}` preserves whitespace and special characters.
+ghq-fzf-cd() {
+  local selected
+  selected=$(ghq list --full-path 2>/dev/null | fzf --height=40% --reverse --prompt='ghq> ') || {
+    zle reset-prompt
+    return
+  }
+  if [[ -n "$selected" ]]; then
+    BUFFER="cd ${(q)selected}"
+    zle accept-line
+  else
+    zle reset-prompt
+  fi
+}
+zle -N ghq-fzf-cd
+bindkey '^g' ghq-fzf-cd

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -24,3 +24,6 @@
 {{- end }}
 [extensions]
 	worktreeConfig = true
+[ghq]
+	root = ~/ghq
+	user = kryota-dev

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -26,4 +26,4 @@
 	worktreeConfig = true
 [ghq]
 	root = ~/ghq
-	user = kryota-dev
+	user = {{ .ghq_user }}

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -1,5 +1,5 @@
 [user]
-	name = kryota-dev
+	name = {{ .name }}
 	email = {{ .email }}
 	signingkey = {{ .signingkey }}
 [core]

--- a/scripts/ghq-version.sh
+++ b/scripts/ghq-version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Extract the mise-pinned ghq version from the given mise config (or the
+# default path) and print it on stdout. Exits non-zero if the version is
+# missing or does not match X.Y.Z. Shared by `make sync-ghq-completion`
+# and the CI job that re-vendors the zsh completion.
+set -euo pipefail
+
+config="${1:-home/dot_config/mise/config.toml}"
+
+if [ ! -f "$config" ]; then
+  printf 'ERROR: mise config not found: %s\n' "$config" >&2
+  exit 1
+fi
+
+version=$(sed -nE 's/^ghq[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*$/\1/p' "$config")
+
+if [ -z "$version" ]; then
+  printf 'ERROR: ghq version (X.Y.Z) not found in %s\n' "$config" >&2
+  exit 1
+fi
+
+printf '%s\n' "$version"

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -55,12 +55,20 @@ load helpers/setup
 }
 
 @test "zsh modules exist" {
-  local modules=(git docker claude codex functions completions wtp)
+  local modules=(git docker claude codex functions completions wtp ghq)
   for mod in "${modules[@]}"; do
     [ -f "${HOME_DIR}/dot_config/zsh/${mod}.zsh" ]
   done
   # aliases.zsh is now a chezmoi template
   [ -f "${HOME_DIR}/dot_config/zsh/aliases.zsh.tmpl" ]
+}
+
+@test "chezmoi source files exist: dot_config/zsh/completions/_ghq" {
+  [ -f "${HOME_DIR}/dot_config/zsh/completions/_ghq" ]
+}
+
+@test "ghq zsh completion has compdef directive on first line" {
+  head -n1 "${HOME_DIR}/dot_config/zsh/completions/_ghq" | grep -q '^#compdef ghq'
 }
 
 @test "lifecycle scripts exist" {

--- a/tests/zsh_syntax.bats
+++ b/tests/zsh_syntax.bats
@@ -33,3 +33,7 @@ load helpers/setup
 @test "zsh syntax: wtp.zsh" {
   zsh -n "${HOME_DIR}/dot_config/zsh/wtp.zsh"
 }
+
+@test "zsh syntax: ghq.zsh" {
+  zsh -n "${HOME_DIR}/dot_config/zsh/ghq.zsh"
+}


### PR DESCRIPTION
## Summary

Operationalizes ghq in the dotfiles. ghq has been installed via mise (v1.10.1) but `git config --global ghq.root` was unset and there was no shell integration or completion. This PR adds the durable configuration so a fresh `chezmoi apply` produces a ready-to-use ghq, and wires up CI so Renovate-driven mise ghq version bumps re-vendor the upstream zsh completion automatically.

closes #163

## Changes

- **gitconfig** (`home/dot_gitconfig.tmpl`): add `[ghq] root = ~/ghq` and `user = kryota-dev`. The default root avoids drift between gitconfig and the GHQ_ROOT env fallback; the user setting lets `ghq get foo` resolve to `github.com/kryota-dev/foo` instead of 404-ing under `$USER`.
- **fzf widget** (`home/dot_config/zsh/ghq.zsh`, new): `ghq-fzf-cd` bound to `Ctrl-G`. Runs `ghq list --full-path | fzf`, writes `cd ${(q)<selection>}` to `BUFFER`, and `zle accept-line`s — so the cd lands in zsh history and Ctrl-R / atuin can resurface it later. `--full-path` is multi-root safe; `${(q)…}` protects against whitespace and special characters.
- **sheldon plugin** (`home/dot_config/sheldon/plugins.toml`): register the new fragment with `apply = ["defer"]`, matching the existing local plugins (aliases, wtp, etc.).
- **vendored completion** (`home/dot_config/zsh/completions/_ghq`, new): vendored from `x-motemen/ghq@v1.10.1 misc/zsh/_ghq`. zsh's completion system identifies completion files by `#compdef <names>` on line 1, so the upstream first line is preserved and a two-line provenance comment is inserted on lines 2–3.
- **completions wiring** (`home/dot_config/zsh/completions.zsh`): add `fpath=(${HOME}/.config/zsh/completions $fpath)` ahead of the existing Docker fpath entry. compinit (already invoked in the same file) autoloads `_ghq`.
- **Makefile** (`Makefile`): new `sync-ghq-completion` target. Extracts the ghq version pin from `home/dot_config/mise/config.toml`, validates it against `^[0-9]+\.[0-9]+\.[0-9]+$`, fetches `misc/zsh/_ghq` from the matching upstream tag, and rewrites the vendored file with the provenance header. Idempotent: a second run on a clean tree produces no diff.
- **CI auto-sync job** (`.github/workflows/ci.yml`): new `sync-ghq-completion` job that runs on same-repo `pull_request` events, executes `make sync-ghq-completion`, and if the vendored file differs from upstream, commits and pushes the result back to the PR branch via `GITHUB_TOKEN`. Renovate ghq-bump PRs become 1-click mergeable; `GITHUB_TOKEN`-authored pushes do not retrigger workflows so there is no recursive CI loop. The job is gated on `pull_request.head.repo.full_name == github.repository` to skip fork PRs entirely (fork PRs would get a read-only token and the push would fail anyway, but skipping avoids running fork-side Makefile code in CI). The version extraction is validated against the same regex as the Makefile before being used in shell commands.
- **setup-validation** (`.github/workflows/setup-validation.yml`): add `Verify ghq config applied` step to both the macOS and Ubuntu jobs. Asserts `git config --type path --global --get ghq.root == $HOME/ghq`, `git config --global --get ghq.user == kryota-dev`, and the presence of `~/.config/zsh/completions/_ghq`. Adds `ghq` to the existing zsh modules deployment check.
- **bats tests** (`tests/files.bats`, `tests/zsh_syntax.bats`): cover the new `ghq.zsh` fragment in `zsh modules exist`, add presence + compdef-on-line-1 assertions for `_ghq`, and add `zsh -n` syntax check for `ghq.zsh`.

## Review record

This PR was produced via the `sdd` skill (Issue → branch → spec docs → implement → review → commit → draft PR). The pre-commit review pass used three reviewer agents (code-quality, security, test) and all returned **APPROVE**. Two SHOULD items from the security pass (fork-PR gate, version-format validation) were applied to the CI job and Makefile target before this PR was opened; one NIT from the code-quality pass (overlong block comment in `ghq.zsh`) was applied.

Spec docs (gitignored, not part of this PR): `.spec-workflow/specs/ghq-setup/{requirements.md,design.md,tasks.md}`.

## Test plan

- [x] `make lint` passes locally (shellcheck + shfmt + zsh -n).
- [x] `make test` passes locally (50 bats tests, including the 3 new ones).
- [x] `make sync-ghq-completion` is idempotent: running it twice produces no diff.
- [ ] CI Lint & Test jobs pass on PR.
- [ ] CI `Sync ghq completion` job runs and reports `No change to _ghq; skipping commit.` on this same-version PR.
- [ ] CI `Validate dotfiles setup (macOS)` and `(Ubuntu)` both pass the new `Verify ghq config applied` step.
- [ ] On a follow-up synthetic Renovate-style ghq bump PR, the `Sync ghq completion` job auto-commits a fresh `_ghq` to the PR branch with no human intervention. (Will be verified in the wild on the next real Renovate ghq update.)
- [ ] After merge, on a fresh `chezmoi apply` in a clean shell: `git config --type path --global --get ghq.root` returns `$HOME/ghq`; `Ctrl-G` opens fzf and `cd`s into the selected repository with `cd <path>` recorded in zsh history; `ghq <TAB>` produces zsh completion suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCm9dSCT8cWMC8ockCKnQK
