### PR TITLE
chore(claude): sync settings.json with /config UI and env tweaks

### DIFF
--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -9,8 +9,7 @@
     "DISABLE_ERROR_REPORTING": "1",
     "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "95",
-    "MAX_THINKING_TOKENS": "31999",
-    "CLAUDE_CODE_DISABLE_MOUSE": "1"
+    "MAX_THINKING_TOKENS": "127999"
   },
   "permissions": {
     "allow": [
@@ -118,5 +117,10 @@
     "type": "command",
     "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/statusline.sh"
   },
-  "model": "claude-opus-4-8[1m]"
+  "model": "claude-opus-4-8[1m]",
+  "enabledPlugins": {
+    "codex@openai-codex": true
+  },
+  "extraKnownMarketplaces": {},
+  "agentPushNotifEnabled": true
 }


### PR DESCRIPTION
## Summary

Capture the drift that has accumulated in `~/.claude/settings.json` since the last source sync and bring `home/dot_claude/settings.json` in line with it.

## Changes

### `env` block
- Bump `MAX_THINKING_TOKENS`: `31999` → `127999`. Avoids silent truncation of reasoning on long prompts.
- Drop `CLAUDE_CODE_DISABLE_MOUSE`: the upstream behaviour the override worked around is no longer present.

### Top-level UI-managed keys
The Claude Code `/config` UI added these keys to the deployed file; capturing them here so future `chezmoi apply` runs stop reporting drift.

- `enabledPlugins.codex@openai-codex = true`
- `extraKnownMarketplaces = {}`
- `agentPushNotifEnabled = true`

## Verification

- [x] JSON parses (`jq empty`).
- [x] `make lint` passes.
- [ ] CI Lint / Test green on PR.
- [ ] After merge, `chezmoi diff` for `.claude/settings.json` is empty modulo cosmetic key-order noise.