### PR TITLE
feat(cli): add happy (slopus/happy) with multi-account wrappers

### DIFF
--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -40,6 +40,10 @@ zoxide = "0.9.9"
 # (electron/slack/dogfood/...) via `agent-browser skills get`, so they are loaded at
 # runtime instead of being vendored; only the discovery stub is chezmoi-managed.
 "npm:agent-browser" = "0.29.1"
+# happy (slopus/happy): a wrapper that runs Claude Code / Codex with phone control and
+# end-to-end encryption (`happy claude` / `happy codex`). CLI only; the mobile/web apps
+# are installed separately and paired at runtime.
+"npm:happy" = "1.1.10"
 
 [settings]
 # Pin precompiled CPython to a flavor that ships lib/; latest mise otherwise

--- a/home/dot_config/zsh/claude.zsh
+++ b/home/dot_config/zsh/claude.zsh
@@ -1,6 +1,8 @@
 # Claude Code account isolation.
 # Each account gets its own config dir plus ECC/CLV2/gateguard state dirs, so cld and
 # cld-r06 never share sessions, governance state.db, instincts, or hook caches.
+# The command to run is passed after the home dir ("claude ..." or "happy claude ..."),
+# so the happy wrapper inherits the exact same per-account environment.
 _claude_with_home() {
   local home_dir="$1"
   shift
@@ -9,17 +11,24 @@ _claude_with_home() {
     CLV2_HOMUNCULUS_DIR="$home_dir/ecc-homunculus" \
     ECC_MCP_HEALTH_STATE_PATH="$home_dir/mcp-health-cache.json" \
     GATEGUARD_STATE_DIR="$home_dir/.gateguard" \
-    claude "$@"
+    "$@"
 }
-alias cld='_claude_with_home "$HOME/.claude"'
-alias cld-r06='_claude_with_home "$HOME/.claude-r06"'
+alias cld='_claude_with_home "$HOME/.claude" claude'
+alias cld-r06='_claude_with_home "$HOME/.claude-r06" claude'
+
+# happy (slopus/happy) variants: run Claude Code through the happy wrapper for phone
+# control, keeping the same per-account isolation. happy spawns claude inheriting this
+# env (so CLAUDE_CONFIG_DIR etc. still pick the account); happy's own state (~/.happy,
+# i.e. HAPPY_HOME_DIR default) is intentionally shared across accounts (one pairing).
+alias hcld='_claude_with_home "$HOME/.claude" happy claude'
+alias hcld-r06='_claude_with_home "$HOME/.claude-r06" happy claude'
 
 # Dedicated session for intentional config edits on the DEFAULT account (~/.claude): routes
 # through _claude_with_home (so ECC state stays isolated to ~/.claude) and disables the ECC
 # config-protection / gateguard-fact-force gates so Claude can edit settings.json / biome.json /
 # eslint.config.* etc. For the r06 account, prefix the same var to cld-r06:
 #   ECC_DISABLED_HOOKS=pre:config-protection,pre:edit-write:gateguard-fact-force cld-r06
-alias claude-config='ECC_DISABLED_HOOKS=pre:config-protection,pre:edit-write:gateguard-fact-force _claude_with_home "$HOME/.claude"'
+alias claude-config='ECC_DISABLED_HOOKS=pre:config-protection,pre:edit-write:gateguard-fact-force _claude_with_home "$HOME/.claude" claude'
 
 alias ccdcmds='ccdcommands'
 

--- a/home/dot_config/zsh/claude.zsh
+++ b/home/dot_config/zsh/claude.zsh
@@ -6,6 +6,9 @@
 _claude_with_home() {
   local home_dir="$1"
   shift
+  # Default to plain `claude` when no command is given, so a direct call still launches
+  # Claude Code (the aliases always pass an explicit command).
+  (($#)) || set -- claude
   CLAUDE_CONFIG_DIR="$home_dir" \
     ECC_AGENT_DATA_HOME="$home_dir" \
     CLV2_HOMUNCULUS_DIR="$home_dir/ecc-homunculus" \

--- a/home/dot_config/zsh/codex.zsh
+++ b/home/dot_config/zsh/codex.zsh
@@ -9,3 +9,10 @@
 #       Always use `cdx` / `cdx-r06` to pick an account with the SSOT config.
 alias cdx='codex --profile shared'
 alias cdx-r06='CODEX_HOME=$HOME/.codex-r06 codex --profile shared'
+
+# happy (slopus/happy) variants: run Codex through the happy wrapper for phone control.
+# `happy codex` forwards `--profile shared` to codex and respects CODEX_HOME, so each
+# account keeps its SSOT config and isolation; happy's own state (~/.happy) is shared
+# across accounts (one pairing controls every account).
+alias hcdx='happy codex --profile shared'
+alias hcdx-r06='CODEX_HOME=$HOME/.codex-r06 happy codex --profile shared'

--- a/tests/zsh_aliases.bats
+++ b/tests/zsh_aliases.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load helpers/setup
+
+# Behavioral regression guard for the happy (slopus/happy) multi-account wrappers and the
+# _claude_with_home refactor: the helper now runs whatever command is passed after the
+# account home dir ("claude ..." or "happy claude ..."), so the happy wrapper inherits the
+# exact same per-account environment. zsh_syntax.bats only covers `zsh -n` (syntax).
+#
+# Aliases defined in a sourced file are NOT expanded for commands in the same parse unit,
+# so these tests drive the underlying function directly and query alias definitions with
+# the `alias` builtin instead of relying on alias expansion. `zsh -f` skips rc files.
+
+@test "claude.zsh: _claude_with_home sets the account env and runs the given command" {
+  run zsh -fc "
+    source '${HOME_DIR}/dot_config/zsh/claude.zsh'
+    happy() { print -r -- \"happy|\$CLAUDE_CONFIG_DIR|\$ECC_AGENT_DATA_HOME|\$GATEGUARD_STATE_DIR|\$*\"; }
+    _claude_with_home \"\$HOME/.claude-r06\" happy claude --resume
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "happy|$HOME/.claude-r06|$HOME/.claude-r06|$HOME/.claude-r06/.gateguard|claude --resume" ]
+}
+
+@test "claude.zsh: _claude_with_home defaults to claude when no command is given" {
+  run zsh -fc "
+    source '${HOME_DIR}/dot_config/zsh/claude.zsh'
+    claude() { print -r -- \"claude|\$CLAUDE_CONFIG_DIR|\$*\"; }
+    _claude_with_home \"\$HOME/.claude\"
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "claude|$HOME/.claude|" ]
+}
+
+@test "claude.zsh: hcld/hcld-r06 wrap claude in happy per account" {
+  run zsh -fc "source '${HOME_DIR}/dot_config/zsh/claude.zsh'; alias hcld hcld-r06"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"happy claude"* ]]
+  [[ "$output" == *".claude-r06"* ]]
+}
+
+@test "codex.zsh: hcdx/hcdx-r06 wrap codex in happy with the work CODEX_HOME" {
+  run zsh -fc "source '${HOME_DIR}/dot_config/zsh/codex.zsh'; alias hcdx hcdx-r06"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"happy codex --profile shared"* ]]
+  [[ "$output" == *"CODEX_HOME=\$HOME/.codex-r06"* ]]
+}


### PR DESCRIPTION
## Summary

Installs [happy](https://github.com/slopus/happy) — a wrapper that runs Claude Code / Codex with phone control and end-to-end encryption (`happy claude` / `happy codex`) — and wires it for **all four accounts** (`cld` / `cld-r06` / `cdx` / `cdx-r06`).

## Changes

- **`mise/config.toml`**: add `"npm:happy" = "1.1.10"` (mise npm backend, same pattern as `agent-browser`). `run_onchange_after_12-setup-mise` installs it on apply.
- **`claude.zsh`**: parametrize `_claude_with_home` on the command it runs (was hardcoded to `claude`), so the happy wrapper inherits the **exact same per-account env** (CLAUDE_CONFIG_DIR + ECC/CLV2/gateguard state dirs). `cld` / `cld-r06` / `claude-config` keep their behavior; add `hcld` / `hcld-r06` (= `happy claude` per account).
- **`codex.zsh`**: add `hcdx` / `hcdx-r06` (= `happy codex --profile shared`, with `CODEX_HOME` for the work account).

## Design decision

happy's **own** state (`~/.happy`, `HAPPY_HOME_DIR` default) is **shared** across accounts — one phone pairing controls every account, and all sessions are visible in one app. The wrapped agent stays account-isolated via `CLAUDE_CONFIG_DIR` / `CODEX_HOME`, which happy inherits (verified: `codexAppServerClient` builds the child env from `process.env`; `codexSkills` honours `CODEX_HOME`) and forwards (`--profile shared` reaches codex; extra args reach claude/codex).

## Verification (mine)

- `make lint` ✅ · TOML parse ✅ · `happy --help` via mise confirms `happy claude` / `happy codex` passthrough ("happy supports ALL Claude options")
- Functional (fake claude/happy): `cld`/`hcld` → personal env, `hcld-r06` → `~/.claude-r06`, `hcdx` → personal codex, `hcdx-r06` → `CODEX_HOME=~/.codex-r06`; `--profile shared` and extra args forwarded
- `mise install npm:happy@1.1.10` succeeds; binary present

## Runtime checklist (user)

- [ ] `chezmoi apply` → `mise install` pulls happy 1.1.10
- [ ] `happy auth login` (one pairing) → phone app paired
- [ ] `hcld` / `hcld-r06` start Claude Code (correct account) under happy
- [ ] `hcdx` / `hcdx-r06` start Codex (correct account, `--profile shared`) under happy
- [ ] `cld` / `cld-r06` still behave as before (refactor is behavior-preserving)