### PR TITLE
feat(hooks): Bash safety dispatcher (strict) + code-quality gates

### DIFF
--- a/home/dot_claude/hooks-fork/post-bash-command-log.js
+++ b/home/dot_claude/hooks-fork/post-bash-command-log.js
@@ -14,7 +14,9 @@
  *
  * Reuse over reimplementation: the command sanitiser (secret redaction) and the path
  * resolver are require()d from the pinned external rather than copied, so they stay in
- * sync with upstream. Only the audit-log path join is overridden. The plugin-root
+ * sync with upstream. On top of ECC's sanitiser the fork layers extraRedact() (extra
+ * secret shapes ECC misses) and writes the log owner-only (0600); the audit-log path
+ * is resolved via getClaudeDir() instead of the hardcoded ~/.claude. The plugin-root
  * fallback mirrors the PR4 governance-capture fork (probing for scripts/lib/utils.js,
  * the module that exports getClaudeDir).
  *
@@ -60,9 +62,13 @@ function resolvePluginRoot() {
     }
   };
 
-  const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
-  if (envRoot && envRoot.trim() && hasRuntime(envRoot.trim())) {
-    return path.resolve(envRoot.trim());
+  // plugin-hook-bootstrap.js reads CLAUDE_PLUGIN_ROOT, falling back to ECC_PLUGIN_ROOT;
+  // honour both so a host that exports only ECC_PLUGIN_ROOT still resolves.
+  for (const name of ['CLAUDE_PLUGIN_ROOT', 'ECC_PLUGIN_ROOT']) {
+    const envRoot = process.env[name];
+    if (envRoot && envRoot.trim() && hasRuntime(envRoot.trim())) {
+      return path.resolve(envRoot.trim());
+    }
   }
 
   const home = os.homedir();
@@ -98,6 +104,26 @@ function resolvePluginRoot() {
   return null;
 }
 
+// Defence-in-depth redaction layered ON TOP of ECC's sanitizeCommand (which is still
+// applied first, so upstream improvements keep flowing through). ECC covers
+// --token / Authorization / AKIA|ASIA / password / gh*_ tokens but misses several
+// secret shapes common in shell commands; redacting them before the line is written
+// keeps secrets out of bash-commands.log alongside the 0600 file mode below. \r is
+// collapsed too (ECC collapses \n only) so a CRLF command leaves no stray carriage
+// return in the log.
+function extraRedact(text) {
+  return String(text)
+    .replace(/\r/g, ' ')
+    // Uppercase env-style assignments: AWS_SECRET_ACCESS_KEY=, ANTHROPIC_API_KEY=,
+    // NPM_TOKEN=, *_PASSWORD= ... (env-var convention is uppercase, so no /i to avoid
+    // over-redacting ordinary words).
+    .replace(/\b([A-Z][A-Z0-9_]*(?:SECRET|KEY|TOKEN|PASSWORD|PASSWD)[A-Z0-9_]*)=\S+/g, '$1=<REDACTED>')
+    // Credentials embedded in a URL: https://user:pass@host -> https://user:<REDACTED>@host
+    .replace(/(https?:\/\/[^/\s:@]+:)[^/\s@]+@/g, '$1<REDACTED>@')
+    // OpenAI / Anthropic style keys: sk-..., sk-ant-...
+    .replace(/\bsk-[A-Za-z0-9_-]{16,}/g, '<REDACTED>');
+}
+
 /**
  * Append a sanitised audit line for the Bash command in `rawInput` to the per-account
  * bash-commands.log. Best-effort: any failure degrades to a silent pass-through.
@@ -117,10 +143,18 @@ function run(rawInput, options = {}) {
         const { getClaudeDir } = require(path.join(pluginRoot, 'scripts', 'lib', 'utils'));
         const input = String(rawInput || '').trim() ? JSON.parse(String(rawInput)) : {};
         const command = (input.tool_input && input.tool_input.command) || '?';
-        const line = `[${new Date().toISOString()}] ${sanitizeCommand(command)}`;
+        const line = `[${new Date().toISOString()}] ${extraRedact(sanitizeCommand(command))}`;
         const filePath = path.join(getClaudeDir(), AUDIT_FILE);
         fs.mkdirSync(path.dirname(filePath), { recursive: true });
-        fs.appendFileSync(filePath, `${line}\n`, 'utf8');
+        // Owner-only: the audit log holds (redacted) command history and must not be
+        // world/group readable. `mode` only applies on create, so chmod after append
+        // also tightens a pre-existing 0644 file (mirrors governance-capture.js).
+        fs.appendFileSync(filePath, `${line}\n`, { encoding: 'utf8', mode: 0o600 });
+        try {
+          fs.chmodSync(filePath, 0o600);
+        } catch {
+          // Best-effort — chmod may be unsupported on some filesystems.
+        }
       }
       // pluginRoot === null: external runtime absent → skip logging (no sanitiser).
     } catch {

--- a/home/dot_claude/hooks-fork/post-bash-command-log.js
+++ b/home/dot_claude/hooks-fork/post-bash-command-log.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Bash Command Audit Log — chezmoi-managed fork of ECC's post-bash-command-log.js.
+ *
+ * Why this fork exists (task #11 / M5): ECC's scripts/hooks/post-bash-command-log.js
+ * appends each executed Bash command to an audit log, but hardcodes the destination as
+ * `os.homedir()/.claude/bash-commands.log`. That ignores ECC_AGENT_DATA_HOME, so the
+ * cld and cld-r06 accounts would both write to ~/.claude/bash-commands.log and their
+ * command histories would collide. This fork resolves the log directory through ECC's
+ * own getClaudeDir() (= resolveAgentDataHome, which honours ECC_AGENT_DATA_HOME), so
+ * cld writes ~/.claude/bash-commands.log and cld-r06 writes ~/.claude-r06/bash-commands.log.
+ *
+ * Reuse over reimplementation: the command sanitiser (secret redaction) and the path
+ * resolver are require()d from the pinned external rather than copied, so they stay in
+ * sync with upstream. Only the audit-log path join is overridden. The plugin-root
+ * fallback mirrors the PR4 governance-capture fork (probing for scripts/lib/utils.js,
+ * the module that exports getClaudeDir).
+ *
+ * Scope: audit mode only (#7). ECC's cost mode (#8, cost-tracker.log) is not adopted —
+ * cost tracking is handled by the dedicated stop:cost-tracker hook (PR3).
+ *
+ * Wiring (home/dot_claude/settings.json): the ECC post:bash:dispatcher's internal
+ * command-log-audit sub-hook is disabled via
+ * ECC_DISABLED_HOOKS=post:bash:command-log-audit and this fork runs instead as a
+ * standalone PostToolUse Bash hook (`node <this file> audit`). A standalone node entry
+ * is required because run-with-flags.js rejects scripts outside the plugin root
+ * (path-traversal guard), so the chezmoi-managed fork cannot route through it —
+ * matching the PR4 governance-capture fork.
+ *
+ * Fail-open: every failure path (missing external runtime, parse error, fs error)
+ * degrades to a stdin pass-through with NO log line written. When the external runtime
+ * is absent the sanitiser is unavailable, so we deliberately skip logging rather than
+ * risk persisting an unredacted command — logging must never block Bash execution and
+ * must never leak secrets. The process always exits 0. (Silent fail mirrors ECC's own
+ * `catch {}` in the upstream hook.)
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const MAX_STDIN = 1024 * 1024;
+const AUDIT_FILE = 'bash-commands.log';
+
+/**
+ * Resolve the ECC plugin root (mirrors plugin-hook-bootstrap.js fallback) so the
+ * command sanitiser and getClaudeDir() can be require()d from the chezmoi-external
+ * runtime. Returns null when no runtime is found (fail-open). Probes for
+ * scripts/lib/utils.js, the module that exports getClaudeDir.
+ */
+function resolvePluginRoot() {
+  const probeRel = path.join('scripts', 'lib', 'utils.js');
+  const hasRuntime = candidate => {
+    try {
+      return Boolean(candidate) && fs.existsSync(path.join(path.resolve(candidate), probeRel));
+    } catch {
+      return false;
+    }
+  };
+
+  const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (envRoot && envRoot.trim() && hasRuntime(envRoot.trim())) {
+    return path.resolve(envRoot.trim());
+  }
+
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, '.agents', 'skills', 'ecc'),
+    path.join(home, '.claude', 'plugins', 'ecc'),
+    path.join(home, '.claude', 'plugins', 'ecc@ecc'),
+    path.join(home, '.claude', 'plugins', 'marketplaces', 'ecc'),
+  ];
+  for (const candidate of candidates) {
+    if (hasRuntime(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Plugin-manager cache: ~/.claude/plugins/cache/ecc/<org>/<version>/
+  try {
+    const cacheBase = path.join(home, '.claude', 'plugins', 'cache', 'ecc');
+    for (const org of fs.readdirSync(cacheBase, { withFileTypes: true })) {
+      if (!org.isDirectory()) continue;
+      for (const version of fs.readdirSync(path.join(cacheBase, org.name), { withFileTypes: true })) {
+        if (!version.isDirectory()) continue;
+        const candidate = path.join(cacheBase, org.name, version.name);
+        if (hasRuntime(candidate)) {
+          return candidate;
+        }
+      }
+    }
+  } catch {
+    // No cache directory — fall through.
+  }
+
+  return null;
+}
+
+/**
+ * Append a sanitised audit line for the Bash command in `rawInput` to the per-account
+ * bash-commands.log. Best-effort: any failure degrades to a silent pass-through.
+ *
+ * @param {string} rawInput - The PostToolUse Bash event JSON from stdin.
+ * @param {object} [options]
+ * @param {string} [options.mode] - Only 'audit' logs; any other mode passes through.
+ * @returns {string} The original stdin, unchanged (PostToolUse pass-through).
+ */
+function run(rawInput, options = {}) {
+  const mode = options.mode || 'audit';
+  if (mode === 'audit') {
+    try {
+      const pluginRoot = resolvePluginRoot();
+      if (pluginRoot) {
+        const { sanitizeCommand } = require(path.join(pluginRoot, 'scripts', 'hooks', 'post-bash-command-log'));
+        const { getClaudeDir } = require(path.join(pluginRoot, 'scripts', 'lib', 'utils'));
+        const input = String(rawInput || '').trim() ? JSON.parse(String(rawInput)) : {};
+        const command = (input.tool_input && input.tool_input.command) || '?';
+        const line = `[${new Date().toISOString()}] ${sanitizeCommand(command)}`;
+        const filePath = path.join(getClaudeDir(), AUDIT_FILE);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.appendFileSync(filePath, `${line}\n`, 'utf8');
+      }
+      // pluginRoot === null: external runtime absent → skip logging (no sanitiser).
+    } catch {
+      // Logging must never block the calling tool.
+    }
+  }
+
+  return typeof rawInput === 'string' ? rawInput : JSON.stringify(rawInput);
+}
+
+// process.exit() immediately after stdout.write() truncates output larger than the OS
+// pipe buffer (~64 KB) — fatal for PostToolUse pass-through of large payloads. Flush
+// via the write callback before exiting (regression guarded in tests/files.bats).
+function writeAndExit(output) {
+  process.exitCode = 0;
+  try {
+    process.stdout.write(output, () => process.exit(0));
+  } catch {
+    process.exit(0);
+  }
+}
+
+// ── stdin entry point ────────────────────────────────────────────────────────
+if (require.main === module) {
+  const mode = process.argv[2] || 'audit';
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      const remaining = MAX_STDIN - raw.length;
+      raw += chunk.substring(0, remaining);
+    }
+  });
+  process.stdin.on('error', () => {
+    writeAndExit(raw);
+  });
+  process.stdin.on('end', () => {
+    let output = raw;
+    try {
+      output = run(raw, { mode });
+    } catch {
+      output = raw;
+    }
+    writeAndExit(output);
+  });
+}
+
+module.exports = {
+  resolvePluginRoot,
+  run,
+};

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -16,7 +16,7 @@
     "ECC_HOOK_PROFILE": "strict",
     "ECC_DISABLED_HOOKS": "post:bash:command-log-audit,post:bash:command-log-cost,post:bash:build-complete",
     "ECC_QUALITY_GATE_FIX": "true",
-    "GATEGUARD_BASH_EXTRA_DESTRUCTIVE": "\\b(?:chezmoi\\s+(?:destroy|forget|purge)\\b|terraform\\s+(?:destroy|state\\s+rm|workspace\\s+delete|force-unlock)\\b|terraform\\s+apply\\s+(?:[^&|;]*\\s)?-{1,2}auto-approve\\b|kubectl\\s+delete\\b|helm\\s+(?:uninstall|delete)\\b|docker\\s+(?:system\\s+prune|volume\\s+(?:rm|prune)|image\\s+prune|container\\s+prune|network\\s+prune)\\b|docker\\s+(?:rm|rmi)\\s+(?:[^&|;]*\\s)?-[a-zA-Z]*f\\b|brew\\s+(?:uninstall|autoremove|untap)\\b|mas\\s+uninstall\\b|mise\\s+(?:uninstall|implode|prune)\\b|aqua\\s+(?:rm|prune)\\b|gh\\s+(?:repo\\s+delete|release\\s+delete|secret\\s+(?:delete|remove)|cache\\s+delete|run\\s+delete)\\b|aws\\s+s3\\s+r[mb]\\b|aws\\s+(?:ec2\\s+terminate-instances|iam\\s+delete-|dynamodb\\s+delete-table|rds\\s+delete-)|gcloud\\s+(?:\\S+\\s+){1,3}delete\\b|supabase\\s+db\\s+reset\\b|supabase\\s+projects\\s+delete\\b|pnpm\\s+(?:purge|store\\s+prune)\\b|npm\\s+(?:unpublish|publish)\\b|yarn\\s+(?:unpublish|publish)\\b|defaults\\s+delete\\b|git\\s+filter-(?:repo|branch)\\b)"
+    "GATEGUARD_BASH_EXTRA_DESTRUCTIVE": "\\b(?:chezmoi\\s+(?:destroy|forget|purge)\\b|terraform\\s+(?:destroy|state\\s+rm|workspace\\s+delete|force-unlock)\\b|terraform\\s+apply\\s+(?:[^&|;]*\\s)?-{1,2}auto-approve\\b|kubectl\\s+delete\\b|helm\\s+(?:uninstall|delete)\\b|docker\\s+(?:system\\s+prune|volume\\s+(?:rm|prune)|image\\s+prune|container\\s+prune|network\\s+prune)\\b|docker\\s+(?:rm|rmi)\\b(?=[^&|;]*\\s(?:--force\\b|-[a-zA-Z]*f\\b))|brew\\s+(?:uninstall|autoremove|untap)\\b|mas\\s+uninstall\\b|mise\\s+(?:uninstall|implode|prune)\\b|aqua\\s+(?:rm|prune)\\b|gh\\s+(?:repo\\s+delete|release\\s+delete|secret\\s+(?:delete|remove)|cache\\s+delete|run\\s+delete)\\b|aws\\s+s3\\s+r[mb]\\b|aws\\s+(?:ec2\\s+terminate-instances|iam\\s+delete-|dynamodb\\s+delete-table|rds\\s+delete-)|aws\\s+\\S+\\s+delete-|gcloud\\s+(?:\\S+\\s+){1,5}delete\\b|supabase\\s+db\\s+reset\\b|supabase\\s+projects\\s+delete\\b|pnpm\\s+(?:purge|store\\s+prune)\\b|npm\\s+(?:unpublish|publish)\\b|yarn\\s+(?:unpublish|publish)\\b|defaults\\s+delete\\b|git\\s+filter-(?:repo|branch)\\b)"
   },
   "permissions": {
     "allow": [
@@ -201,7 +201,7 @@
             "timeout": 15
           }
         ],
-        "description": "Bash safety dispatcher (Theme H, strict profile). Runs block-no-verify, auto-tmux-dev, tmux-reminder, git-push-reminder, commit-quality, and the destructive-command gateguard in sequence; each sub-hook self-gates on ECC_HOOK_PROFILE/ECC_DISABLED_HOOKS. The gateguard honours GATEGUARD_BASH_EXTRA_DESTRUCTIVE (task #12).",
+        "description": "Bash safety dispatcher (Theme H, strict profile). Runs block-no-verify, auto-tmux-dev, tmux-reminder, git-push-reminder, commit-quality, and pre:bash:gateguard-fact-force (which gates both the first non-read-only Bash per session and destructive commands) in sequence; each sub-hook self-gates on ECC_HOOK_PROFILE/ECC_DISABLED_HOOKS. The gateguard's destructive set honours GATEGUARD_BASH_EXTRA_DESTRUCTIVE (task #12).",
         "id": "pre:bash:dispatcher"
       },
       {
@@ -295,7 +295,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:edit:accumulate scripts/hooks/post-edit-accumulator.js standard,strict"
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:edit:accumulate scripts/hooks/post-edit-accumulator.js standard,strict",
+            "timeout": 10
           }
         ],
         "description": "Accumulate edited JS/TS file paths for the Stop-time batched format/typecheck (D2, feeds stop:format-typecheck)",
@@ -307,11 +308,10 @@
           {
             "type": "command",
             "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:quality-gate scripts/hooks/quality-gate.js standard,strict",
-            "async": true,
             "timeout": 30
           }
         ],
-        "description": "Per-edit quality gate: auto-format .json/.md/.go/.py via biome/prettier/gofmt/ruff (D3, ECC_QUALITY_GATE_FIX=true; advisory, non-blocking). JS/TS in Biome projects are handled by stop:format-typecheck instead.",
+        "description": "Per-edit quality gate: auto-format .json/.md/.go/.py via biome/prettier/gofmt/ruff (D3, ECC_QUALITY_GATE_FIX=true). Runs synchronously: FIX rewrites the file, so an async format would race a following read/edit of the same file. JS/TS in Biome projects are handled by stop:format-typecheck instead.",
         "id": "post:quality-gate"
       },
       {
@@ -331,7 +331,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:edit:console-warn scripts/hooks/post-edit-console-warn.js standard,strict"
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:edit:console-warn scripts/hooks/post-edit-console-warn.js standard,strict",
+            "timeout": 10
           }
         ],
         "description": "Warn (with line numbers) when an edited JS/TS file still contains console.log statements (D4)",
@@ -398,10 +399,11 @@
           {
             "type": "command",
             "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js stop:format-typecheck scripts/hooks/stop-format-typecheck.js standard,strict",
+            "async": true,
             "timeout": 300
           }
         ],
-        "description": "At Stop, batch-format (biome/prettier) and typecheck (tsc --noEmit) the JS/TS files edited this session (D1, fed by post:edit:accumulate). No-op when no JS/TS was edited or tooling is unavailable.",
+        "description": "At Stop, batch-format (biome/prettier) and typecheck (tsc --noEmit) the JS/TS files edited this session (D1, fed by post:edit:accumulate). Runs async (like the other Stop hooks) so tsc never blocks the response; no-op when no JS/TS was edited or tooling is unavailable.",
         "id": "stop:format-typecheck"
       },
       {
@@ -409,10 +411,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js stop:check-console-log scripts/hooks/check-console-log.js standard,strict"
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js stop:check-console-log scripts/hooks/check-console-log.js standard,strict",
+            "timeout": 15
           }
         ],
-        "description": "At Stop, aggregate console.log warnings across git-modified JS/TS files (excluding tests/scripts) (D5, pairs with post:edit:console-warn)",
+        "description": "At Stop, aggregate console.log warnings across git-modified JS/TS files (excluding tests/scripts) (D5, pairs with post:edit:console-warn). Sync (fast grep) so warnings surface.",
         "id": "stop:check-console-log"
       }
     ]

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -12,7 +12,11 @@
     "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "95",
     "MAX_THINKING_TOKENS": "127999",
-    "ECC_GOVERNANCE_CAPTURE": "1"
+    "ECC_GOVERNANCE_CAPTURE": "1",
+    "ECC_HOOK_PROFILE": "strict",
+    "ECC_DISABLED_HOOKS": "post:bash:command-log-audit,post:bash:command-log-cost,post:bash:build-complete",
+    "ECC_QUALITY_GATE_FIX": "true",
+    "GATEGUARD_BASH_EXTRA_DESTRUCTIVE": "\\b(?:chezmoi\\s+(?:destroy|forget|purge)\\b|terraform\\s+(?:destroy|state\\s+rm|workspace\\s+delete|force-unlock)\\b|terraform\\s+apply\\s+(?:[^&|;]*\\s)?-{1,2}auto-approve\\b|kubectl\\s+delete\\b|helm\\s+(?:uninstall|delete)\\b|docker\\s+(?:system\\s+prune|volume\\s+(?:rm|prune)|image\\s+prune|container\\s+prune|network\\s+prune)\\b|docker\\s+(?:rm|rmi)\\s+(?:[^&|;]*\\s)?-[a-zA-Z]*f\\b|brew\\s+(?:uninstall|autoremove|untap)\\b|mas\\s+uninstall\\b|mise\\s+(?:uninstall|implode|prune)\\b|aqua\\s+(?:rm|prune)\\b|gh\\s+(?:repo\\s+delete|release\\s+delete|secret\\s+(?:delete|remove)|cache\\s+delete|run\\s+delete)\\b|aws\\s+s3\\s+r[mb]\\b|aws\\s+(?:ec2\\s+terminate-instances|iam\\s+delete-|dynamodb\\s+delete-table|rds\\s+delete-)|gcloud\\s+(?:\\S+\\s+){1,3}delete\\b|supabase\\s+db\\s+reset\\b|supabase\\s+projects\\s+delete\\b|pnpm\\s+(?:purge|store\\s+prune)\\b|npm\\s+(?:unpublish|publish)\\b|yarn\\s+(?:unpublish|publish)\\b|defaults\\s+delete\\b|git\\s+filter-(?:repo|branch)\\b)"
   },
   "permissions": {
     "allow": [
@@ -189,6 +193,18 @@
         "id": "pre:governance-capture"
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/pre-bash-dispatcher.js",
+            "timeout": 15
+          }
+        ],
+        "description": "Bash safety dispatcher (Theme H, strict profile). Runs block-no-verify, auto-tmux-dev, tmux-reminder, git-push-reminder, commit-quality, and the destructive-command gateguard in sequence; each sub-hook self-gates on ECC_HOOK_PROFILE/ECC_DISABLED_HOOKS. The gateguard honours GATEGUARD_BASH_EXTRA_DESTRUCTIVE (task #12).",
+        "id": "pre:bash:dispatcher"
+      },
+      {
         "matcher": "mcp__.*",
         "hooks": [
           {
@@ -248,6 +264,78 @@
         ],
         "description": "Capture governance events from tool outputs to per-account state.db (pairs with pre:governance-capture)",
         "id": "post:governance-capture"
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/post-bash-dispatcher.js",
+            "async": true,
+            "timeout": 30
+          }
+        ],
+        "description": "Post-Bash dispatcher (Theme H). Runs pr-created detection; command-log-audit/cost and build-complete are disabled via ECC_DISABLED_HOOKS (audit is replaced by the account-aware fork below).",
+        "id": "post:bash:dispatcher"
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$HOME/.claude/hooks-fork/post-bash-command-log.js\" audit",
+            "timeout": 10
+          }
+        ],
+        "description": "Append each executed Bash command to a per-account bash-commands.log. Forked from ECC to resolve the log dir via getClaudeDir() (ECC_AGENT_DATA_HOME-aware) instead of a hardcoded ~/.claude, so cld and cld-r06 keep separate histories (task #11). Replaces the dispatcher's disabled command-log-audit sub-hook.",
+        "id": "post:bash:command-log-audit"
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:edit:accumulate scripts/hooks/post-edit-accumulator.js standard,strict"
+          }
+        ],
+        "description": "Accumulate edited JS/TS file paths for the Stop-time batched format/typecheck (D2, feeds stop:format-typecheck)",
+        "id": "post:edit:accumulate"
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:quality-gate scripts/hooks/quality-gate.js standard,strict",
+            "async": true,
+            "timeout": 30
+          }
+        ],
+        "description": "Per-edit quality gate: auto-format .json/.md/.go/.py via biome/prettier/gofmt/ruff (D3, ECC_QUALITY_GATE_FIX=true; advisory, non-blocking). JS/TS in Biome projects are handled by stop:format-typecheck instead.",
+        "id": "post:quality-gate"
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:edit:design-quality-check scripts/hooks/design-quality-check.js standard,strict",
+            "timeout": 10
+          }
+        ],
+        "description": "Per-edit frontend design-quality checklist warnings (D6)",
+        "id": "post:edit:design-quality-check"
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js post:edit:console-warn scripts/hooks/post-edit-console-warn.js standard,strict"
+          }
+        ],
+        "description": "Warn (with line numbers) when an edited JS/TS file still contains console.log statements (D4)",
+        "id": "post:edit:console-warn"
       }
     ],
     "PostToolUseFailure": [
@@ -303,6 +391,29 @@
         ],
         "description": "Send desktop notification (macOS/WSL) with task summary when Claude responds",
         "id": "stop:desktop-notify"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js stop:format-typecheck scripts/hooks/stop-format-typecheck.js standard,strict",
+            "timeout": 300
+          }
+        ],
+        "description": "At Stop, batch-format (biome/prettier) and typecheck (tsc --noEmit) the JS/TS files edited this session (D1, fed by post:edit:accumulate). No-op when no JS/TS was edited or tooling is unavailable.",
+        "id": "stop:format-typecheck"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js stop:check-console-log scripts/hooks/check-console-log.js standard,strict"
+          }
+        ],
+        "description": "At Stop, aggregate console.log warnings across git-modified JS/TS files (excluding tests/scripts) (D5, pairs with post:edit:console-warn)",
+        "id": "stop:check-console-log"
       }
     ]
   },

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -167,6 +167,45 @@ load helpers/setup
   [ "$count" -ge 1 ]
 }
 
+@test "ecc post-bash-command-log fork exists and passes node syntax check" {
+  local fork="${HOME_DIR}/dot_claude/hooks-fork/post-bash-command-log.js"
+  [ -f "$fork" ]
+  node --check "$fork"
+}
+
+# Regression guard: a bare process.exit() after stdout.write() truncates output
+# larger than the OS pipe buffer (~64 KB). The fork must pass the PostToolUse Bash
+# payload through byte-for-byte regardless of size. No ECC runtime needed (logging
+# is best-effort; the pass-through is unconditional).
+@test "ecc post-bash-command-log fork passes large input through without truncation" {
+  local fork="${HOME_DIR}/dot_claude/hooks-fork/post-bash-command-log.js"
+  local tmp; tmp=$(mktemp -d)
+  node -e 'process.stdout.write(JSON.stringify({hook_event_name:"PostToolUse",tool_name:"Bash",tool_input:{command:"echo "+"A".repeat(200000)}}))' > "$tmp/in.json"
+  local in_bytes out_bytes
+  in_bytes=$(wc -c < "$tmp/in.json")
+  out_bytes=$(ECC_AGENT_DATA_HOME="$tmp" node "$fork" audit < "$tmp/in.json" 2>/dev/null | wc -c)
+  rm -rf "$tmp"
+  [ "$in_bytes" -gt 65536 ]
+  [ "$in_bytes" -eq "$out_bytes" ]
+}
+
+# Functional smoke: with the ECC runtime present, the fork appends a sanitized line
+# to the per-account bash-commands.log resolved via getClaudeDir() (ECC_AGENT_DATA_HOME),
+# proving account isolation (task #11) — not the hardcoded ~/.claude of the ECC original.
+# Skips in minimal CI (no ECC external deployed).
+@test "ecc post-bash-command-log fork appends to per-account bash-commands.log" {
+  local fork="${HOME_DIR}/dot_claude/hooks-fork/post-bash-command-log.js"
+  local ecc="${HOME}/.agents/skills/ecc/scripts/hooks/post-bash-command-log.js"
+  [ -f "$ecc" ] || skip "ECC external runtime not deployed"
+  local tmp; tmp=$(mktemp -d)
+  printf '%s' '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"git push origin main"}}' \
+    | CLAUDE_PLUGIN_ROOT="${HOME}/.agents/skills/ecc" ECC_AGENT_DATA_HOME="$tmp" node "$fork" audit >/dev/null 2>&1
+  local ok=0
+  [ -f "$tmp/bash-commands.log" ] && grep -q 'git push origin main' "$tmp/bash-commands.log" && ok=1
+  rm -rf "$tmp"
+  [ "$ok" -eq 1 ]
+}
+
 @test "1password-backed secret template exists" {
   [ -f "${HOME_DIR}/private_dot_aws/config.tmpl" ]
 }

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -181,29 +181,43 @@ load helpers/setup
   local fork="${HOME_DIR}/dot_claude/hooks-fork/post-bash-command-log.js"
   local tmp; tmp=$(mktemp -d)
   node -e 'process.stdout.write(JSON.stringify({hook_event_name:"PostToolUse",tool_name:"Bash",tool_input:{command:"echo "+"A".repeat(200000)}}))' > "$tmp/in.json"
-  local in_bytes out_bytes
-  in_bytes=$(wc -c < "$tmp/in.json")
-  out_bytes=$(ECC_AGENT_DATA_HOME="$tmp" node "$fork" audit < "$tmp/in.json" 2>/dev/null | wc -c)
+  ECC_AGENT_DATA_HOME="$tmp" node "$fork" audit < "$tmp/in.json" > "$tmp/out.json" 2>/dev/null
+  local in_bytes; in_bytes=$(wc -c < "$tmp/in.json")
+  # Byte-exact pass-through: input exceeds the OS pipe buffer AND output is identical
+  # (cmp catches reordering/corruption that an equal byte count would miss).
+  run cmp "$tmp/in.json" "$tmp/out.json"
+  local cmp_status=$status
   rm -rf "$tmp"
   [ "$in_bytes" -gt 65536 ]
-  [ "$in_bytes" -eq "$out_bytes" ]
+  [ "$cmp_status" -eq 0 ]
 }
 
-# Functional smoke: with the ECC runtime present, the fork appends a sanitized line
-# to the per-account bash-commands.log resolved via getClaudeDir() (ECC_AGENT_DATA_HOME),
-# proving account isolation (task #11) — not the hardcoded ~/.claude of the ECC original.
+# Functional smoke: with the ECC runtime present, the fork appends a sanitized, 0600
+# line to the per-account bash-commands.log resolved via getClaudeDir()
+# (ECC_AGENT_DATA_HOME), proving account isolation (task #11) — not the hardcoded
+# ~/.claude of the ECC original — and that extraRedact() strips a secret ECC's own
+# sanitizer misses. Assertions are split so a failure pinpoints which guarantee broke.
 # Skips in minimal CI (no ECC external deployed).
-@test "ecc post-bash-command-log fork appends to per-account bash-commands.log" {
+@test "ecc post-bash-command-log fork appends a redacted 0600 line to the per-account log" {
   local fork="${HOME_DIR}/dot_claude/hooks-fork/post-bash-command-log.js"
   local ecc="${HOME}/.agents/skills/ecc/scripts/hooks/post-bash-command-log.js"
   [ -f "$ecc" ] || skip "ECC external runtime not deployed"
   local tmp; tmp=$(mktemp -d)
-  printf '%s' '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"git push origin main"}}' \
+  local log="$tmp/bash-commands.log"
+  # AWS_SECRET_ACCESS_KEY=... is a secret shape ECC's sanitizeCommand does not catch;
+  # extraRedact() must strip it before the line is written.
+  printf '%s' '{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"AWS_SECRET_ACCESS_KEY=abcdEFGH1234 aws s3 ls"}}' \
     | CLAUDE_PLUGIN_ROOT="${HOME}/.agents/skills/ecc" ECC_AGENT_DATA_HOME="$tmp" node "$fork" audit >/dev/null 2>&1
-  local ok=0
-  [ -f "$tmp/bash-commands.log" ] && grep -q 'git push origin main' "$tmp/bash-commands.log" && ok=1
+  local file_exists=0 has_cmd=0 secret_leaked=0 perms=""
+  [ -f "$log" ] && file_exists=1
+  grep -q 'aws s3 ls' "$log" 2>/dev/null && has_cmd=1
+  grep -q 'abcdEFGH1234' "$log" 2>/dev/null && secret_leaked=1
+  perms=$(stat -f '%Lp' "$log" 2>/dev/null || stat -c '%a' "$log" 2>/dev/null)
   rm -rf "$tmp"
-  [ "$ok" -eq 1 ]
+  [ "$file_exists" -eq 1 ]   # account-aware log created under ECC_AGENT_DATA_HOME
+  [ "$has_cmd" -eq 1 ]       # command recorded
+  [ "$secret_leaked" -eq 0 ] # extraRedact stripped the secret env value
+  [ "$perms" = "600" ]       # owner-only permissions
 }
 
 @test "1password-backed secret template exists" {


### PR DESCRIPTION
## Summary

PR5 of the Phase 6 stack (Claude Code enhancement). Wires the **ECC Bash safety dispatcher** (Theme H, strict profile) and the **Theme D code-quality gates**, plus a chezmoi-managed **fork of `post-bash-command-log`** for per-account audit logging. This is the heaviest PR in the stack (largest perf footprint), so the dispatcher pattern and `async` flags are used deliberately to bound added latency.

Tasks: Theme H, Theme D (D1–D6), **#11** (account-aware command-log fork), **#12** (`GATEGUARD_BASH_EXTRA_DESTRUCTIVE` regex).

## What this wires

### Theme H — Bash dispatcher (strict)
- **`pre:bash:dispatcher`** (PreToolUse `Bash`, sync): runs 6 sub-hooks in one node process — `block-no-verify`, `auto-tmux-dev`, `tmux-reminder`, `git-push-reminder`, `commit-quality`, and the destructive-command **gateguard**. The gateguard denies destructive commands via `permissionDecision: deny` and gates the first non-read-only Bash per session (read-only git introspection is exempt).
- **`post:bash:dispatcher`** (PostToolUse `Bash`, async): `pr-created` only. `command-log-audit`, `command-log-cost`, and `build-complete` are disabled via `ECC_DISABLED_HOOKS`.

### #11 — account-aware command-log fork
- 🆕 `home/dot_claude/hooks-fork/post-bash-command-log.js`: ECC's original hardcodes `os.homedir()/.claude/bash-commands.log`, which collides across the `cld`/`cld-r06` accounts. The fork resolves the log dir via ECC's own `getClaudeDir()` (honours `ECC_AGENT_DATA_HOME`) and reuses ECC's `sanitizeCommand` + `getClaudeDir` by `require()` from the pinned external (no copy → stays in sync). Wired as a standalone `node` entry because `run-with-flags.js` rejects scripts outside the plugin root (same constraint as the PR4 governance fork). Replaces the dispatcher's disabled `command-log-audit` sub-hook.

### #12 — destructive-command gateguard regex
- `GATEGUARD_BASH_EXTRA_DESTRUCTIVE`: the S11 regex (96 cases, 0 FP / 0 FN) covering chezmoi/terraform/kubectl/helm/docker/brew/mise/aqua/gh/aws/gcloud/supabase/npm publish/git filter-repo destroy-class commands. Consumed by gateguard via `new RegExp(raw, 'i')`. JSON-escaped form generated mechanically to avoid hand-escaping errors.

### Theme D — code-quality gates
- `post:edit:accumulate` (D2), `post:quality-gate` (D3, `ECC_QUALITY_GATE_FIX=true`, async), `post:edit:design-quality-check` (D6), `post:edit:console-warn` (D4), `stop:format-typecheck` (D1), `stop:check-console-log` (D5). Advisory (non-blocking); D1 no-ops when no JS/TS was edited.

### env additions
`ECC_HOOK_PROFILE=strict` / `ECC_DISABLED_HOOKS=post:bash:command-log-audit,post:bash:command-log-cost,post:bash:build-complete` / `ECC_QUALITY_GATE_FIX=true` / `GATEGUARD_BASH_EXTRA_DESTRUCTIVE=<regex>`.

## Design decisions (grill-me)
- **Single PR** (Theme H + D + #11 + #12): all homogeneous hook wiring.
- **#11 wiring**: separate fork entry + disable the dispatcher's `command-log-audit` (vs forking the whole dispatcher) — minimal maintenance surface.
- **strict profile**: full Theme H (incl. tmux/push/commit reminders).
- **#12 regex**: full S11 regex (FP watch over 1 week of runtime).
- **auto-tmux-dev**: kept (dev-server → detached tmux).
- **routine-bash gate**: kept (first-bash-per-session intent gate; destructive gate is independent).

## Verification (local)
- `make lint` ✅, `make test` ✅ (58 bats tests; +3 for the command-log fork).
- `chezmoi diff` clean; rendered `settings.json` is valid JSON; rendered fork passes `node --check`.
- Sandbox functional checks: `pre:bash:dispatcher` denies `chezmoi destroy` / `terraform destroy -auto-approve` (and **does not** without the EXTRA regex, proving it is the catch source); benign commands hit only the routine gate; fork writes a sanitized line to `$ECC_AGENT_DATA_HOME/bash-commands.log` (token redacted); 200 KB pass-through is byte-exact (truncation guard); all post/stop hooks exit 0.
- perf: `pre:bash:dispatcher` ~53 ms (6 sub-hooks in one node start), fork ~49 ms, D hooks ~47 ms each; heaviest (`D3`, `post:bash:dispatcher`) are async (non-additive). Details in `perf-log.md`.

## User runtime checklist (after `chezmoi apply`)
- [ ] Destructive command (e.g. `chezmoi destroy`, `terraform destroy`) is denied with the fact-forcing prompt; benign retry after stating facts proceeds.
- [ ] First non-read-only Bash of a session prompts for intent once; `git status`/`git log` do not.
- [ ] `bash-commands.log` is written under the active account (`~/.claude` vs `~/.claude-r06`) with secrets redacted.
- [ ] `npm run dev` (etc.) is redirected into a detached tmux session.
- [ ] Editing a `.json`/`.md`/`.go`/`.py` file auto-formats it; a JS/TS file with `console.log` warns; Stop runs batched format/typecheck on edited JS/TS.
- [ ] No perceptible blocking from the async hooks; watch the destructive regex for false positives over ~1 week.

## Test plan
- [x] `make lint`
- [x] `make test` (58 bats)
- [x] `chezmoi diff` clean + render validation
- [x] sandbox functional + perf
- [ ] user `chezmoi apply` + runtime checklist
