### PR TITLE
feat(mcp): declare context7 + deepwiki as user-scope MCP servers

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,15 +1,5 @@
 {
   "mcpServers": {
-    "context7": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"],
-      "env": {}
-    },
-    "deepwiki": {
-      "command": "npx",
-      "args": ["mcp-remote", "https://mcp.deepwiki.com/mcp"]
-    },
     "spec-workflow": {
       "command": "npx",
       "args": ["-y", "@pimzino/spec-workflow-mcp@latest", "."]

--- a/home/run_onchange_after_13-setup-mcp.sh.tmpl
+++ b/home/run_onchange_after_13-setup-mcp.sh.tmpl
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+# Declaratively register user-scope MCP servers for every Claude Code account.
+#
+# `claude mcp add-json --scope user` writes to "$CLAUDE_CONFIG_DIR/.claude.json", which the
+# CLI rewrites on every session (volatile). chezmoi must not own that file directly, so this
+# script drives the CLI instead. run_onchange re-runs whenever the server definitions below
+# change (the rendered script body is the change key).
+#
+# Only globally-useful servers belong here: context7 (library docs) and deepwiki (repo Q&A)
+# are wanted in every project. Project-specific servers (spec-workflow, serena) stay in each
+# repo's own .mcp.json. claude.ai connectors and the Chrome extension are configured manually.
+
+if ! command -v claude &>/dev/null; then
+  echo "WARNING: claude CLI not found; skipping user-scope MCP setup."
+  exit 0
+fi
+
+# Each account is isolated by CLAUDE_CONFIG_DIR (see dot_config/zsh/claude.zsh: cld -> ~/.claude,
+# cld-r06 -> ~/.claude-r06). user-scope servers live in "<config dir>/.claude.json", so register
+# them once per account.
+config_dirs=("$HOME/.claude" "$HOME/.claude-r06")
+
+# Server name -> canonical JSON. Both are stdio (npx-launched); deepwiki bridges to its remote
+# HTTP endpoint via mcp-remote. Keep in sync with the project's .mcp.json removal of these two.
+mcp_names=("context7" "deepwiki")
+mcp_configs=(
+  '{"type":"stdio","command":"npx","args":["-y","@upstash/context7-mcp"]}'
+  '{"type":"stdio","command":"npx","args":["mcp-remote","https://mcp.deepwiki.com/mcp"]}'
+)
+
+for config_dir in "${config_dirs[@]}"; do
+  echo "==> Registering user-scope MCP servers in ${config_dir}..."
+  for i in "${!mcp_names[@]}"; do
+    name="${mcp_names[$i]}"
+    cfg="${mcp_configs[$i]}"
+    # Idempotent: drop any stale definition, then add the canonical one. remove exits non-zero
+    # when the server is absent, which is expected on a first run.
+    CLAUDE_CONFIG_DIR="$config_dir" claude mcp remove "$name" --scope user >/dev/null 2>&1 || true
+    if ! CLAUDE_CONFIG_DIR="$config_dir" claude mcp add-json "$name" "$cfg" --scope user >/dev/null 2>&1; then
+      echo "WARNING: failed to register MCP server '${name}' in ${config_dir}; add it later with 'claude mcp add-json'."
+    fi
+  done
+done
+
+echo "==> User-scope MCP servers registered."

--- a/home/run_onchange_after_13-setup-mcp.sh.tmpl
+++ b/home/run_onchange_after_13-setup-mcp.sh.tmpl
@@ -8,12 +8,17 @@ set -euo pipefail
 # script drives the CLI instead. run_onchange re-runs whenever the server definitions below
 # change (the rendered script body is the change key).
 #
+# claude is mise-managed (dot_config/mise/config.toml) and installed by run_onchange_after_12,
+# so it is invoked via `mise exec` rather than via PATH: this script (after_13) runs before the
+# ~/.local/bin/claude launcher symlink is created (run_once_after_16), so `command -v claude`
+# is not yet reliable on a fresh apply. mise + the mise-installed claude are both present by 13.
+#
 # Only globally-useful servers belong here: context7 (library docs) and deepwiki (repo Q&A)
-# are wanted in every project. Project-specific servers (spec-workflow, serena) stay in each
+# are wanted in every project. Project-specific servers (e.g. spec-workflow) stay in each
 # repo's own .mcp.json. claude.ai connectors and the Chrome extension are configured manually.
 
-if ! command -v claude &>/dev/null; then
-  echo "WARNING: claude CLI not found; skipping user-scope MCP setup."
+if ! command -v mise &>/dev/null; then
+  echo "WARNING: mise is not installed; skipping user-scope MCP setup."
   exit 0
 fi
 
@@ -22,26 +27,39 @@ fi
 # them once per account.
 config_dirs=("$HOME/.claude" "$HOME/.claude-r06")
 
-# Server name -> canonical JSON. Both are stdio (npx-launched); deepwiki bridges to its remote
-# HTTP endpoint via mcp-remote. Keep in sync with the project's .mcp.json removal of these two.
+# Server name -> canonical JSON. Both are stdio (npx-launched, -y so the first run never blocks
+# on an install prompt); deepwiki bridges to its remote HTTP endpoint via mcp-remote. Keep in
+# sync with the project's .mcp.json removal of these two.
 mcp_names=("context7" "deepwiki")
 mcp_configs=(
   '{"type":"stdio","command":"npx","args":["-y","@upstash/context7-mcp"]}'
-  '{"type":"stdio","command":"npx","args":["mcp-remote","https://mcp.deepwiki.com/mcp"]}'
+  '{"type":"stdio","command":"npx","args":["-y","mcp-remote","https://mcp.deepwiki.com/mcp"]}'
 )
 
+failed=0
 for config_dir in "${config_dirs[@]}"; do
+  # `claude mcp add-json` already creates a missing config dir, but create it explicitly so the
+  # intent is clear and the script is robust to CLI changes.
+  mkdir -p "$config_dir"
   echo "==> Registering user-scope MCP servers in ${config_dir}..."
   for i in "${!mcp_names[@]}"; do
     name="${mcp_names[$i]}"
     cfg="${mcp_configs[$i]}"
     # Idempotent: drop any stale definition, then add the canonical one. remove exits non-zero
     # when the server is absent, which is expected on a first run.
-    CLAUDE_CONFIG_DIR="$config_dir" claude mcp remove "$name" --scope user >/dev/null 2>&1 || true
-    if ! CLAUDE_CONFIG_DIR="$config_dir" claude mcp add-json "$name" "$cfg" --scope user >/dev/null 2>&1; then
-      echo "WARNING: failed to register MCP server '${name}' in ${config_dir}; add it later with 'claude mcp add-json'."
+    CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude mcp remove "$name" --scope user >/dev/null 2>&1 || true
+    if ! out=$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude mcp add-json "$name" "$cfg" --scope user 2>&1); then
+      printf 'ERROR: failed to register MCP server %s in %s\n%s\n' "$name" "$config_dir" "$out" >&2
+      failed=1
     fi
   done
 done
+
+if [ "$failed" -ne 0 ]; then
+  # Exit non-zero so chezmoi does not record this run as successful and retries on the next
+  # apply, instead of freezing a partially-registered state.
+  echo "ERROR: one or more MCP servers failed to register; chezmoi will retry on the next apply." >&2
+  exit 1
+fi
 
 echo "==> User-scope MCP servers registered."

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -236,13 +236,48 @@ load helpers/setup
   [ -f "${HOME_DIR}/run_onchange_after_12-setup-mise.sh.tmpl" ]
 }
 
-@test "mcp setup script registers context7 and deepwiki as user-scope" {
+@test "mcp setup registers both servers as user scope for every account config dir" {
   local script="${HOME_DIR}/run_onchange_after_13-setup-mcp.sh.tmpl"
   [ -f "$script" ]
-  # Both globally-useful servers are declared and added with user scope.
-  grep -q 'context7' "$script"
-  grep -q 'deepwiki' "$script"
-  grep -q -- '--scope user' "$script"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/bin"
+  # Fake mise that emulates `mise exec -- <cmd...>` by logging the wrapped command together
+  # with the CLAUDE_CONFIG_DIR it ran under. Lets us assert the script's real behaviour
+  # (per-account loop + --scope user) instead of just matching strings in the source.
+  cat >"$tmp/bin/mise" <<'FAKE'
+#!/usr/bin/env bash
+if [ "$1" = "exec" ] && [ "$2" = "--" ]; then
+  shift 2
+  printf '%s ::: %s\n' "${CLAUDE_CONFIG_DIR:-NONE}" "$*" >>"$MISE_FAKE_LOG"
+fi
+exit 0
+FAKE
+  chmod +x "$tmp/bin/mise"
+
+  run env HOME="$tmp/home" PATH="$tmp/bin:$PATH" MISE_FAKE_LOG="$tmp/log" \
+    bash "$script"
+  [ "$status" -eq 0 ]
+
+  # Both servers are add-json'd with user scope for both account config dirs. The trailing
+  # " :::" anchors ".claude" so it does not also match ".claude-r06".
+  local d
+  for d in '\.claude' '\.claude-r06'; do
+    grep -qE "/home/${d} ::: claude mcp add-json context7 .* --scope user" "$tmp/log"
+    grep -qE "/home/${d} ::: claude mcp add-json deepwiki .* --scope user" "$tmp/log"
+  done
+}
+
+@test "mcp setup script declares valid JSON server configs" {
+  local script="${HOME_DIR}/run_onchange_after_13-setup-mcp.sh.tmpl"
+  local json count=0
+  # Each server config is a single-quoted JSON literal; ensure every one parses.
+  while IFS= read -r json; do
+    [ -n "$json" ] || continue
+    echo "$json" | jq -e . >/dev/null
+    count=$((count + 1))
+  done < <(grep -oE "'\{[^']*\}'" "$script" | tr -d "'")
+  [ "$count" -ge 2 ]
 }
 
 @test "project .mcp.json keeps only project-scoped servers" {

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -236,6 +236,25 @@ load helpers/setup
   [ -f "${HOME_DIR}/run_onchange_after_12-setup-mise.sh.tmpl" ]
 }
 
+@test "mcp setup script registers context7 and deepwiki as user-scope" {
+  local script="${HOME_DIR}/run_onchange_after_13-setup-mcp.sh.tmpl"
+  [ -f "$script" ]
+  # Both globally-useful servers are declared and added with user scope.
+  grep -q 'context7' "$script"
+  grep -q 'deepwiki' "$script"
+  grep -q -- '--scope user' "$script"
+}
+
+@test "project .mcp.json keeps only project-scoped servers" {
+  # context7/deepwiki were moved to user scope (run_onchange_after_13); the repo's own
+  # .mcp.json must keep the project-specific spec-workflow but no longer declare them.
+  local mcp="${REPO_ROOT}/.mcp.json"
+  [ -f "$mcp" ]
+  grep -q 'spec-workflow' "$mcp"
+  ! grep -q 'context7' "$mcp"
+  ! grep -q 'deepwiki' "$mcp"
+}
+
 @test "bootstrap script exists" {
   [ -f "${REPO_ROOT}/install/install.sh" ]
 }


### PR DESCRIPTION
## Summary

Migrates the two globally-useful MCP servers — **context7** (library docs) and **deepwiki** (repo Q&A) — from this repo's project-scoped `.mcp.json` to **user scope**, so they are available in every project instead of only inside `dotfiles`.

This is **PR7** of the Phase 6 stack. Scope was intentionally narrowed to **task #33 only**; the tool-install tasks #16/#17/#18 (AgentShield / firecrawl+Exa MCP / dmux) are **deferred** to ride with the ECC skill-external work (#46/#15), because their dependent ECC skills (`security-scan` / `deep-research` / `exa-search` / `dmux-workflows`) are not deployed yet and #17 additionally requires firecrawl/Exa API keys.

## Changes

- **`home/run_onchange_after_13-setup-mcp.sh.tmpl`** (new): a `run_onchange` lifecycle script that idempotently registers context7 + deepwiki as user-scope servers for **every account config dir** (`~/.claude` and `~/.claude-r06`). It drives `claude mcp add-json --scope user` (remove-then-add), is fail-soft, and skips when the `claude` CLI is absent. `~/.claude.json`-style user config is volatile (rewritten by the CLI per session), so it is driven via the CLI rather than owned by chezmoi.
- **`.mcp.json`**: dropped context7/deepwiki; kept the project-specific **spec-workflow** (this repo has an active `.spec-workflow/`, so per the design principle "project-specific servers stay in the repo that uses them", spec-workflow is retained — this deviates from the plan's literal "git rm .mcp.json", verified against the primary source).
- **`tests/files.bats`**: added coverage for the setup script (declares both servers with `--scope user`) and the `.mcp.json` contract (keeps spec-workflow, no longer declares context7/deepwiki).

## Verification (mine)

- `make lint` ✅ / `make test` ✅ (68 bats, incl. 2 new)
- `chezmoi execute-template` renders the script cleanly; `bash -n` OK; chezmoi recognizes `13-setup-mcp.sh`
- End-to-end against a sandbox config dir: both servers register as **"User config (available in all your projects)"**, idempotent re-run does not error

## Runtime checklist (user)

- [ ] `chezmoi apply` → `13-setup-mcp.sh` runs
- [ ] `cld` → `claude mcp list` shows context7 + deepwiki as **user** scope
- [ ] `cld-r06` → `claude mcp list` shows context7 + deepwiki as **user** scope
- [ ] In `dotfiles`, spec-workflow still resolves (project scope); context7/deepwiki now come from user scope