### PR TITLE
feat(plumbing): adopt ECC hook runtime via chezmoi external and isolate accounts

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,16 +60,19 @@
       extractVersionTemplate: '^v(?<version>.+)$',
     },
     {
-      // ECC is pinned to a semver release tag in [ecc].version; track upstream releases.
+      // ECC ships executable hook code, so it is pinned to an immutable commit digest (not a
+      // moveable tag). github-tags tracks release tags and updates both the version and the
+      // commit digest in [ecc]; the packageRule below keeps ECC out of automerge.
       customType: 'regex',
       managerFilePatterns: [
         '/home/\\.chezmoidata\\.toml$/',
       ],
       matchStrings: [
-        '\\[ecc\\][\\s\\S]*?version\\s*=\\s*"(?<currentValue>\\d+\\.\\d+\\.\\d+)"',
+        '\\[ecc\\][\\s\\S]*?version\\s*=\\s*"(?<currentValue>[^"]+)"[\\s\\S]*?commit\\s*=\\s*"(?<currentDigest>[a-f0-9]+)"',
       ],
       depNameTemplate: 'affaan-m/ECC',
-      datasourceTemplate: 'github-releases',
+      packageNameTemplate: 'affaan-m/ECC',
+      datasourceTemplate: 'github-tags',
       extractVersionTemplate: '^v(?<version>.+)$',
     },
   ],
@@ -78,4 +81,11 @@
       '/home/dot_config/mise/config\\.toml/',
     ],
   },
+  packageRules: [
+    {
+      // ECC ships third-party executable hook code: never auto-merge, always review.
+      matchDepNames: ['affaan-m/ECC'],
+      automerge: false,
+    },
+  ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,6 +59,19 @@
       datasourceTemplate: 'github-releases',
       extractVersionTemplate: '^v(?<version>.+)$',
     },
+    {
+      // ECC is pinned to a semver release tag in [ecc].version; track upstream releases.
+      customType: 'regex',
+      managerFilePatterns: [
+        '/home/\\.chezmoidata\\.toml$/',
+      ],
+      matchStrings: [
+        '\\[ecc\\][\\s\\S]*?version\\s*=\\s*"(?<currentValue>\\d+\\.\\d+\\.\\d+)"',
+      ],
+      depNameTemplate: 'affaan-m/ECC',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.+)$',
+    },
   ],
   mise: {
     managerFilePatterns: [

--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -10,5 +10,9 @@ ghq_user = "kryota-dev"
   anthropic_commit = "57546260929473d4e0d1c1bb75297be2fdfa1949"
 
 [ecc]
-  # Everything Claude Code — https://github.com/affaan-m/ECC (pinned to a semver release tag)
+  # Everything Claude Code — https://github.com/affaan-m/ECC
+  # Pinned to an immutable commit (the v2.0.0 release commit) so the executable hook runtime
+  # cannot change under a moved tag. Renovate (github-tags) tracks release tags and bumps both
+  # version and commit together; ECC is never auto-merged (see packageRules in renovate.json5).
   version = "2.0.0"
+  commit = "8ad4151095e453301ce0e50374103bcd8f50ded2"

--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -8,3 +8,7 @@ ghq_user = "kryota-dev"
 
 [skills]
   anthropic_commit = "57546260929473d4e0d1c1bb75297be2fdfa1949"
+
+[ecc]
+  # Everything Claude Code — https://github.com/affaan-m/ECC (pinned to a semver release tag)
+  version = "2.0.0"

--- a/home/.chezmoiexternal.toml
+++ b/home/.chezmoiexternal.toml
@@ -122,6 +122,17 @@
     include = ["*/skills/xlsx/**"]
     refreshPeriod = "168h"
 
+# Everything Claude Code (ECC) hook runtime — https://github.com/affaan-m/ECC
+# Only scripts/hooks + scripts/lib are fetched here (the hook runtime that later PRs wire
+# into settings.json). Skills / agents / rules are managed separately. The tarball is large,
+# but chezmoi extracts only the included paths. Version pinned in .chezmoidata.toml [ecc].version.
+[".agents/skills/ecc/scripts"]
+    type = "archive"
+    url = "https://github.com/affaan-m/ECC/archive/refs/tags/v{{ .ecc.version }}.tar.gz"
+    stripComponents = 2
+    include = ["*/scripts/hooks/**", "*/scripts/lib/**"]
+    refreshPeriod = "168h"
+
 # Moralerspace font (macOS only)
 # Version is defined in .chezmoidata.toml [versions.moralerspace_font]
 {{ if eq .chezmoi.os "darwin" -}}

--- a/home/.chezmoiexternal.toml
+++ b/home/.chezmoiexternal.toml
@@ -128,7 +128,7 @@
 # but chezmoi extracts only the included paths. Version pinned in .chezmoidata.toml [ecc].version.
 [".agents/skills/ecc/scripts"]
     type = "archive"
-    url = "https://github.com/affaan-m/ECC/archive/refs/tags/v{{ .ecc.version }}.tar.gz"
+    url = "https://github.com/affaan-m/ECC/archive/{{ .ecc.commit }}.tar.gz"
     stripComponents = 2
     include = ["*/scripts/hooks/**", "*/scripts/lib/**"]
     refreshPeriod = "168h"

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -18,6 +18,13 @@
 .claude/teams
 .claude/todos
 
+# ECC runtime state (hooks, governance state.db, continuous-learning, gateguard)
+.claude/ecc
+.claude/ecc-homunculus
+.claude/.gateguard
+.claude/mcp-health-cache.json
+.claude/metrics
+
 # Claude Code runtime data (work account)
 .claude-r06/backups
 .claude-r06/chrome
@@ -37,6 +44,15 @@
 .claude-r06/tasks
 .claude-r06/teams
 .claude-r06/todos
+.claude-r06/ecc
+.claude-r06/ecc-homunculus
+.claude-r06/.gateguard
+.claude-r06/mcp-health-cache.json
+.claude-r06/metrics
+
+# Shared agents: skill lock files (managed by skill tooling, not chezmoi)
+.agents/.skill-lock.json
+.agents/skills-lock.json
 
 # Codex runtime data
 # config.toml is intentionally unmanaged (Codex writes trust_level etc. dynamically);

--- a/home/dot_config/zsh/claude.zsh
+++ b/home/dot_config/zsh/claude.zsh
@@ -1,5 +1,29 @@
-alias cld='claude'
-alias cld-r06='CLAUDE_CONFIG_DIR=$HOME/.claude-r06 claude'
+# Claude Code account isolation.
+# Each account gets its own config dir plus ECC/CLV2/gateguard state dirs, so cld and
+# cld-r06 never share sessions, governance state.db, instincts, or hook caches.
+_claude_with_home() {
+  local home_dir="$1"
+  shift
+  CLAUDE_CONFIG_DIR="$home_dir" \
+    ECC_AGENT_DATA_HOME="$home_dir" \
+    CLV2_HOMUNCULUS_DIR="$home_dir/ecc-homunculus" \
+    ECC_MCP_HEALTH_STATE_PATH="$home_dir/mcp-health-cache.json" \
+    GATEGUARD_STATE_DIR="$home_dir/.gateguard" \
+    claude "$@"
+}
+alias cld='_claude_with_home "$HOME/.claude"'
+alias cld-r06='_claude_with_home "$HOME/.claude-r06"'
+
+# Dedicated session for intentional config edits: disables the ECC config-protection and
+# gateguard-fact-force gates so Claude can edit settings.json / biome.json / eslint.config.* etc.
+alias claude-config='ECC_DISABLED_HOOKS=pre:config-protection,pre:edit-write:gateguard-fact-force claude'
+
+# ECC state.db CLI (account-aware via ECC_AGENT_DATA_HOME). ECC scripts are chezmoi-managed
+# under ~/.agents/skills/ecc; these need the ECC runtime deps that a later PR installs.
+alias ecc-status='node "$HOME/.agents/skills/ecc/scripts/status.js" --db "${ECC_AGENT_DATA_HOME:-$HOME/.claude}/ecc/state.db"'
+alias ecc-sessions='node "$HOME/.agents/skills/ecc/scripts/sessions-cli.js" --db "${ECC_AGENT_DATA_HOME:-$HOME/.claude}/ecc/state.db"'
+alias ecc-work-items='node "$HOME/.agents/skills/ecc/scripts/work-items.js" --db "${ECC_AGENT_DATA_HOME:-$HOME/.claude}/ecc/state.db"'
+
 alias ccdcmds='ccdcommands'
 
 function ccdpaths() {

--- a/home/dot_config/zsh/claude.zsh
+++ b/home/dot_config/zsh/claude.zsh
@@ -14,15 +14,12 @@ _claude_with_home() {
 alias cld='_claude_with_home "$HOME/.claude"'
 alias cld-r06='_claude_with_home "$HOME/.claude-r06"'
 
-# Dedicated session for intentional config edits: disables the ECC config-protection and
-# gateguard-fact-force gates so Claude can edit settings.json / biome.json / eslint.config.* etc.
-alias claude-config='ECC_DISABLED_HOOKS=pre:config-protection,pre:edit-write:gateguard-fact-force claude'
-
-# ECC state.db CLI (account-aware via ECC_AGENT_DATA_HOME). ECC scripts are chezmoi-managed
-# under ~/.agents/skills/ecc; these need the ECC runtime deps that a later PR installs.
-alias ecc-status='node "$HOME/.agents/skills/ecc/scripts/status.js" --db "${ECC_AGENT_DATA_HOME:-$HOME/.claude}/ecc/state.db"'
-alias ecc-sessions='node "$HOME/.agents/skills/ecc/scripts/sessions-cli.js" --db "${ECC_AGENT_DATA_HOME:-$HOME/.claude}/ecc/state.db"'
-alias ecc-work-items='node "$HOME/.agents/skills/ecc/scripts/work-items.js" --db "${ECC_AGENT_DATA_HOME:-$HOME/.claude}/ecc/state.db"'
+# Dedicated session for intentional config edits on the DEFAULT account (~/.claude): routes
+# through _claude_with_home (so ECC state stays isolated to ~/.claude) and disables the ECC
+# config-protection / gateguard-fact-force gates so Claude can edit settings.json / biome.json /
+# eslint.config.* etc. For the r06 account, prefix the same var to cld-r06:
+#   ECC_DISABLED_HOOKS=pre:config-protection,pre:edit-write:gateguard-fact-force cld-r06
+alias claude-config='ECC_DISABLED_HOOKS=pre:config-protection,pre:edit-write:gateguard-fact-force _claude_with_home "$HOME/.claude"'
 
 alias ccdcmds='ccdcommands'
 


### PR DESCRIPTION
## Summary

PR2 of the Phase 6 Stacked PR series — the keystone that replaces ECC plugin install with chezmoi-managed vendoring, plus per-account isolation. This unblocks the hook PRs (PR3–PR5).

- **ECC hook runtime via chezmoi external**: fetch `scripts/hooks/**` + `scripts/lib/**` from `affaan-m/ECC` into `~/.agents/skills/ecc/scripts/`, pinned to an **immutable commit SHA** (the v2.0.0 release commit) in `.chezmoidata.toml [ecc].commit`. Verified against the real tarball: top-dir `ECC-<sha>/`, so `stripComponents = 2` lands the 141 hook+lib files correctly. `skills` / `agents` / `rules` are excluded (agents/rules rejected in design; the 133 adopted skills + template-ization are a focused follow-up).
- **Account isolation**: `cld` / `cld-r06` set five env vars (`CLAUDE_CONFIG_DIR`, `ECC_AGENT_DATA_HOME`, `CLV2_HOMUNCULUS_DIR`, `ECC_MCP_HEALTH_STATE_PATH`, `GATEGUARD_STATE_DIR`) via a `_claude_with_home` helper, so the two accounts never share sessions, governance `state.db`, instincts, or hook caches. `claude-config` (config-edit escape hatch) routes through the same helper.
- **Ignore runtime state**: ECC/account state (`ecc/`, `ecc-homunculus/`, `metrics/`, `mcp-health-cache.json`, `.gateguard/`) for both accounts + `.agents` skill locks.
- **Renovate**: a `github-tags` manager tracks ECC releases and pins both `[ecc].version` and the commit digest; a `packageRule` keeps ECC (third-party executable code) out of automerge.

## Security: immutable commit pin (verified)

ECC ships executable hook code, so it is pinned to a commit SHA — not a moveable `refs/tags/` URL — matching how `anthropics/skills` is pinned in the same file. This prevents a re-pointed tag from silently swapping the hook runtime. (Resolved from the multi-review High finding.)

## Why v2.0.0 (verified, not assumed)

The design analyzed ECC v1.4.1, but the fork/hook/account assumptions were re-verified against v2.0.0 directly in the installed cache: `getClaudeDir()`, `insertGovernanceEvent`, `ECC_AGENT_DATA_HOME`, and `CLAUDE_PLUGIN_ROOT` resolution all exist; `governance-capture.js` is still stderr-only and `post-bash-command-log.js` still hardcodes `os.homedir()` (both fork rationales hold).

## Stacked PR

PR2 of 11, branched off `phase6/pr01-plumbing-hygiene` (#168). Reviewed PR-by-PR; do not merge out of order.

## Review

multi-review (cc-code-review + cc-security-review) — all findings resolved or validated against primary sources:
- **High** (mutable tag URL) → commit-SHA pin + `github-tags` digest tracking + ECC `automerge: false`.
- **Both reviewers** flagged `ecc-*` aliases referencing `scripts/*.js` outside the include globs → aliases removed (they also need ECC runtime deps); they return with the ECC state.db CLI + dependency follow-up.
- `claude-config` routed through `_claude_with_home`; r06 escape hatch documented.
- Deferred (not blockers): tarball `checksum` (commit-SHA + HTTPS suffices and matches anthropics/skills), state.db backup strategy (ops concern, not code).

## Test plan (static — done)

- [x] `make lint` and full `make test-bats` green; `claude.zsh` passes `zsh -n`
- [x] `chezmoi data` loads `[ecc].version` + `[ecc].commit`; `.chezmoiexternal.toml` renders to the commit-SHA tarball URL
- [x] Real tarball verified: `ECC-<sha>/scripts/{hooks,lib}`, `stripComponents=2`, 141 files
- [x] `renovate.json5` valid JSON5 (github-tags digest manager + ECC packageRule)

## Runtime verification (maintainer, on `chezmoi apply`)

- [ ] `~/.agents/skills/ecc/scripts/hooks/` and `scripts/lib/` materialize (141 files)
- [ ] `cld` writes to `~/.claude/...`, `cld-r06` to `~/.claude-r06/...` (sessions, ecc/, ecc-homunculus separated)
- [ ] Renovate opens a PR (not automerged) when a new ECC release tag ships
