### PR TITLE
refactor(chezmoi): auto-deploy chezmoi config and centralize template data

### DIFF
--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -93,8 +93,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          mkdir -p ~/.config/chezmoi
-          cp home/.chezmoi.toml ~/.config/chezmoi/chezmoi.toml
           for attempt in 1 2 3; do
             if installer=$(curl -fsLS get.chezmoi.io) && [ -n "$installer" ]; then
               break

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Follows chezmoi naming conventions (`dot_` → `.`, `.tmpl` → template, `run_o
   - `run_once_after_90-other-apps.sh.tmpl` — other app configurations
 
 - **zsh config**: `dot_zshrc.tmpl` → activates mise, direnv, starship synchronously, then loads `dot_config/zsh/*.zsh` via sheldon with deferred loading
-- **Template variables**: `.chezmoi.toml` defines `email` and `signingkey`
+- **Template variables**: `home/.chezmoidata.toml` defines `email`, `signingkey`, `name`, and `ghq_user` (auto-loaded from the source tree, no per-machine config required). Chezmoi behavior config (e.g., `[diff]`) lives in `home/dot_config/chezmoi/chezmoi.toml` and is auto-deployed.
 - **1Password secrets**: `private_dot_aws/config.tmpl` — rendered from 1Password Secure Notes via `onepasswordRead`
 - **AI agent config**: `dot_claude/`, `dot_codex/`, `dot_agents/skills/` — shared skills are centralized in `dot_agents/skills/` and distributed to each tool via symlinks
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,9 +55,10 @@ dotfiles/
 ├── .chezmoiroot              # ソースルート → home/
 ├── install/                   # ブートストラップスクリプト
 ├── home/
-│   ├── .chezmoi.toml         # chezmoi 設定（email、signingkey）
+│   ├── .chezmoidata.toml     # テンプレートデータ（email、signingkey、name、ghq_user、versions、skills）
 │   ├── dot_zshrc.tmpl        # 最小コア、sheldon 駆動
 │   ├── dot_config/
+│   │   ├── chezmoi/          # chezmoi 挙動設定（自動 deploy）
 │   │   ├── ghostty/          # ターミナル設定
 │   │   ├── mise/             # ツールバージョンマネージャー
 │   │   ├── sheldon/          # プラグインマネージャー

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ dotfiles/
 ├── .chezmoiroot              # source root → home/
 ├── install/                   # bootstrap script
 ├── home/
-│   ├── .chezmoi.toml         # chezmoi config (email, signingkey)
+│   ├── .chezmoidata.toml     # template data (email, signingkey, name, ghq_user, versions, skills)
 │   ├── dot_zshrc.tmpl        # minimal core, sheldon-powered
 │   ├── dot_config/
+│   │   ├── chezmoi/          # chezmoi behavior config (auto-deployed)
 │   │   ├── ghostty/          # terminal config
 │   │   ├── mise/             # tool version manager
 │   │   ├── sheldon/          # plugin manager

--- a/home/.chezmoi.toml
+++ b/home/.chezmoi.toml
@@ -1,8 +1,0 @@
-[data]
-  name = "kryota-dev"
-  email = "50436249+kryota-dev@users.noreply.github.com"
-  signingkey = "~/.ssh/ssh-key.pub"
-  ghq_user = "kryota-dev"
-
-[diff]
-  exclude = ["scripts"]

--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -1,3 +1,8 @@
+email = "50436249+kryota-dev@users.noreply.github.com"
+signingkey = "~/.ssh/ssh-key.pub"
+name = "kryota-dev"
+ghq_user = "kryota-dev"
+
 [versions]
   moralerspace_font = "2.0.0"
 

--- a/home/dot_agents/skills/chezmoi/SKILL.md
+++ b/home/dot_agents/skills/chezmoi/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 chezmoiは **source state** から **target state** を計算し、**destination directory**（ホームディレクトリ）に適用することでdotfilesを管理する。
 
 - **Source directory**: chezmoiがsource stateを保存する場所（default: `~/.local/share/chezmoi`、`.chezmoiroot`で変更可能）
-- **Config file**: マシン固有のデータ（`~/.config/chezmoi/chezmoi.toml`）
+- **Config file**: chezmoiの挙動設定とテンプレートデータ（`~/.config/chezmoi/chezmoi.toml`）。テンプレートデータは `.chezmoidata.<format>` を source dir に置くことで auto-load も可能
 - **Target state**: source state + config + destination stateから計算される目標状態
 - **Working tree**: gitのworking tree（通常はsource directoryと同じだが、`.chezmoiroot`使用時は親ディレクトリになる場合がある）
 

--- a/home/dot_config/chezmoi/private_chezmoi.toml
+++ b/home/dot_config/chezmoi/private_chezmoi.toml
@@ -1,0 +1,2 @@
+[diff]
+  exclude = ["scripts"]


### PR DESCRIPTION
## Summary

Eliminate the `cp home/.chezmoi.toml ~/.config/chezmoi/chezmoi.toml` bootstrap pattern in favour of chezmoi's own auto-load / auto-deploy conventions, so there is no longer a per-machine config file to keep in sync by hand.

This is the Option D refactor we sketched out after the conversation around #164:

- Personal template variables move from a `[data]` block in a hand-synced `~/.config/chezmoi/chezmoi.toml` into top-level keys in `home/.chezmoidata.toml`, which chezmoi auto-loads from the source tree. Templates that already used `{{ .email }}` / `{{ .signingkey }}` / `{{ .name }}` / `{{ .ghq_user }}` continue to work unchanged.
- chezmoi behaviour config (just `[diff].exclude` today) is now a `home/dot_config/chezmoi/private_chezmoi.toml` source file. chezmoi deploys it to `~/.config/chezmoi/chezmoi.toml` like any other dotfile (0600 via the `private_` prefix).
- `home/.chezmoi.toml` is deleted; its content is now split across the two files above.
- The `cp home/.chezmoi.toml ~/.config/chezmoi/chezmoi.toml` line is removed from both the macOS and Ubuntu jobs of `setup-validation.yml`. The existing `Verify ghq config applied` step (added by #164) keeps working unchanged.
- Docs (`README.md`, `README.ja.md`, `AGENTS.md`, the chezmoi skill `SKILL.md`) are updated to describe the new layout.

## Why

The old pattern was a quiet anti-pattern:

- `home/.chezmoi.toml` was committed but not deployed by chezmoi, so the live config had to be kept in sync by hand or by CI's `cp`.
- All four values were always-the-same across machines, so the "machine-specific config file" framing didn't match reality.
- New template variables (e.g., `ghq_user` introduced in #164) silently broke `chezmoi apply` on the maintainer's machine until the personal copy was updated.

After this PR there is nothing for the maintainer to copy manually; a fresh `chezmoi apply` on a new machine resolves all template variables from the source tree and writes its own `~/.config/chezmoi/chezmoi.toml`.

## Verification

- [x] `make lint` and `make test` (50 bats tests) pass locally.
- [x] `chezmoi execute-template` resolves `{{ .email }}`, `{{ .ghq_user }}`, `{{ .name }}`, `{{ .signingkey }}` from `home/.chezmoidata.toml` only — no `~/.config/chezmoi/chezmoi.toml` required for templating.
- [x] `chezmoi diff` shows the user's `~/.config/chezmoi/chezmoi.toml` losing the `[data]` block and keeping `[diff]` only, with mode preserved at 0600.
- [ ] CI: Lint / Test / Sync ghq completion / Validate dotfiles setup (macOS) pass. (Ubuntu validation remains failing for the pre-existing untrusted Homebrew tap issue tracked in #148.)
- [ ] After merge + `chezmoi apply --force` on the maintainer's machine, `git config --get ghq.user` still returns `kryota-dev` and `git config --get user.name` still returns `kryota-dev`.

## Notes for the maintainer (post-merge)

- The existing `~/.config/chezmoi/chezmoi.toml` was hand-edited to add `name` / `ghq_user` for #164. On the first `chezmoi apply` after this lands, chezmoi will detect the external modification and ask before overwriting — use `chezmoi apply --force` once to accept the new, slimmer file.
- No edits are needed in `~/.config/chezmoi/chezmoi.toml` going forward; new personal template variables go straight into `home/.chezmoidata.toml`.