### PR TITLE
feat(hooks): add config protection and governance audit hooks

### DIFF
--- a/home/dot_claude/hooks-fork/governance-capture.js
+++ b/home/dot_claude/hooks-fork/governance-capture.js
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Governance Event Capture — chezmoi-managed fork of ECC's governance-capture.js.
+ *
+ * Why this fork exists (task #6 / M3): ECC's scripts/hooks/governance-capture.js
+ * detects governance-relevant events (secrets, approval-required commands, sensitive
+ * paths, elevated-privilege commands) but only writes them to stderr — its
+ * documented state-store persistence is never wired up. This fork reuses ECC's
+ * detection logic verbatim (require()d from the pinned external) and ADDS durable
+ * persistence to the per-account governance_events table.
+ *
+ * Why node:sqlite instead of ECC's state-store: ECC's state-store is built on the
+ * sql.js npm package and an ajv-validated schema file, none of which the
+ * chezmoi-external adoption provisions (no `npm install`, so node_modules and the
+ * schemas/ dir are absent). Node's built-in node:sqlite (DatabaseSync) needs no
+ * dependencies and writes a standard SQLite3 file that ECC's sql.js readers can
+ * still open. The schema is applied by replaying ECC's own migration SQL
+ * (require()d from scripts/lib/state-store/migrations.js, which is pure JS with no
+ * sql.js/ajv dependency), so the resulting database is byte-compatible with what
+ * ECC would have produced — including the schema_migrations bookkeeping — and ECC's
+ * later migrations skip cleanly.
+ *
+ * Foreign keys are intentionally left disabled on this connection: this hook only
+ * appends governance rows, whose session_id may reference a session this hook does
+ * not own (it never creates `sessions` rows). FK enforcement would reject those
+ * inserts; raw SQLite defaults FK off anyway, so the declared constraint stays
+ * inert here and is enforced only when ECC opens the same file with FK on.
+ *
+ * Account isolation: dbPath derives from ECC_AGENT_DATA_HOME (exported by the
+ * cld / cld-r06 aliases), so cld writes ~/.claude/ecc/state.db and cld-r06 writes
+ * ~/.claude-r06/ecc/state.db.
+ *
+ * Fail-open: every failure path (governance capture disabled, missing external
+ * runtime, parse error, DB error) degrades to stderr-only emit plus a stdin
+ * pass-through. The tool pipeline is never blocked and the process exits 0.
+ *
+ * Wiring (home/dot_claude/settings.json): invoked directly as `node <this file>`
+ * for both pre:governance-capture (PreToolUse) and post:governance-capture
+ * (PostToolUse); the phase is derived from the payload's hook_event_name. Enable
+ * with ECC_GOVERNANCE_CAPTURE=1.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const MAX_STDIN = 1024 * 1024;
+
+function emitGovernanceEvent(event) {
+  process.stderr.write(`[governance] ${JSON.stringify(event)}\n`);
+}
+
+/**
+ * Resolve the ECC plugin root (mirrors plugin-hook-bootstrap.js fallback) so the
+ * detection logic and migration SQL can be require()d from the chezmoi-external
+ * runtime. Returns null when no runtime is found (fail-open).
+ */
+function resolvePluginRoot() {
+  const probeRel = path.join('scripts', 'lib', 'state-store', 'migrations.js');
+  const hasRuntime = candidate => {
+    try {
+      return Boolean(candidate) && fs.existsSync(path.join(path.resolve(candidate), probeRel));
+    } catch {
+      return false;
+    }
+  };
+
+  const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (envRoot && envRoot.trim() && hasRuntime(envRoot.trim())) {
+    return path.resolve(envRoot.trim());
+  }
+
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, '.agents', 'skills', 'ecc'),
+    path.join(home, '.claude', 'plugins', 'ecc'),
+    path.join(home, '.claude', 'plugins', 'ecc@ecc'),
+    path.join(home, '.claude', 'plugins', 'marketplaces', 'ecc'),
+  ];
+  for (const candidate of candidates) {
+    if (hasRuntime(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Plugin-manager cache: ~/.claude/plugins/cache/ecc/<org>/<version>/
+  try {
+    const cacheBase = path.join(home, '.claude', 'plugins', 'cache', 'ecc');
+    for (const org of fs.readdirSync(cacheBase, { withFileTypes: true })) {
+      if (!org.isDirectory()) continue;
+      for (const version of fs.readdirSync(path.join(cacheBase, org.name), { withFileTypes: true })) {
+        if (!version.isDirectory()) continue;
+        const candidate = path.join(cacheBase, org.name, version.name);
+        if (hasRuntime(candidate)) {
+          return candidate;
+        }
+      }
+    }
+  } catch {
+    // No cache directory — fall through.
+  }
+
+  return null;
+}
+
+function stateDbPath() {
+  const base = process.env.ECC_AGENT_DATA_HOME || path.join(os.homedir(), '.claude');
+  return path.join(base, 'ecc', 'state.db');
+}
+
+/**
+ * Persist governance events to the per-account state.db. Best-effort: any failure
+ * degrades to stderr-only (the events were already emitted by the caller).
+ */
+function persistEvents(events, pluginRoot) {
+  if (!events.length || !pluginRoot) {
+    return;
+  }
+
+  let DatabaseSync;
+  try {
+    ({ DatabaseSync } = require('node:sqlite'));
+  } catch {
+    return; // node:sqlite unavailable (older Node) — emit-only.
+  }
+
+  let MIGRATIONS;
+  try {
+    ({ MIGRATIONS } = require(path.join(pluginRoot, 'scripts', 'lib', 'state-store', 'migrations.js')));
+  } catch {
+    return;
+  }
+
+  const dbPath = stateDbPath();
+  try {
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  } catch {
+    // Directory creation failed — the open below will surface the error.
+  }
+
+  let db;
+  try {
+    // FK off: see file header — appended rows may reference unmanaged sessions.
+    db = new DatabaseSync(dbPath, { enableForeignKeyConstraints: false });
+  } catch (err) {
+    process.stderr.write(`[governance] open failed: ${err.message}\n`);
+    return;
+  }
+
+  try {
+    db.exec(
+      'CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL)'
+    );
+    const applied = new Set(db.prepare('SELECT version FROM schema_migrations').all().map(row => row.version));
+    const recordMigration = db.prepare('INSERT INTO schema_migrations (version, name, applied_at) VALUES (?, ?, ?)');
+
+    db.exec('BEGIN');
+    try {
+      for (const migration of Array.isArray(MIGRATIONS) ? MIGRATIONS : []) {
+        if (applied.has(migration.version)) continue;
+        db.exec(migration.sql);
+        recordMigration.run(migration.version, migration.name, new Date().toISOString());
+      }
+      db.exec('COMMIT');
+    } catch (err) {
+      try {
+        db.exec('ROLLBACK');
+      } catch {
+        // Ignore rollback failure.
+      }
+      throw err;
+    }
+
+    const insert = db.prepare(
+      'INSERT INTO governance_events (id, session_id, event_type, payload, resolved_at, resolution, created_at) ' +
+        'VALUES (@id, @session_id, @event_type, @payload, @resolved_at, @resolution, @created_at) ' +
+        'ON CONFLICT(id) DO UPDATE SET session_id=excluded.session_id, event_type=excluded.event_type, ' +
+        'payload=excluded.payload, resolved_at=excluded.resolved_at, resolution=excluded.resolution, ' +
+        'created_at=excluded.created_at'
+    );
+    for (const event of events) {
+      insert.run({
+        '@id': event.id,
+        '@session_id': event.sessionId ?? null,
+        '@event_type': event.eventType,
+        '@payload': JSON.stringify(event.payload ?? {}),
+        '@resolved_at': event.resolvedAt ?? null,
+        '@resolution': event.resolution ?? null,
+        '@created_at': event.createdAt || new Date().toISOString(),
+      });
+    }
+  } catch (err) {
+    process.stderr.write(`[governance] persist failed: ${err.message}\n`);
+  } finally {
+    try {
+      db.close();
+    } catch {
+      // Ignore close failure.
+    }
+  }
+}
+
+/**
+ * Core hook logic. Detects governance events (via ECC's analyzer), emits each to
+ * stderr (preserving ECC behaviour), persists them to state.db, and returns the
+ * untouched input for pass-through.
+ */
+function run(rawInput, options = {}) {
+  if (String(process.env.ECC_GOVERNANCE_CAPTURE || '').toLowerCase() !== '1') {
+    return rawInput;
+  }
+
+  const pluginRoot = resolvePluginRoot();
+
+  let analyze = null;
+  let generateEventId = null;
+  if (pluginRoot) {
+    try {
+      const eccModule = require(path.join(pluginRoot, 'scripts', 'hooks', 'governance-capture.js'));
+      analyze = eccModule.analyzeForGovernanceEvents;
+      generateEventId = eccModule.generateEventId;
+    } catch {
+      analyze = null;
+    }
+  }
+
+  const sessionId = process.env.ECC_SESSION_ID || null;
+
+  let input = null;
+  try {
+    input = JSON.parse(rawInput);
+  } catch {
+    input = null;
+  }
+
+  const eventName = (input && input.hook_event_name) || process.env.CLAUDE_HOOK_EVENT_NAME || '';
+  const hookPhase = String(eventName).startsWith('Pre') ? 'pre' : 'post';
+
+  const events = [];
+
+  if (options.truncated) {
+    events.push({
+      id: typeof generateEventId === 'function' ? generateEventId() : `gov-${Date.now()}-truncated`,
+      sessionId,
+      eventType: 'hook_input_truncated',
+      payload: {
+        hookPhase,
+        sizeLimitBytes: options.maxStdin || MAX_STDIN,
+        severity: 'warning',
+      },
+      resolvedAt: null,
+      resolution: null,
+    });
+  }
+
+  if (typeof analyze === 'function' && input) {
+    try {
+      events.push(...analyze(input, { sessionId, hookPhase }));
+    } catch {
+      // Detection failure must never block the tool pipeline.
+    }
+  }
+
+  for (const event of events) {
+    emitGovernanceEvent(event);
+  }
+
+  try {
+    persistEvents(events, pluginRoot);
+  } catch (err) {
+    process.stderr.write(`[governance] persist error: ${err.message}\n`);
+  }
+
+  return rawInput;
+}
+
+// ── stdin entry point ────────────────────────────────────────────────────────
+if (require.main === module) {
+  let raw = '';
+  let truncated = /^(1|true|yes)$/i.test(String(process.env.ECC_HOOK_INPUT_TRUNCATED || ''));
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      const remaining = MAX_STDIN - raw.length;
+      raw += chunk.substring(0, remaining);
+      if (chunk.length > remaining) {
+        truncated = true;
+      }
+    } else {
+      truncated = true;
+    }
+  });
+  process.stdin.on('error', () => {
+    process.stdout.write(raw);
+    process.exit(0);
+  });
+  process.stdin.on('end', () => {
+    let output = raw;
+    try {
+      output = run(raw, {
+        truncated,
+        maxStdin: Number(process.env.ECC_HOOK_INPUT_MAX_BYTES) || MAX_STDIN,
+      });
+    } catch {
+      output = raw;
+    }
+    process.stdout.write(output);
+    process.exit(0);
+  });
+}
+
+module.exports = {
+  resolvePluginRoot,
+  stateDbPath,
+  persistEvents,
+  run,
+};

--- a/home/dot_claude/hooks-fork/governance-capture.js
+++ b/home/dot_claude/hooks-fork/governance-capture.js
@@ -18,9 +18,16 @@
  * dependencies and writes a standard SQLite3 file that ECC's sql.js readers can
  * still open. The schema is applied by replaying ECC's own migration SQL
  * (require()d from scripts/lib/state-store/migrations.js, which is pure JS with no
- * sql.js/ajv dependency), so the resulting database is byte-compatible with what
+ * sql.js/ajv dependency), so the resulting database is schema-compatible with what
  * ECC would have produced — including the schema_migrations bookkeeping — and ECC's
- * later migrations skip cleanly.
+ * later migrations skip cleanly. We replay the MIGRATIONS array ourselves rather
+ * than calling ECC's applyMigrations() because the latter uses better-sqlite3's
+ * db.transaction(), which node:sqlite's DatabaseSync does not expose; if ECC ever
+ * changes its migration-apply semantics, this replay loop must be updated by hand.
+ *
+ * WAL + busy_timeout match ECC's own connection (state-store/index.js sets WAL) and
+ * let concurrent hook processes (parallel tool calls each fire pre+post) serialise
+ * writes instead of dropping audit rows on SQLITE_BUSY.
  *
  * Foreign keys are intentionally left disabled on this connection: this hook only
  * appends governance rows, whose session_id may reference a session this hook does
@@ -134,29 +141,71 @@ function persistEvents(events, pluginRoot) {
   }
 
   const dbPath = stateDbPath();
+  const dbDir = path.dirname(dbPath);
+  const dirExisted = fs.existsSync(dbDir);
   try {
-    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    // 0700: the audit DB holds sensitive-path / command metadata; keep its
+    // directory owner-only. recursive mode only applies to created components.
+    fs.mkdirSync(dbDir, { recursive: true, mode: 0o700 });
   } catch {
     // Directory creation failed — the open below will surface the error.
   }
+  if (!dirExisted) {
+    try {
+      fs.chmodSync(dbDir, 0o700);
+    } catch {
+      // Best-effort hardening only.
+    }
+  }
 
+  const dbExisted = fs.existsSync(dbPath);
   let db;
   try {
     // FK off: see file header — appended rows may reference unmanaged sessions.
     db = new DatabaseSync(dbPath, { enableForeignKeyConstraints: false });
   } catch (err) {
-    process.stderr.write(`[governance] open failed: ${err.message}\n`);
+    process.stderr.write(`[governance][persist-failed] open failed: ${err.message}\n`);
     return;
   }
 
+  if (!dbExisted) {
+    // Restrict a freshly created audit DB to the owner (0600). Existing files
+    // are left untouched so we never widen or fight a user's chosen mode.
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        fs.chmodSync(dbPath + suffix, 0o600);
+      } catch {
+        // Sidecar may not exist yet / chmod unsupported — best-effort only.
+      }
+    }
+  }
+
   try {
+    // Match ECC's own connection (state-store/index.js uses WAL) and let
+    // concurrent hook processes wait on the write lock instead of dropping
+    // audit rows on SQLITE_BUSY. busy_timeout stays under the hook's 10s budget.
+    try {
+      db.exec('PRAGMA journal_mode = WAL');
+    } catch {
+      // WAL unsupported in this context — fall back to the default journal.
+    }
+    try {
+      db.exec('PRAGMA busy_timeout = 5000');
+    } catch {
+      // Ignore — a missing busy_timeout only weakens concurrent-write resilience.
+    }
+
     db.exec(
       'CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL)'
     );
     const applied = new Set(db.prepare('SELECT version FROM schema_migrations').all().map(row => row.version));
-    const recordMigration = db.prepare('INSERT INTO schema_migrations (version, name, applied_at) VALUES (?, ?, ?)');
+    // INSERT OR IGNORE: a concurrent fork on a fresh DB may also be recording
+    // the same migration version — let the loser skip rather than error.
+    const recordMigration = db.prepare('INSERT OR IGNORE INTO schema_migrations (version, name, applied_at) VALUES (?, ?, ?)');
 
-    db.exec('BEGIN');
+    // BEGIN IMMEDIATE acquires the write lock up front so two concurrent forks
+    // serialise the whole migrate+insert unit instead of racing the lock mid-write.
+    db.exec('BEGIN IMMEDIATE');
     try {
       for (const migration of Array.isArray(MIGRATIONS) ? MIGRATIONS : []) {
         if (applied.has(migration.version)) continue;
@@ -173,12 +222,13 @@ function persistEvents(events, pluginRoot) {
       throw err;
     }
 
+    // DO NOTHING keeps the table append-only: governance events are an audit
+    // trail, and ids are unique, so a (near-impossible) id collision must never
+    // silently overwrite an existing row.
     const insert = db.prepare(
       'INSERT INTO governance_events (id, session_id, event_type, payload, resolved_at, resolution, created_at) ' +
         'VALUES (@id, @session_id, @event_type, @payload, @resolved_at, @resolution, @created_at) ' +
-        'ON CONFLICT(id) DO UPDATE SET session_id=excluded.session_id, event_type=excluded.event_type, ' +
-        'payload=excluded.payload, resolved_at=excluded.resolved_at, resolution=excluded.resolution, ' +
-        'created_at=excluded.created_at'
+        'ON CONFLICT(id) DO NOTHING'
     );
     for (const event of events) {
       insert.run({
@@ -192,7 +242,9 @@ function persistEvents(events, pluginRoot) {
       });
     }
   } catch (err) {
-    process.stderr.write(`[governance] persist failed: ${err.message}\n`);
+    // Machine-readable marker so external monitoring can detect dropped audit
+    // events even though the hook fails open and never blocks the tool.
+    process.stderr.write(`[governance][persist-failed] ${err.message}\n`);
   } finally {
     try {
       db.close();
@@ -226,8 +278,6 @@ function run(rawInput, options = {}) {
     }
   }
 
-  const sessionId = process.env.ECC_SESSION_ID || null;
-
   let input = null;
   try {
     input = JSON.parse(rawInput);
@@ -235,9 +285,25 @@ function run(rawInput, options = {}) {
     input = null;
   }
 
+  // session_id arrives in the stdin payload (a common hook input field); the
+  // cld/cld-r06 aliases do NOT export ECC_SESSION_ID, so reading it from the
+  // payload is what actually correlates events to a session.
+  const sessionId = (input && input.session_id) || process.env.ECC_SESSION_ID || null;
+
   const eventName = (input && input.hook_event_name) || process.env.CLAUDE_HOOK_EVENT_NAME || '';
   const hookPhase = String(eventName).startsWith('Pre') ? 'pre' : 'post';
 
+  // ECC's analyzer inspects `tool_output` for output-side secrets, but Claude
+  // Code delivers tool output under `tool_response` (PostToolUse/PostToolUseFailure).
+  // Normalise so the post-side detection actually runs.
+  if (input && input.tool_output == null && input.tool_response != null) {
+    input.tool_output =
+      typeof input.tool_response === 'string' ? input.tool_response : JSON.stringify(input.tool_response);
+  }
+
+  // Note: when stdin exceeded MAX_STDIN the payload is truncated, JSON.parse
+  // above fails, and only the hook_input_truncated event below is recorded —
+  // detection is intentionally skipped rather than run on a corrupt payload.
   const events = [];
 
   if (options.truncated) {
@@ -270,10 +336,22 @@ function run(rawInput, options = {}) {
   try {
     persistEvents(events, pluginRoot);
   } catch (err) {
-    process.stderr.write(`[governance] persist error: ${err.message}\n`);
+    process.stderr.write(`[governance][persist-failed] ${err.message}\n`);
   }
 
   return rawInput;
+}
+
+// Write stdout and exit only once the buffer is fully flushed. A bare
+// process.exit() after a write truncates output larger than the OS pipe buffer
+// (~64 KB) — fatal for PostToolUse pass-through of large tool_response payloads.
+function writeAndExit(output) {
+  process.exitCode = 0;
+  try {
+    process.stdout.write(output, () => process.exit(0));
+  } catch {
+    process.exit(0);
+  }
 }
 
 // ── stdin entry point ────────────────────────────────────────────────────────
@@ -293,8 +371,7 @@ if (require.main === module) {
     }
   });
   process.stdin.on('error', () => {
-    process.stdout.write(raw);
-    process.exit(0);
+    writeAndExit(raw);
   });
   process.stdin.on('end', () => {
     let output = raw;
@@ -306,8 +383,7 @@ if (require.main === module) {
     } catch {
       output = raw;
     }
-    process.stdout.write(output);
-    process.exit(0);
+    writeAndExit(output);
   });
 }
 

--- a/home/dot_claude/hooks-fork/governance-capture.js
+++ b/home/dot_claude/hooks-fork/governance-capture.js
@@ -117,6 +117,17 @@ function stateDbPath() {
   return path.join(base, 'ecc', 'state.db');
 }
 
+// Best-effort owner-only (0600) on the audit DB and its WAL sidecars.
+function hardenDbPerms(dbPath) {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try {
+      fs.chmodSync(dbPath + suffix, 0o600);
+    } catch {
+      // Sidecar may not exist / chmod unsupported — best-effort only.
+    }
+  }
+}
+
 /**
  * Persist governance events to the per-account state.db. Best-effort: any failure
  * degrades to stderr-only (the events were already emitted by the caller).
@@ -130,19 +141,22 @@ function persistEvents(events, pluginRoot) {
   try {
     ({ DatabaseSync } = require('node:sqlite'));
   } catch {
-    return; // node:sqlite unavailable (older Node) — emit-only.
+    // Emit the drop marker so every persistence-failure path is observable,
+    // not just DB-open/write errors. (node:sqlite needs Node >= 22.5.)
+    process.stderr.write('[governance][persist-failed] node:sqlite unavailable\n');
+    return;
   }
 
   let MIGRATIONS;
   try {
     ({ MIGRATIONS } = require(path.join(pluginRoot, 'scripts', 'lib', 'state-store', 'migrations.js')));
-  } catch {
+  } catch (err) {
+    process.stderr.write(`[governance][persist-failed] migration load failed: ${err.message}\n`);
     return;
   }
 
   const dbPath = stateDbPath();
   const dbDir = path.dirname(dbPath);
-  const dirExisted = fs.existsSync(dbDir);
   try {
     // 0700: the audit DB holds sensitive-path / command metadata; keep its
     // directory owner-only. recursive mode only applies to created components.
@@ -150,15 +164,15 @@ function persistEvents(events, pluginRoot) {
   } catch {
     // Directory creation failed — the open below will surface the error.
   }
-  if (!dirExisted) {
-    try {
-      fs.chmodSync(dbDir, 0o700);
-    } catch {
-      // Best-effort hardening only.
-    }
+  // Enforce owner-only on the audit dir every run (idempotent), so an existing
+  // dir created with a looser umask is also tightened. An audit store has no
+  // legitimate reason to be group/world-accessible.
+  try {
+    fs.chmodSync(dbDir, 0o700);
+  } catch {
+    // Best-effort hardening only.
   }
 
-  const dbExisted = fs.existsSync(dbPath);
   let db;
   try {
     // FK off: see file header — appended rows may reference unmanaged sessions.
@@ -168,17 +182,10 @@ function persistEvents(events, pluginRoot) {
     return;
   }
 
-  if (!dbExisted) {
-    // Restrict a freshly created audit DB to the owner (0600). Existing files
-    // are left untouched so we never widen or fight a user's chosen mode.
-    for (const suffix of ['', '-wal', '-shm']) {
-      try {
-        fs.chmodSync(dbPath + suffix, 0o600);
-      } catch {
-        // Sidecar may not exist yet / chmod unsupported — best-effort only.
-      }
-    }
-  }
+  // Restrict the audit DB to the owner (0600), every run and idempotently. The
+  // -wal/-shm sidecars only exist once WAL is active, so they are re-hardened
+  // again after the writes below.
+  hardenDbPerms(dbPath);
 
   try {
     // Match ECC's own connection (state-store/index.js uses WAL) and let
@@ -241,6 +248,9 @@ function persistEvents(events, pluginRoot) {
         '@created_at': event.createdAt || new Date().toISOString(),
       });
     }
+
+    // Re-harden now that WAL writes have materialised the -wal/-shm sidecars.
+    hardenDbPerms(dbPath);
   } catch (err) {
     // Machine-readable marker so external monitoring can detect dropped audit
     // events even though the hook fails open and never blocks the tool.

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -11,7 +11,8 @@
     "DISABLE_INSTALLATION_CHECKS": "1",
     "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "95",
-    "MAX_THINKING_TOKENS": "127999"
+    "MAX_THINKING_TOKENS": "127999",
+    "ECC_GOVERNANCE_CAPTURE": "1"
   },
   "permissions": {
     "allow": [
@@ -150,6 +151,64 @@
         ],
         "description": "Suggest manual compaction at logical intervals",
         "id": "pre:edit-write:suggest-compact"
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js pre:config-protection scripts/hooks/config-protection.js standard,strict",
+            "timeout": 5
+          }
+        ],
+        "description": "Block edits to linter/formatter config files (bypass with ECC_DISABLED_HOOKS=pre:config-protection)",
+        "id": "pre:config-protection"
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js pre:edit-write:gateguard-fact-force scripts/hooks/gateguard-fact-force.js standard,strict",
+            "timeout": 5
+          }
+        ],
+        "description": "Fact-forcing gate: require articulating impact before the first Edit/Write per file",
+        "id": "pre:edit-write:gateguard-fact-force"
+      },
+      {
+        "matcher": "Bash|Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$HOME/.claude/hooks-fork/governance-capture.js\"",
+            "timeout": 10
+          }
+        ],
+        "description": "Capture governance events (secrets, approval-required commands, sensitive paths) to per-account state.db. Forked from ECC to add persistence; enable with ECC_GOVERNANCE_CAPTURE=1",
+        "id": "pre:governance-capture"
+      },
+      {
+        "matcher": "mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js pre:mcp-health-check scripts/hooks/mcp-health-check.js standard,strict"
+          }
+        ],
+        "description": "Probe MCP server health before MCP tool execution (matcher narrowed to mcp__.* per task #13 so non-MCP tools never pay the hook cost)",
+        "id": "pre:mcp-health-check"
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js pre:write:doc-file-warning scripts/hooks/doc-file-warning.js standard,strict"
+          }
+        ],
+        "description": "Warn when creating non-standard scratch documentation files (TODO.md/NOTES.md/etc.) outside structured directories",
+        "id": "pre:write:doc-file-warning"
       }
     ],
     "PostToolUse": [
@@ -176,6 +235,31 @@
         ],
         "description": "Inject agent warnings on context exhaustion, high cost, scope creep, or tool loops",
         "id": "post:ecc-context-monitor"
+      },
+      {
+        "matcher": "Bash|Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$HOME/.claude/hooks-fork/governance-capture.js\"",
+            "timeout": 10
+          }
+        ],
+        "description": "Capture governance events from tool outputs to per-account state.db (pairs with pre:governance-capture)",
+        "id": "post:governance-capture"
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:mcp-health-check scripts/hooks/mcp-health-check.js standard,strict"
+          }
+        ],
+        "description": "Track failed MCP tool calls, mark unhealthy servers, and attempt reconnect",
+        "id": "post:mcp-health-check"
       }
     ],
     "Stop": [

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -193,10 +193,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js pre:mcp-health-check scripts/hooks/mcp-health-check.js standard,strict"
+            "command": "CLAUDE_HOOK_EVENT_NAME=PreToolUse $HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js pre:mcp-health-check scripts/hooks/mcp-health-check.js standard,strict",
+            "timeout": 10
           }
         ],
-        "description": "Probe MCP server health before MCP tool execution (matcher narrowed to mcp__.* per task #13 so non-MCP tools never pay the hook cost)",
+        "description": "Probe MCP server health before MCP tool execution (matcher narrowed to mcp__.* per task #13 so non-MCP tools never pay the hook cost). CLAUDE_HOOK_EVENT_NAME is set explicitly because Claude Code does not export it and mcp-health-check.js selects its handler from that env var.",
         "id": "pre:mcp-health-check"
       },
       {
@@ -255,10 +256,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:mcp-health-check scripts/hooks/mcp-health-check.js standard,strict"
+            "command": "CLAUDE_HOOK_EVENT_NAME=PostToolUseFailure $HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:mcp-health-check scripts/hooks/mcp-health-check.js standard,strict",
+            "timeout": 10
           }
         ],
-        "description": "Track failed MCP tool calls, mark unhealthy servers, and attempt reconnect",
+        "description": "Track failed MCP tool calls, mark unhealthy servers, and attempt reconnect. CLAUDE_HOOK_EVENT_NAME=PostToolUseFailure is set explicitly because Claude Code does not export it and mcp-health-check.js would otherwise default to the PreToolUse handler.",
         "id": "post:mcp-health-check"
       }
     ],

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -127,6 +127,12 @@ load helpers/setup
   [ -f "${HOME_DIR}/dot_claude/executable_ecc-hook.sh" ]
 }
 
+@test "ecc governance-capture fork exists and passes node syntax check" {
+  local fork="${HOME_DIR}/dot_claude/hooks-fork/governance-capture.js"
+  [ -f "$fork" ]
+  node --check "$fork"
+}
+
 @test "1password-backed secret template exists" {
   [ -f "${HOME_DIR}/private_dot_aws/config.tmpl" ]
 }

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -133,6 +133,40 @@ load helpers/setup
   node --check "$fork"
 }
 
+# Regression guard: a bare process.exit() after stdout.write() truncates output
+# larger than the OS pipe buffer (~64 KB), which would corrupt PostToolUse
+# pass-through of large tool_response payloads. The fork must pass input through
+# byte-for-byte regardless of size. No ECC runtime needed (a benign tool yields
+# zero events, so the hook only passes stdin through).
+@test "ecc governance-capture fork passes large input through without truncation" {
+  local fork="${HOME_DIR}/dot_claude/hooks-fork/governance-capture.js"
+  local tmp; tmp=$(mktemp -d)
+  node -e 'process.stdout.write(JSON.stringify({hook_event_name:"PostToolUse",tool_name:"Read",tool_input:{file_path:"/x"},tool_response:"A".repeat(200000)}))' > "$tmp/in.json"
+  local in_bytes out_bytes
+  in_bytes=$(wc -c < "$tmp/in.json")
+  out_bytes=$(ECC_GOVERNANCE_CAPTURE=1 ECC_AGENT_DATA_HOME="$tmp" node "$fork" < "$tmp/in.json" 2>/dev/null | wc -c)
+  rm -rf "$tmp"
+  [ "$in_bytes" -gt 65536 ]
+  [ "$in_bytes" -eq "$out_bytes" ]
+}
+
+# Functional smoke: with the ECC runtime present and node:sqlite available, a
+# governance-relevant tool call must persist a row to the per-account state.db.
+# Skips in minimal CI (no ECC external / older Node without node:sqlite).
+@test "ecc governance-capture fork persists an event to state.db" {
+  local fork="${HOME_DIR}/dot_claude/hooks-fork/governance-capture.js"
+  local ecc="${HOME}/.agents/skills/ecc/scripts/hooks/governance-capture.js"
+  [ -f "$ecc" ] || skip "ECC external runtime not deployed"
+  node -e 'require("node:sqlite")' 2>/dev/null || skip "node:sqlite unavailable"
+  local tmp; tmp=$(mktemp -d)
+  printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git push origin main --force"},"session_id":"bats-gov"}' \
+    | CLAUDE_PLUGIN_ROOT="${HOME}/.agents/skills/ecc" ECC_GOVERNANCE_CAPTURE=1 ECC_AGENT_DATA_HOME="$tmp" node "$fork" >/dev/null 2>&1
+  local count
+  count=$(node -e 'const{DatabaseSync}=require("node:sqlite");const db=new DatabaseSync(process.argv[1],{enableForeignKeyConstraints:false});process.stdout.write(String(db.prepare("SELECT count(*) c, session_id s FROM governance_events").get().c));db.close()' "$tmp/ecc/state.db" 2>/dev/null)
+  rm -rf "$tmp"
+  [ "$count" -ge 1 ]
+}
+
 @test "1password-backed secret template exists" {
   [ -f "${HOME_DIR}/private_dot_aws/config.tmpl" ]
 }


### PR DESCRIPTION
## Summary

Wire seven ECC protection/governance hooks into `settings.json` (PR4 of the Phase 6 stacked plan), plus a `node:sqlite` fork of `governance-capture` that persists detected events to a per-account `state.db`.

| hook | event | matcher | source | notes |
|---|---|---|---|---|
| **E1** `pre:config-protection` | PreToolUse | `Write\|Edit\|MultiEdit` | ECC (launcher) | block edits to **existing** linter/formatter configs; new scaffolds exempt |
| **E2** `pre:governance-capture` | PreToolUse | `Bash\|Write\|Edit\|MultiEdit` | 🆕 fork | audit secrets / approval-required commands / sensitive paths |
| **E3** `post:governance-capture` | PostToolUse | `Bash\|Write\|Edit\|MultiEdit` | 🆕 fork | tool-output side of the audit |
| **F1** `pre:edit-write:gateguard-fact-force` | PreToolUse | `Edit\|Write\|MultiEdit` | ECC (launcher) | force impact articulation on first touch |
| **G1** `pre:mcp-health-check` | PreToolUse | `mcp__.*` | ECC (launcher) | matcher narrowed (task #13) so non-MCP tools never start the hook |
| **G2** `post:mcp-health-check` | PostToolUseFailure | `*` | ECC (launcher) | mark unhealthy servers, attempt reconnect |
| **I1** `pre:write:doc-file-warning` | PreToolUse | `Write` | ECC (launcher) | warn on ad-hoc scratch doc filenames outside structured dirs |

Adds `ECC_GOVERNANCE_CAPTURE=1` to the env block.

## The `governance-capture` fork (task #6)

ECC's `governance-capture.js` only emits detected events to stderr — it never persists them. The fork (`home/dot_claude/hooks-fork/governance-capture.js`) adds durable persistence.

It uses Node's built-in **`node:sqlite`** rather than ECC's `sql.js`-based state-store, because that subsystem's dependency closure (`sql.js`, `ajv` + 5 transitive deps, and `schemas/state-store.schema.json`) is **not provisioned by the chezmoi-external adoption** (no `npm install`). The fork:

- reuses ECC's detection logic (`analyzeForGovernanceEvents`) and migration SQL (`migrations.js` — both dependency-free) via a plugin-root fallback `require`, so the resulting database is **ECC-compatible** (full schema + `schema_migrations` bookkeeping);
- derives the db path from `ECC_AGENT_DATA_HOME`, so `cld` writes `~/.claude/ecc/state.db` and `cld-r06` writes `~/.claude-r06/ecc/state.db`;
- leaves foreign keys disabled (it appends rows referencing `sessions` it does not own);
- is **lazy** (opens the db only when there is an event) and **fails open** on every error (stderr-only + stdin pass-through).

This removes the dependency on the deferred `sql.js`/`ajv` provisioning work (#46/#15).

## Verification

- [x] `make lint` / `make test` — 53 bats tests pass (incl. `node --check` on the fork)
- [x] fork: detect → stderr emit → `state.db` persist → pass-through; account isolation; fail-open; lazy open (benign call opens no db)
- [x] E1 blocks an existing `.eslintrc.json` (exit 2), exempts a missing one and non-config files
- [x] I1 emits `additionalContext` on `TODO.md` outside structured dirs, exempt inside `docs/`/`.claude/`
- [x] F1 denies the first Edit (articulation gate); G1/G2 run on MCP payloads without crashing
- [x] `chezmoi diff` confirms the new fork file + `settings.json` wiring
- [x] matcher semantics for `mcp__.*` confirmed against the official hooks docs (regex evaluation; `mcp__` alone would be exact-match)
- [ ] user runtime (after `chezmoi apply`): real-session `governance_events` rows (cld vs cld-r06), config-edit block, MCP probe

## Notes

- `ecc-status` / `ecc-sessions` CLIs are out of scope — their scripts live at the ECC plugin root (not under the fetched `scripts/hooks` / `scripts/lib`) and need the deferred npm-dep provisioning (#46). This PR only **writes** `state.db`.
- Base: `main` @ 76a9122 (merge-as-we-go, not stacked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
