### PR TITLE
feat(hooks): cross-harness Codex gateguard sharing the task #12 destructive set

### DIFF
--- a/home/.chezmoitemplates/codex-hooks.json
+++ b/home/.chezmoitemplates/codex-hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"{{ .chezmoi.homeDir }}/.config/gateguard/codex-bash-gate.js\"",
+            "statusMessage": "Checking Bash command against cross-harness gateguard",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/home/dot_codex-r06/hooks.json.tmpl
+++ b/home/dot_codex-r06/hooks.json.tmpl
@@ -1,0 +1,1 @@
+{{ includeTemplate "codex-hooks.json" . }}

--- a/home/dot_codex/hooks.json.tmpl
+++ b/home/dot_codex/hooks.json.tmpl
@@ -1,0 +1,1 @@
+{{ includeTemplate "codex-hooks.json" . }}

--- a/home/dot_config/gateguard/executable_codex-bash-gate.js
+++ b/home/dot_config/gateguard/executable_codex-bash-gate.js
@@ -8,8 +8,10 @@
  * `matcher = "^Bash$"`. It receives the tool-call JSON on stdin, inspects
  * the Bash command, and DENIES execution when the command matches a
  * destructive pattern. Denial uses the documented JSON form
- * (`hookSpecificOutput.permissionDecision = "deny"`); any other outcome
- * leaves the decision unset so Codex falls back to its normal flow.
+ * (`hookSpecificOutput.permissionDecision = "deny"` + a non-empty
+ * `permissionDecisionReason`, both required by Codex's wire schema); any
+ * other outcome leaves the decision unset so Codex falls back to its
+ * normal flow.
  *
  * SSOT relationship with Claude (task #12):
  *   - Claude's authoritative gate is the ECC `gateguard-fact-force.js`
@@ -21,26 +23,44 @@
  *     gracefully (fail-open) when settings.json cannot be read, mirroring
  *     ECC's "a hook must never crash tool execution" philosophy.
  *
- * This Codex gate is intentionally a complementary best-effort layer
- * (Codex also has sandbox + approval). It does not aim for byte-for-byte
- * parity with ECC's token parser; it ports the high-value built-ins
- * (rm -rf / destructive git / SQL drop+truncate / dd) and shares the
- * operator EXTRA regex.
+ * This Codex gate is a complementary best-effort layer (Codex also has a
+ * sandbox + approval flow). It does not aim for byte-for-byte parity with
+ * ECC's token parser, but it hardens the common evasion vectors an LLM
+ * may emit: command substitution (even inside double quotes), `sh -c`
+ * bodies, subshell `()` / brace `{}` / process-substitution groups, and
+ * `env`/`command`/`exec`/`sudo` wrappers.
+ *
+ * Known best-effort limits (deferred to Codex's sandbox/approval):
+ *   - base64/hex-encoded payloads decoded at runtime;
+ *   - deeply nested wrapper option parsing (e.g. `sudo -u u … cmd`);
+ *   - per-account `settings.json` divergence — the EXTRA set is read from
+ *     ~/.claude first (it is account-independent today, task #12).
  */
 
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-// --- SQL / dd patterns: stable phrases, applied to the de-quoted line. ---
-const DESTRUCTIVE_SQL_DD = /\b(drop\s+table|delete\s+from|truncate|dd\s+if=)\b/i;
+// --- SQL phrases, applied to the de-quoted segment (also catches `psql -c
+// "drop table …"` because the quoted body is extracted before stripping).
+const DESTRUCTIVE_SQL = /\b(?:drop\s+table|delete\s+from|truncate)\b/i;
+
+// Leading wrappers that pass their tail to another command. Stripping them
+// lets `env rm -rf`, `command rm -rf`, `exec rm -rf`, `sudo rm -rf`, and
+// `VAR=val rm -rf` be classified on the real command.
+const WRAPPER_COMMANDS = new Set([
+  'env', 'command', 'exec', 'nohup', 'sudo', 'time', 'builtin', 'setsid', 'stdbuf', 'nice', 'ionice',
+]);
+const SHELL_COMMANDS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
 
 /**
  * Resolve the operator EXTRA destructive regex from the Claude settings
  * that hold the task #12 SSOT. An explicit env override wins (handy for
  * tests); otherwise the standard and r06 account `settings.json` files
  * are tried in order. Returns null (built-ins only) when unreadable or
- * invalid so the gate never crashes on operator config errors.
+ * invalid so the gate never crashes on operator config errors. A parse
+ * failure is surfaced once on stderr (matching ECC) so a broken operator
+ * regex is not silently dropped.
  *
  * @returns {RegExp | null}
  */
@@ -49,7 +69,8 @@ function getExtraDestructiveRegex() {
   if (fromEnv) {
     try {
       return new RegExp(fromEnv, 'i');
-    } catch (_) {
+    } catch (err) {
+      warnOnce(`ignoring invalid GATEGUARD_BASH_EXTRA_DESTRUCTIVE regex: ${err.message}`);
       return null;
     }
   }
@@ -59,24 +80,40 @@ function getExtraDestructiveRegex() {
     path.join(os.homedir(), '.claude-r06', 'settings.json'),
   ];
   for (const p of settingsPaths) {
+    let raw;
     try {
-      const raw = fs.readFileSync(p, 'utf8');
+      raw = fs.readFileSync(p, 'utf8');
+    } catch (_) {
+      continue; // missing/unreadable — try the next candidate.
+    }
+    try {
       const json = JSON.parse(raw);
       const pattern = json && json.env && json.env.GATEGUARD_BASH_EXTRA_DESTRUCTIVE;
       if (typeof pattern === 'string' && pattern.length > 0) {
         return new RegExp(pattern, 'i');
       }
-    } catch (_) {
-      // Unreadable / malformed / missing — try the next candidate.
+    } catch (err) {
+      warnOnce(`ignoring unparseable ${p}: ${err.message}`);
     }
   }
   return null;
 }
 
+let warned = false;
+function warnOnce(msg) {
+  if (warned) return;
+  warned = true;
+  try {
+    process.stderr.write(`[codex-bash-gate] ${msg}\n`);
+  } catch (_) { /* stderr write failure is non-fatal */ }
+}
+
 /**
  * Replace the contents of single- and double-quoted strings so a phrase
  * inside an echoed argument or commit message ("drop table") does not
- * trigger the destructive detector.
+ * trigger the destructive detector. Command-substitution and `sh -c`
+ * bodies are extracted BEFORE this runs (see collectEmbeddedCommands), so
+ * stripping quotes here does not hide a destructive sub-expression.
  *
  * @param {string} input
  * @returns {string}
@@ -88,13 +125,48 @@ function stripQuotedStrings(input) {
 }
 
 /**
- * Promote subshell delimiters to top-level separators so the check also
- * applies inside `$(...)` and backtick sub-expressions.
+ * Collect destructive-bearing sub-expressions that live inside quotes or
+ * shell wrappers, scanned from the RAW command before quotes are stripped:
+ *   - `$(...)` and backtick command substitutions (also inside "..."),
+ *   - `sh -c '...'` / `bash -c "..."` command bodies.
+ * Returns the extra command strings to classify alongside the main line.
+ * Runs a couple of passes so a body nested one level deep is still found.
+ *
+ * @param {string} raw
+ * @returns {string[]}
+ */
+function collectEmbeddedCommands(raw) {
+  const out = [];
+  let frontier = [raw];
+  for (let depth = 0; depth < 3 && frontier.length; depth += 1) {
+    const next = [];
+    for (const text of frontier) {
+      let m;
+      const dollar = /\$\(([^()]*)\)/g;
+      while ((m = dollar.exec(text))) { out.push(m[1]); next.push(m[1]); }
+      const back = /`([^`]*)`/g;
+      while ((m = back.exec(text))) { out.push(m[1]); next.push(m[1]); }
+      // Quoted bodies passed to a `-c` / `--command` / `-e` / `--eval`
+      // flag (sh -c, bash -c, psql -c, mysql -e, …). The body is scanned
+      // as its own command so destructive shell *and* SQL hide nowhere.
+      const cBody = /\s(?:-[a-zA-Z]*[ce]|--command|--eval)\s+(['"])([\s\S]*?)\1/g;
+      while ((m = cBody.exec(text))) { out.push(m[2]); next.push(m[2]); }
+    }
+    frontier = next;
+  }
+  return out;
+}
+
+/**
+ * Promote unquoted subshell / process-substitution delimiters to segment
+ * separators so the check also applies inside `$(...)`, backticks, plain
+ * `(...)` subshells, `{ ...; }` brace groups, and `<(...)` process
+ * substitution. Run iteratively to handle a layer of nesting.
  *
  * @param {string} input
  * @returns {string}
  */
-function explodeSubshells(input) {
+function explodeGroups(input) {
   let out = input;
   for (let i = 0; i < 4; i += 1) {
     const before = out;
@@ -107,28 +179,46 @@ function explodeSubshells(input) {
 
 /**
  * Split a command line into top-level segments at unquoted shell
- * separators. Quotes are stripped first so separators inside quotes do
- * not split. Per-segment comments are removed.
+ * separators and group delimiters. Quotes are stripped first so
+ * separators inside quotes do not split. Per-segment comments are removed.
  *
  * @param {string} input
  * @returns {string[]}
  */
 function splitSegments(input) {
-  const exploded = explodeSubshells(stripQuotedStrings(input));
+  const exploded = explodeGroups(stripQuotedStrings(input));
   return exploded
-    .split(/[;|&\n]+/)
+    .split(/[;|&\n(){}]+/)
     .map((s) => s.replace(/#.*$/, '').trim())
     .filter((s) => s.length > 0);
 }
 
 /**
- * Tokenize a single segment on whitespace. Quotes are already stripped.
+ * Tokenize a single segment on whitespace, then strip leading wrappers
+ * (`env`, `sudo`, `exec`, `VAR=val`, …) so the real command is exposed.
  *
  * @param {string} segment
  * @returns {string[]}
  */
-function tokenize(segment) {
-  return segment.split(/\s+/).filter((t) => t.length > 0);
+function tokenizeCommand(segment) {
+  let tokens = segment.split(/\s+/).filter((t) => t.length > 0);
+  // Strip leading env-assignments and wrapper commands repeatedly.
+  let changed = true;
+  while (changed && tokens.length > 0) {
+    changed = false;
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0])) {
+      tokens = tokens.slice(1);
+      changed = true;
+      continue;
+    }
+    if (WRAPPER_COMMANDS.has(commandBasename(tokens[0]))) {
+      tokens = tokens.slice(1);
+      // Drop immediate option flags of the wrapper (best-effort, e.g. `sudo -n`).
+      while (tokens.length > 0 && tokens[0].startsWith('-')) tokens = tokens.slice(1);
+      changed = true;
+    }
+  }
+  return tokens;
 }
 
 /**
@@ -164,57 +254,89 @@ function isDestructiveRm(tokens) {
 }
 
 /**
- * Destructive `git` subcommands: `reset --hard`, `clean -f...`,
- * `push --force`/`-f` (but not `--force-with-lease`), `branch -D`,
- * `checkout -f` / `switch -f`, `filter-repo` / `filter-branch`.
+ * `dd` writing/reading a device or file. `if=`/`of=` may appear in any
+ * order, so a token scan (not a positional regex) is used.
+ *
+ * @param {string[]} tokens
+ * @returns {boolean}
+ */
+function isDestructiveDd(tokens) {
+  if (tokens.length === 0 || commandBasename(tokens[0]) !== 'dd') return false;
+  return tokens.slice(1).some((t) => /^(?:if|of)=/.test(t));
+}
+
+const hasForceFlag = (t) => t === '--force' || /^-[a-zA-Z]*f/.test(t); // lowercase f only
+
+/**
+ * Destructive `git` subcommands. Mirrors the high-value cases of ECC's
+ * `isDestructiveGit`: `reset --hard`, `clean -f`, `push --force`/`-f`/
+ * `+refspec` (but not lone `--force-with-lease`), `checkout`/`switch`
+ * `--force`/`--`/`.`, `branch -D`, `commit --amend`, `rm -r`,
+ * `filter-repo`/`filter-branch`.
  *
  * @param {string[]} tokens
  * @returns {boolean}
  */
 function isDestructiveGit(tokens) {
   if (tokens.length < 2 || commandBasename(tokens[0]) !== 'git') return false;
-  // Skip leading global options to find the subcommand.
+  // Skip leading global options to find the subcommand. Some options take a
+  // separate value (`-c key=val`, `-C path`, `--git-dir path`) — consume it
+  // so the value is not mistaken for the subcommand.
   let i = 1;
-  const valueConsuming = new Set(['-c', '-C']);
+  const valueConsumingShort = new Set(['-c', '-C']);
+  const valueConsumingLong = new Set(['--git-dir', '--work-tree', '--namespace', '--super-prefix']);
   while (i < tokens.length) {
     const t = tokens[i];
-    if (valueConsuming.has(t)) { i += 2; continue; }
+    if (valueConsumingShort.has(t) || valueConsumingLong.has(t)) { i += 2; continue; }
+    if (t.startsWith('--git-dir=') || t.startsWith('--work-tree=') || t.startsWith('--namespace=') || t.startsWith('--super-prefix=')) { i += 1; continue; }
     if (t.startsWith('-')) { i += 1; continue; }
     break;
   }
   if (i >= tokens.length) return false;
   const sub = tokens[i].toLowerCase();
   const rest = tokens.slice(i + 1);
-  const hasForceFlag = (t) => t === '--force' || /^-[a-zA-Z]*f/.test(t);
 
   if (sub === 'reset') return rest.includes('--hard');
   if (sub === 'clean') return rest.some(hasForceFlag);
   if (sub === 'push') {
-    if (rest.includes('--force-with-lease')) return false;
-    return rest.some(hasForceFlag);
+    // A bare --force/-f overrides lease protection; a `+refspec` is an
+    // inline force. Lone --force-with-lease is the safe form.
+    if (rest.some(hasForceFlag)) return true;
+    if (rest.some((t) => /^\+\S+/.test(t))) return true;
+    return false;
   }
-  if (sub === 'checkout' || sub === 'switch') return rest.some(hasForceFlag);
+  if (sub === 'checkout' || sub === 'switch') {
+    return rest.some((t) => t === '--' || t === '.' || t === '--discard-changes' || hasForceFlag(t));
+  }
   if (sub === 'branch') return rest.some((t) => t === '-D' || /^-[a-zA-Z]*D/.test(t));
+  if (sub === 'commit') return rest.includes('--amend');
+  if (sub === 'rm') {
+    return rest.some((t) => t === '-r' || t === '--recursive' || (t.startsWith('-') && !t.startsWith('--') && /[rR]/.test(t.slice(1))));
+  }
   if (sub === 'filter-repo' || sub === 'filter-branch') return true;
   return false;
 }
 
 /**
  * Decide whether a Bash command is destructive. Returns the matched
- * category label (for the denial reason) or null.
+ * category label (for the denial reason) or null. The main line plus any
+ * embedded command-substitution / `sh -c` bodies are all scanned.
  *
  * @param {string} command
  * @returns {string | null}
  */
 function classifyDestructive(command) {
   const extra = getExtraDestructiveRegex();
-  const segments = splitSegments(command);
-  for (const segment of segments) {
-    if (DESTRUCTIVE_SQL_DD.test(segment)) return 'SQL/dd destructive statement';
-    const tokens = tokenize(segment);
-    if (isDestructiveRm(tokens)) return 'recursive force rm';
-    if (isDestructiveGit(tokens)) return 'destructive git subcommand';
-    if (extra && extra.test(segment)) return 'operator destructive pattern (task #12 SSOT)';
+  const sources = [command, ...collectEmbeddedCommands(command)];
+  for (const source of sources) {
+    for (const segment of splitSegments(source)) {
+      if (DESTRUCTIVE_SQL.test(segment)) return 'SQL destructive statement';
+      const tokens = tokenizeCommand(segment);
+      if (isDestructiveRm(tokens)) return 'recursive force rm';
+      if (isDestructiveDd(tokens)) return 'dd to/from a device or file';
+      if (isDestructiveGit(tokens)) return 'destructive git subcommand';
+      if (extra && extra.test(segment)) return 'operator destructive pattern (task #12 SSOT)';
+    }
   }
   return null;
 }

--- a/home/dot_config/gateguard/executable_codex-bash-gate.js
+++ b/home/dot_config/gateguard/executable_codex-bash-gate.js
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+'use strict';
+
+/*
+ * Cross-harness gateguard — Codex PreToolUse Bash gate (task #26).
+ *
+ * Codex registers this script as a `PreToolUse` command hook with
+ * `matcher = "^Bash$"`. It receives the tool-call JSON on stdin, inspects
+ * the Bash command, and DENIES execution when the command matches a
+ * destructive pattern. Denial uses the documented JSON form
+ * (`hookSpecificOutput.permissionDecision = "deny"`); any other outcome
+ * leaves the decision unset so Codex falls back to its normal flow.
+ *
+ * SSOT relationship with Claude (task #12):
+ *   - Claude's authoritative gate is the ECC `gateguard-fact-force.js`
+ *     hook (Theme H), which consumes `GATEGUARD_BASH_EXTRA_DESTRUCTIVE`
+ *     from `~/.claude/settings.json`.
+ *   - This script re-reads that SAME env value out of `settings.json` at
+ *     runtime so the operator-tuned destructive set lives in exactly one
+ *     place. The built-in patterns below always apply and degrade
+ *     gracefully (fail-open) when settings.json cannot be read, mirroring
+ *     ECC's "a hook must never crash tool execution" philosophy.
+ *
+ * This Codex gate is intentionally a complementary best-effort layer
+ * (Codex also has sandbox + approval). It does not aim for byte-for-byte
+ * parity with ECC's token parser; it ports the high-value built-ins
+ * (rm -rf / destructive git / SQL drop+truncate / dd) and shares the
+ * operator EXTRA regex.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// --- SQL / dd patterns: stable phrases, applied to the de-quoted line. ---
+const DESTRUCTIVE_SQL_DD = /\b(drop\s+table|delete\s+from|truncate|dd\s+if=)\b/i;
+
+/**
+ * Resolve the operator EXTRA destructive regex from the Claude settings
+ * that hold the task #12 SSOT. An explicit env override wins (handy for
+ * tests); otherwise the standard and r06 account `settings.json` files
+ * are tried in order. Returns null (built-ins only) when unreadable or
+ * invalid so the gate never crashes on operator config errors.
+ *
+ * @returns {RegExp | null}
+ */
+function getExtraDestructiveRegex() {
+  const fromEnv = process.env.GATEGUARD_BASH_EXTRA_DESTRUCTIVE;
+  if (fromEnv) {
+    try {
+      return new RegExp(fromEnv, 'i');
+    } catch (_) {
+      return null;
+    }
+  }
+
+  const settingsPaths = [
+    path.join(os.homedir(), '.claude', 'settings.json'),
+    path.join(os.homedir(), '.claude-r06', 'settings.json'),
+  ];
+  for (const p of settingsPaths) {
+    try {
+      const raw = fs.readFileSync(p, 'utf8');
+      const json = JSON.parse(raw);
+      const pattern = json && json.env && json.env.GATEGUARD_BASH_EXTRA_DESTRUCTIVE;
+      if (typeof pattern === 'string' && pattern.length > 0) {
+        return new RegExp(pattern, 'i');
+      }
+    } catch (_) {
+      // Unreadable / malformed / missing — try the next candidate.
+    }
+  }
+  return null;
+}
+
+/**
+ * Replace the contents of single- and double-quoted strings so a phrase
+ * inside an echoed argument or commit message ("drop table") does not
+ * trigger the destructive detector.
+ *
+ * @param {string} input
+ * @returns {string}
+ */
+function stripQuotedStrings(input) {
+  return input
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""');
+}
+
+/**
+ * Promote subshell delimiters to top-level separators so the check also
+ * applies inside `$(...)` and backtick sub-expressions.
+ *
+ * @param {string} input
+ * @returns {string}
+ */
+function explodeSubshells(input) {
+  let out = input;
+  for (let i = 0; i < 4; i += 1) {
+    const before = out;
+    out = out.replace(/\$\(([^()`]*)\)/g, ';$1;');
+    out = out.replace(/`([^`]*)`/g, ';$1;');
+    if (out === before) break;
+  }
+  return out;
+}
+
+/**
+ * Split a command line into top-level segments at unquoted shell
+ * separators. Quotes are stripped first so separators inside quotes do
+ * not split. Per-segment comments are removed.
+ *
+ * @param {string} input
+ * @returns {string[]}
+ */
+function splitSegments(input) {
+  const exploded = explodeSubshells(stripQuotedStrings(input));
+  return exploded
+    .split(/[;|&\n]+/)
+    .map((s) => s.replace(/#.*$/, '').trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Tokenize a single segment on whitespace. Quotes are already stripped.
+ *
+ * @param {string} segment
+ * @returns {string[]}
+ */
+function tokenize(segment) {
+  return segment.split(/\s+/).filter((t) => t.length > 0);
+}
+
+/**
+ * Strip a leading path so `/bin/rm` matches the `rm` rules.
+ *
+ * @param {string} token
+ * @returns {string}
+ */
+function commandBasename(token) {
+  const slash = token.lastIndexOf('/');
+  return slash === -1 ? token : token.slice(slash + 1);
+}
+
+/**
+ * `rm` invoked with both recursive and force flags (combined or split).
+ *
+ * @param {string[]} tokens
+ * @returns {boolean}
+ */
+function isDestructiveRm(tokens) {
+  if (tokens.length === 0 || commandBasename(tokens[0]) !== 'rm') return false;
+  let hasR = false;
+  let hasF = false;
+  for (const t of tokens.slice(1)) {
+    if (t === '--recursive') { hasR = true; continue; }
+    if (t === '--force') { hasF = true; continue; }
+    if (!t.startsWith('-') || t.startsWith('--')) continue;
+    const body = t.slice(1);
+    if (/[rR]/.test(body)) hasR = true;
+    if (/f/.test(body)) hasF = true;
+  }
+  return hasR && hasF;
+}
+
+/**
+ * Destructive `git` subcommands: `reset --hard`, `clean -f...`,
+ * `push --force`/`-f` (but not `--force-with-lease`), `branch -D`,
+ * `checkout -f` / `switch -f`, `filter-repo` / `filter-branch`.
+ *
+ * @param {string[]} tokens
+ * @returns {boolean}
+ */
+function isDestructiveGit(tokens) {
+  if (tokens.length < 2 || commandBasename(tokens[0]) !== 'git') return false;
+  // Skip leading global options to find the subcommand.
+  let i = 1;
+  const valueConsuming = new Set(['-c', '-C']);
+  while (i < tokens.length) {
+    const t = tokens[i];
+    if (valueConsuming.has(t)) { i += 2; continue; }
+    if (t.startsWith('-')) { i += 1; continue; }
+    break;
+  }
+  if (i >= tokens.length) return false;
+  const sub = tokens[i].toLowerCase();
+  const rest = tokens.slice(i + 1);
+  const hasForceFlag = (t) => t === '--force' || /^-[a-zA-Z]*f/.test(t);
+
+  if (sub === 'reset') return rest.includes('--hard');
+  if (sub === 'clean') return rest.some(hasForceFlag);
+  if (sub === 'push') {
+    if (rest.includes('--force-with-lease')) return false;
+    return rest.some(hasForceFlag);
+  }
+  if (sub === 'checkout' || sub === 'switch') return rest.some(hasForceFlag);
+  if (sub === 'branch') return rest.some((t) => t === '-D' || /^-[a-zA-Z]*D/.test(t));
+  if (sub === 'filter-repo' || sub === 'filter-branch') return true;
+  return false;
+}
+
+/**
+ * Decide whether a Bash command is destructive. Returns the matched
+ * category label (for the denial reason) or null.
+ *
+ * @param {string} command
+ * @returns {string | null}
+ */
+function classifyDestructive(command) {
+  const extra = getExtraDestructiveRegex();
+  const segments = splitSegments(command);
+  for (const segment of segments) {
+    if (DESTRUCTIVE_SQL_DD.test(segment)) return 'SQL/dd destructive statement';
+    const tokens = tokenize(segment);
+    if (isDestructiveRm(tokens)) return 'recursive force rm';
+    if (isDestructiveGit(tokens)) return 'destructive git subcommand';
+    if (extra && extra.test(segment)) return 'operator destructive pattern (task #12 SSOT)';
+  }
+  return null;
+}
+
+function readStdin() {
+  try {
+    return fs.readFileSync(0, 'utf8');
+  } catch (_) {
+    return '';
+  }
+}
+
+function main() {
+  const input = readStdin();
+  let payload;
+  try {
+    payload = JSON.parse(input);
+  } catch (_) {
+    // No parseable payload — do not interfere with Codex.
+    process.exit(0);
+  }
+
+  const command =
+    payload && payload.tool_input && typeof payload.tool_input.command === 'string'
+      ? payload.tool_input.command
+      : '';
+  if (!command) process.exit(0);
+
+  const category = classifyDestructive(command);
+  if (!category) process.exit(0);
+
+  const reason =
+    `Destructive command blocked by cross-harness gateguard (${category}). ` +
+    'This shares the Claude task #12 destructive set. ' +
+    'Re-run with explicit operator approval if this is intended.';
+
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason,
+      },
+    })
+  );
+  process.exit(0);
+}
+
+main();

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -323,20 +323,68 @@ FAKE
   grep -q 'includeTemplate "codex-hooks.json"' "${HOME_DIR}/dot_codex-r06/hooks.json.tmpl"
 }
 
-@test "codex gateguard denies a built-in destructive command (rm -rf)" {
-  local gate="${HOME_DIR}/dot_config/gateguard/executable_codex-bash-gate.js"
-  local out
-  out=$(printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"rm -rf build"}}' \
-    | GATEGUARD_BASH_EXTRA_DESTRUCTIVE= node "$gate" 2>/dev/null)
-  echo "$out" | grep -q '"permissionDecision":"deny"'
+# Drive the gate with an ISOLATED HOME (empty BATS_TEST_TMPDIR, no .claude)
+# so an empty GATEGUARD_BASH_EXTRA_DESTRUCTIVE does not silently fall back to
+# the developer's real ~/.claude/settings.json. Echoes "deny" or "allow".
+_gate_decision() {
+  local gate="$1" cmd="$2" json
+  json=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"PreToolUse",tool_name:"Bash",tool_input:{command:process.argv[1]}}))' "$cmd")
+  if printf '%s' "$json" | HOME="$BATS_TEST_TMPDIR" GATEGUARD_BASH_EXTRA_DESTRUCTIVE= node "$gate" 2>/dev/null \
+      | grep -q '"permissionDecision":"deny"'; then
+    echo deny
+  else
+    echo allow
+  fi
 }
 
-@test "codex gateguard allows a benign command" {
+@test "codex gateguard denies a built-in destructive command (rm -rf)" {
   local gate="${HOME_DIR}/dot_config/gateguard/executable_codex-bash-gate.js"
-  local out
-  out=$(printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ls -la && git status"}}' \
-    | GATEGUARD_BASH_EXTRA_DESTRUCTIVE= node "$gate" 2>/dev/null)
-  [ -z "$out" ]
+  [ "$(_gate_decision "$gate" 'rm -rf build')" = deny ]
+}
+
+@test "codex gateguard allows benign commands without false positives" {
+  local gate="${HOME_DIR}/dot_config/gateguard/executable_codex-bash-gate.js" c
+  # Each must pass through. A destructive phrase inside quotes, a safe
+  # --force-with-lease, and env-assignment prefixes must not trip the gate.
+  for c in \
+    'ls -la && git status' \
+    'git commit -m "drop table notes from the agenda"' \
+    'git push --force-with-lease origin main' \
+    'git checkout -b feature/x' \
+    'env FOO=bar npm run build' \
+    'dd --help'; do
+    [ "$(_gate_decision "$gate" "$c")" = allow ] || { echo "false positive: $c"; return 1; }
+  done
+}
+
+# Regression guard for the evasion vectors surfaced by multi-review (cc-code /
+# cc-security / codex): wrappers, subshell/brace/process-substitution groups,
+# quoted command substitution, sh -c / psql -c bodies, dd arg order, and the
+# ECC git-parity gaps. Each MUST be blocked.
+@test "codex gateguard resists destructive-command evasion vectors" {
+  local gate="${HOME_DIR}/dot_config/gateguard/executable_codex-bash-gate.js" c
+  for c in \
+    'dd if=/dev/zero of=/dev/sda' \
+    'dd of=/dev/disk1 if=/dev/zero' \
+    'env rm -rf /tmp/x' \
+    'command rm -rf /tmp/x' \
+    'sudo rm -rf /tmp/x' \
+    '/bin/rm -rf /tmp/x' \
+    '(rm -rf /tmp/x)' \
+    '{ rm -rf /tmp/x; }' \
+    'cat <(rm -rf /tmp/x)' \
+    'echo "$(rm -rf /tmp/x)"' \
+    'sh -c "rm -rf /tmp/x"' \
+    'bash -c "rm -rf /tmp/x"' \
+    'psql -c "drop table users"' \
+    'git push --force --force-with-lease origin main' \
+    'git push origin +main' \
+    'git --git-dir .git reset --hard' \
+    'git checkout -- .' \
+    'git commit --amend' \
+    'git rm -r src/'; do
+    [ "$(_gate_decision "$gate" "$c")" = deny ] || { echo "bypass: $c"; return 1; }
+  done
 }
 
 @test "codex gateguard consumes the task #12 EXTRA regex from the environment" {

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -302,6 +302,76 @@ FAKE
   [ -f "${HOME_DIR}/Library/Application Support/Code/User/keybindings.json" ]
 }
 
+# --- Cross-harness gateguard: Codex PreToolUse Bash gate (task #26) ---
+
+@test "codex cross-harness gateguard script exists and passes node syntax check" {
+  local gate="${HOME_DIR}/dot_config/gateguard/executable_codex-bash-gate.js"
+  [ -f "$gate" ]
+  node --check "$gate"
+}
+
+@test "codex hooks.json registers the gateguard as a PreToolUse Bash hook for both accounts" {
+  local shared="${HOME_DIR}/.chezmoitemplates/codex-hooks.json"
+  [ -f "$shared" ]
+  # Shared template is valid JSON once the homeDir placeholder is filled.
+  HOME_RENDER="/home/test" \
+    node -e 'const fs=require("fs");let s=fs.readFileSync(process.argv[1],"utf8").replace(/\{\{[^}]*\}\}/g,process.env.HOME_RENDER+"/.config/gateguard/codex-bash-gate.js");const j=JSON.parse(s);const m=j.hooks.PreToolUse[0];if(m.matcher!=="^Bash$")throw new Error("matcher");if(m.hooks[0].type!=="command")throw new Error("type");if(!/codex-bash-gate\.js/.test(m.hooks[0].command))throw new Error("command")' "$shared"
+  # Both accounts include the shared template (config.toml itself is unmanaged).
+  [ -f "${HOME_DIR}/dot_codex/hooks.json.tmpl" ]
+  [ -f "${HOME_DIR}/dot_codex-r06/hooks.json.tmpl" ]
+  grep -q 'includeTemplate "codex-hooks.json"' "${HOME_DIR}/dot_codex/hooks.json.tmpl"
+  grep -q 'includeTemplate "codex-hooks.json"' "${HOME_DIR}/dot_codex-r06/hooks.json.tmpl"
+}
+
+@test "codex gateguard denies a built-in destructive command (rm -rf)" {
+  local gate="${HOME_DIR}/dot_config/gateguard/executable_codex-bash-gate.js"
+  local out
+  out=$(printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"rm -rf build"}}' \
+    | GATEGUARD_BASH_EXTRA_DESTRUCTIVE= node "$gate" 2>/dev/null)
+  echo "$out" | grep -q '"permissionDecision":"deny"'
+}
+
+@test "codex gateguard allows a benign command" {
+  local gate="${HOME_DIR}/dot_config/gateguard/executable_codex-bash-gate.js"
+  local out
+  out=$(printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ls -la && git status"}}' \
+    | GATEGUARD_BASH_EXTRA_DESTRUCTIVE= node "$gate" 2>/dev/null)
+  [ -z "$out" ]
+}
+
+@test "codex gateguard consumes the task #12 EXTRA regex from the environment" {
+  local gate="${HOME_DIR}/dot_config/gateguard/executable_codex-bash-gate.js"
+  local out
+  # chezmoi destroy is NOT a built-in; only the operator EXTRA set covers it.
+  out=$(printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"chezmoi destroy"}}' \
+    | GATEGUARD_BASH_EXTRA_DESTRUCTIVE='chezmoi\s+destroy\b' node "$gate" 2>/dev/null)
+  echo "$out" | grep -q '"permissionDecision":"deny"'
+}
+
+# Proves the single-source-of-truth path: with no env override, the gate reads
+# GATEGUARD_BASH_EXTRA_DESTRUCTIVE out of ~/.claude/settings.json (task #12 SSOT).
+@test "codex gateguard reads the EXTRA regex from settings.json when no env override" {
+  local gate="${HOME_DIR}/dot_config/gateguard/executable_codex-bash-gate.js"
+  local tmp; tmp=$(mktemp -d)
+  mkdir -p "$tmp/.claude"
+  printf '%s' '{"env":{"GATEGUARD_BASH_EXTRA_DESTRUCTIVE":"chezmoi\\s+destroy\\b"}}' > "$tmp/.claude/settings.json"
+  local out
+  out=$(printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"chezmoi destroy"}}' \
+    | HOME="$tmp" GATEGUARD_BASH_EXTRA_DESTRUCTIVE= node "$gate" 2>/dev/null)
+  rm -rf "$tmp"
+  echo "$out" | grep -q '"permissionDecision":"deny"'
+}
+
+# Guard against quoted-string false positives: a destructive phrase inside a
+# commit message must not trip the gate.
+@test "codex gateguard does not false-positive on a destructive phrase inside quotes" {
+  local gate="${HOME_DIR}/dot_config/gateguard/executable_codex-bash-gate.js"
+  local out
+  out=$(printf '%s' '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git commit -m \"drop table notes from the agenda\""}}' \
+    | GATEGUARD_BASH_EXTRA_DESTRUCTIVE= node "$gate" 2>/dev/null)
+  [ -z "$out" ]
+}
+
 @test "chezmoi source files exist: VS Code mcp.json" {
   [ -f "${HOME_DIR}/Library/Application Support/Code/User/mcp.json" ]
 }


### PR DESCRIPTION
## Summary

Adds a **cross-harness gateguard** (task #26) so the Codex CLI blocks destructive Bash commands using the *same* destructive set as Claude's Theme H gateguard — without duplicating the operator-tuned pattern.

- **`~/.config/gateguard/codex-bash-gate.js`** — a standalone Codex `PreToolUse` Bash hook. It denies destructive commands via the documented JSON form (`hookSpecificOutput.permissionDecision = "deny"`).
- **SSOT for the destructive pattern (task #12):** the gate re-reads `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` from `~/.claude/settings.json` at runtime, so the operator regex lives in exactly one place. It is **fail-open** — built-in `rm -rf` / destructive-`git` / SQL-`drop`/`truncate` / `dd` patterns always apply, and a missing/invalid settings.json degrades to built-ins only (a hook must never crash tool execution).
- **Wiring via `hooks.json`, not `config.toml`:** `~/.codex/config.toml` is written dynamically by Codex (trust_level, model migrations) and is `.chezmoiignore`d. `hooks.json` is the documented discovery location, is honored **regardless of `--profile`** (so even a bare `codex` is covered, unlike `shared.config.toml` which only loads under `cdx`/`cdx-r06`), and is safely chezmoi-managed. A shared template (`.chezmoitemplates/codex-hooks.json`) is included into both account files so cdx and cdx-r06 stay in sync.

### Design decisions

| Decision | Rationale |
|---|---|
| Claude Theme H gateguard left **unchanged** | The mature ECC `gateguard-fact-force.js` (quote-stripping, subshell explosion, segment splitting) stays authoritative for Claude; this is a complementary Codex layer. |
| New standalone script (no ECC dependency) | ECC is external-vendored and exports only `run` (which has session side-effects), so its destructive check cannot be imported. The script ports the high-value built-ins and shares the EXTRA regex. |
| Gate placed at account-independent `~/.config/gateguard/` | One script for both accounts; `hooks.json` references it via `{{ .chezmoi.homeDir }}` resolved at apply time (no runtime `$HOME` expansion). |

## Test plan

- [x] `make lint` (shellcheck + shfmt + zsh syntax)
- [x] `make test` (80 bats, incl. 7 new: script syntax, hooks.json wiring + JSON validity for both accounts, built-in `rm -rf` deny, benign allow, EXTRA-regex env consumption, settings.json SSOT read path, quoted-phrase false-positive guard)
- [x] `chezmoi diff` — `~/.codex/hooks.json`, `~/.codex-r06/hooks.json` render with the resolved gate path; gate script deploys 0755
- [ ] **User runtime:** `chezmoi apply`; trust the hook once via Codex `/hooks`; confirm a destructive command (e.g. `chezmoi destroy`) is blocked under `cdx` and `cdx-r06`, and a benign command passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
