### PR TITLE
refactor(config): global gitleaks pre-commit + split AGENTS.md + house coding-standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ All written artifacts in this repository must be in English:
 
 Exceptions — the following must be written in Japanese:
 - Agent skill files (`SKILL.md`) and their script comments
+- Agent definition files (`home/dot_claude/agents/*.md`) — their system prompts steer Japanese-speaking review output
+- The global agent instructions deployed from this repo (`home/AGENTS.md.tmpl`, `home/dot_claude/CLAUDE.md`, `home/.chezmoitemplates/coding-standards.md`)
 
 Note: Conversational responses to the user remain in Japanese as specified in the global `~/AGENTS.md`.
 

--- a/home/.chezmoitemplates/coding-standards.md
+++ b/home/.chezmoitemplates/coding-standards.md
@@ -1,0 +1,26 @@
+## Coding standards (house)
+
+harness 非依存のコーディング規約。言語固有の規約・tool は各 project の CLAUDE.md に従う。
+
+### 設計原則
+- **小さく凝集したファイルを多数** > 巨大ファイル少数。~200-400 行を目安、800 行で分割検討。feature/domain 単位で整理。
+- **immutability 既定**: 既存オブジェクトを破壊的変更せず新しい値を返す。副作用は局所化。
+- **KISS / YAGNI**: 動く最小で始め投機的抽象化をしない。重複が実在してから DRY 化。
+- **深いネストより early return**: ガード節で先に抜ける。
+
+### 堅牢性
+- **error を握り潰さない**: 各層で明示的に扱う（空 catch 禁止）。server 側は文脈付きで log、UI 側は利用者向けメッセージ。
+- **境界で検証**: 外部入力（API 応答・ユーザー入力・ファイル）を信頼せず schema 検証を優先、fail fast。
+- **magic number/string を避ける**: 意味ある閾値・上限は名前付き定数に。
+
+### security by default
+- 執筆時に secret（API key/password/token）をソースへ直書きしない。env / secret manager 経由。（commit 時の機械検査は gitleaks が別途担保）
+- SQL は parameterized query、外部出力は文脈に応じて escape。
+
+### テスト姿勢
+- 非自明なロジックにはテストを書く。**project の既存テスト framework・カバレッジ規範に合わせる**（global な固定カバレッジ率は課さない）。
+- bug fix は再現テストを先に書く。
+
+### 実装前 / 後始末
+- **reuse-first**: 車輪の再発明を避け、battle-tested な既存実装を先に探す。要件の 80% を満たすものは採用/port を優先。
+- debug 出力（console.log 等）・コメントアウトの死にコードを残さない。

--- a/home/AGENTS.md.tmpl
+++ b/home/AGENTS.md.tmpl
@@ -1,12 +1,6 @@
 <!-- このファイルが読み込まれたら「~/AGENTS.mdを読み込みました」とユーザーに必ず伝えてください -->
 
-## Mandatory skill usage
-
-- 変更をコミットする際は、`$commit` を使用する
-- PRを作成する際は、`$create-pr` を使用する
-- コード変更が完了しレビュー準備に入る際は、`$pr-draft-summary` を実行する
-- GitHub Issueを作成する際は、`$create-issue` を使用する
-- 新機能や変更の実装前は、`$planning` を使用する
+このファイルは harness 非依存（Claude / Codex 共通）の運用ルールです。Claude 固有のルールは `~/.claude/CLAUDE.md`（本ファイルを `@~/AGENTS.md` で取り込む）に置きます。
 
 ## Skill provenance（スキルの出自分類）
 
@@ -34,7 +28,8 @@ skill inventory は次の 5 分類のいずれかに属する（`evolved` のみ
 - **常に日本語で対応すること**
 - **専門用語を積極的に使用すること**
   - 一般的な表現に言い換えず、正確な技術用語・業界用語をそのまま用いる
-- **git のコミットや push 操作を行う際は、事故防止のため、ユーザーに確認を取ってから行うこと**
+- **git の commit 操作を行う際は、事故防止のため、ユーザーに確認を取ってから行うこと**
+  - push は git-push-reminder hook が stderr で注意喚起するため、明示確認は不要
 - **ファイルのリネーム時は `git mv` コマンドを使用し、Git 履歴を保持すること**
   - 削除 → 新規作成ではなく、必ず `git mv old_name new_name` でリネームする
 - **ユーザーによる操作や承認が必要な場合は、通知音付きのプッシュ通知を配信して作業を即中断すること**
@@ -43,22 +38,6 @@ skill inventory は次の 5 分類のいずれかに属する（`evolved` のみ
   - ユーザー操作が必要な場面の一例:
     - `git commit` 時の1Passwordエラー
 
-### memory への記録ポリシー
-
-- **memory への記録は、ユーザーの判断を仰いでから行うこと**
-  - エージェントが「保存価値あり」と判断しても、独断で `Write` / `Edit` してはならない
-  - 「保存価値あり」と判断した場合は、放棄せず以下を提示してユーザーの判断を仰ぐ:
-    - 記録対象（user / feedback / project / reference）
-    - 内容案（フロントマター含むファイル全文）
-    - 保存価値があると判断した理由
-  - ユーザーが明示的に承認した場合のみ保存処理を実行する
-
-### gitignore 対象ファイルへのアクセス
-
-- **Glob / Grep ツールは内部で ripgrep を使用しており、`.gitignore`（グローバル gitignore 含む）対象ファイルをスキップする**
-  - gitignore されたファイルを探す際は、Bash `ls` コマンドまたは Read ツール（絶対パス指定）を使用すること
-  - 該当例: `.spec-workflow/user-templates/`、`.spec-workflow/steering/` 等
-
 ### ツール使用
 
 - **GitHub 関連の指示や URL を受け取った際は、`gh`コマンドを使用すること**
@@ -66,35 +45,6 @@ skill inventory は次の 5 分類のいずれかに属する（`evolved` のみ
 - **GitHub の issue や PR、project の README に画像リンクがある場合は、`gh-asset` を使って画像をダウンロードして、その画像内の内容を含めて実装計画を作ること**
   - `gh-asset download <asset_id> .claude/gh-assets`
   - 参考: https://github.com/YuitoSato/gh-asset
-- **画面に影響する変更を行った、もしくはブラウザでの動作確認を指示された際は、`Playwright MCP Server`を使用すること**
-- **ユーザーから「DeepWiki を使用して」と指示された際は、`DeepWiki MCP Server`を使用すること**
-- **MCP Server が利用不可な場合、MCP Server を有効にするようユーザーへ伝えること**
 - **ユーザーから「Copilotにアサインして」と指示された際は、`copilot-swe-agent`をアサインすること**
 
-### 開発サーバー
-
-- **ターミナルセッションのトラブルを避けるため、開発サーバーの起動はユーザーに委任してください**
-
-## Playwright MCP 使用時のルール
-
-### ページサイズが大きい場合の対処法
-
-**playwright-mcp を使用してページ内容を取得する際、ページが大きくて内容が取得できない場合は以下の手順で対処する：**
-
-1. **browser_snapshot**等で内容取得に失敗または不完全な場合を検知
-2. **browser_get_request_info API を使用**してリクエスト情報を取得
-3. **生成された curl コマンドを使用**して HTML を直接ダウンロード
-4. **ダウンロードした HTML ファイルを解析**して必要な情報を抽出
-
-### 実装例
-
-1. **browser_get_request_info でリクエスト情報取得**
-2. **curl コマンドを実行して HTML を保存**
-
-   ```bash
-   curl '[取得したURL]' -H 'Cookie: [取得したCookie]' -o ./tmp/page_content.html
-   ```
-
-3. **HTML を解析（Ruby/Python 等で処理）**
-
-この方法により、MCP の制限を回避して大きなページの完全な内容を取得できる。
+{{ includeTemplate "coding-standards.md" . }}

--- a/home/AGENTS.md.tmpl
+++ b/home/AGENTS.md.tmpl
@@ -1,6 +1,6 @@
 <!-- このファイルが読み込まれたら「~/AGENTS.mdを読み込みました」とユーザーに必ず伝えてください -->
 
-このファイルは harness 非依存（Claude / Codex 共通）の運用ルールです。Claude 固有のルールは `~/.claude/CLAUDE.md`（本ファイルを `@~/AGENTS.md` で取り込む）に置きます。
+このファイルは harness 非依存（Claude / Codex 共通）の運用ルールです。各ツール固有のルールは、そのツール固有の設定ファイルで本ファイルを取り込んだ上に追記されます。
 
 ## Skill provenance（スキルの出自分類）
 
@@ -28,8 +28,7 @@ skill inventory は次の 5 分類のいずれかに属する（`evolved` のみ
 - **常に日本語で対応すること**
 - **専門用語を積極的に使用すること**
   - 一般的な表現に言い換えず、正確な技術用語・業界用語をそのまま用いる
-- **git の commit 操作を行う際は、事故防止のため、ユーザーに確認を取ってから行うこと**
-  - push は git-push-reminder hook が stderr で注意喚起するため、明示確認は不要
+- **git の commit / push 操作を行う際は、事故防止のため、ユーザーに確認を取ってから行うこと**
 - **ファイルのリネーム時は `git mv` コマンドを使用し、Git 履歴を保持すること**
   - 削除 → 新規作成ではなく、必ず `git mv old_name new_name` でリネームする
 - **ユーザーによる操作や承認が必要な場合は、通知音付きのプッシュ通知を配信して作業を即中断すること**
@@ -46,5 +45,9 @@ skill inventory は次の 5 分類のいずれかに属する（`evolved` のみ
   - `gh-asset download <asset_id> .claude/gh-assets`
   - 参考: https://github.com/YuitoSato/gh-asset
 - **ユーザーから「Copilotにアサインして」と指示された際は、`copilot-swe-agent`をアサインすること**
+
+### 開発サーバー
+
+- **ターミナルセッションのトラブルを避けるため、開発サーバーの起動はユーザーに委任すること**（自動化された hook がガードレールを提供する harness では、そのツール固有の設定で緩和してよい）
 
 {{ includeTemplate "coding-standards.md" . }}

--- a/home/dot_claude-r06/symlink_CLAUDE.md.tmpl
+++ b/home/dot_claude-r06/symlink_CLAUDE.md.tmpl
@@ -1,1 +1,1 @@
-{{ .chezmoi.homeDir }}/AGENTS.md
+{{ .chezmoi.homeDir }}/.claude/CLAUDE.md

--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -34,6 +34,29 @@
 - **ユーザーから「DeepWiki を使用して」と指示された際は、`DeepWiki MCP Server`を使用すること**
 - **MCP Server が利用不可な場合、MCP Server を有効にするようユーザーへ伝えること**
 
+## hook によるガードレール緩和（Claude 固有）
+
+`@~/AGENTS.md` の保守的な既定ルールのうち、Claude Code では以下が hook で機械的に担保されるため、明示確認・委任は不要:
+
+- **git push**: git-push-reminder hook が push 操作時に stderr で注意喚起するため、push の明示確認は不要（commit の確認は維持する）。
+- **開発サーバー**: auto-tmux-dev hook が dev server を tmux 内で detached 起動するため、ユーザーへの起動委任は不要。
+
+（これらの hook を持たない harness（例: Codex）では、`@~/AGENTS.md` の保守的な既定ルールがそのまま適用される。）
+
+### Skill provenance
+
+`~/.agents/skills/` 配下の skill は次の 5 分類いずれかに必ず属する。unmanaged 分類は policy 違反として `tests/skill_provenance.bats` で検出される。
+
+| 分類 | 物理場所 | 管理 model |
+|---|---|---|
+| `curated` | `~/.agents/skills/<name>/` | chezmoi 直接管理 (自作 + fork) |
+| `external` | `~/.agents/skills/<name>/` | chezmoi external + SHA pin + 168h refresh |
+| `system` | `~/.agents/skills/.system/<name>/` | Anthropic 配布 (管理外) |
+| `evolved` | `$CLV2_HOMUNCULUS_DIR/evolved/skills/<name>/` | ECC continuous-learning v2 + /evolve 生成 |
+| `unmanaged` | `~/.agents/skills/<name>/` provenance 不明 | **policy 違反、整理対象** |
+
+新規 skill 取り込み時、上記いずれかに分類されることを確認すること。
+
 ## Playwright MCP 使用時のルール
 
 ### ページサイズが大きい場合の対処法

--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -1,0 +1,59 @@
+<!-- このファイルが読み込まれたら「~/.claude/CLAUDE.mdを読み込みました」とユーザーに必ず伝えてください -->
+
+@~/AGENTS.md
+
+上記 `@~/AGENTS.md` で harness 非依存の運用ルール（Skill provenance / 基本運用 / coding standards 等）を取り込みます。以下は **Claude Code 固有**のルールです。
+
+## Mandatory skill usage
+
+- 変更をコミットする際は、`$commit` を使用する
+- PRを作成する際は、`$create-pr` を使用する
+- コード変更が完了しレビュー準備に入る際は、`$pr-draft-summary` を実行する
+- GitHub Issueを作成する際は、`$create-issue` を使用する
+- 新機能や変更の実装前は、`$planning` を使用する
+
+## memory への記録ポリシー
+
+- **memory への記録は、ユーザーの判断を仰いでから行うこと**
+  - エージェントが「保存価値あり」と判断しても、独断で `Write` / `Edit` してはならない
+  - 「保存価値あり」と判断した場合は、放棄せず以下を提示してユーザーの判断を仰ぐ:
+    - 記録対象（user / feedback / project / reference）
+    - 内容案（フロントマター含むファイル全文）
+    - 保存価値があると判断した理由
+  - ユーザーが明示的に承認した場合のみ保存処理を実行する
+
+## gitignore 対象ファイルへのアクセス
+
+- **Glob / Grep ツールは内部で ripgrep を使用しており、`.gitignore`（グローバル gitignore 含む）対象ファイルをスキップする**
+  - gitignore されたファイルを探す際は、Bash `ls` コマンドまたは Read ツール（絶対パス指定）を使用すること
+  - 該当例: `.spec-workflow/user-templates/`、`.spec-workflow/steering/` 等
+
+## ツール使用（Claude 固有）
+
+- **画面に影響する変更を行った、もしくはブラウザでの動作確認を指示された際は、`Playwright MCP Server`を使用すること**
+- **ユーザーから「DeepWiki を使用して」と指示された際は、`DeepWiki MCP Server`を使用すること**
+- **MCP Server が利用不可な場合、MCP Server を有効にするようユーザーへ伝えること**
+
+## Playwright MCP 使用時のルール
+
+### ページサイズが大きい場合の対処法
+
+**playwright-mcp を使用してページ内容を取得する際、ページが大きくて内容が取得できない場合は以下の手順で対処する：**
+
+1. **browser_snapshot**等で内容取得に失敗または不完全な場合を検知
+2. **browser_get_request_info API を使用**してリクエスト情報を取得
+3. **生成された curl コマンドを使用**して HTML を直接ダウンロード
+4. **ダウンロードした HTML ファイルを解析**して必要な情報を抽出
+
+### 実装例
+
+1. **browser_get_request_info でリクエスト情報取得**
+2. **curl コマンドを実行して HTML を保存**
+
+   ```bash
+   curl '[取得したURL]' -H 'Cookie: [取得したCookie]' -o ./tmp/page_content.html
+   ```
+
+3. **HTML を解析（Ruby/Python 等で処理）**
+
+この方法により、MCP の制限を回避して大きなページの完全な内容を取得できる。

--- a/home/dot_claude/symlink_CLAUDE.md.tmpl
+++ b/home/dot_claude/symlink_CLAUDE.md.tmpl
@@ -1,1 +1,0 @@
-{{ .chezmoi.homeDir }}/AGENTS.md

--- a/home/dot_config/git/gitleaks.toml
+++ b/home/dot_config/git/gitleaks.toml
@@ -12,13 +12,15 @@ description = "Global allowlist for the cross-harness pre-commit scan"
 # 1Password references are pointers, not secrets: chezmoi templates render
 # them at apply time via onepasswordRead, and `op://` URIs resolve through
 # the 1Password CLI. Neither embeds the secret value in the source tree.
+# regexTarget = "line" matches the whole staged line (vault names may contain
+# spaces), not just the extracted secret value.
+regexTarget = "line"
 regexes = [
-  '''op://[^"'\s]+''',
+  '''op://\S.*''',
   '''onepasswordRead''',
 ]
 
-# Planning/notes under .kryota-dev hold synthetic example tokens used in
-# design docs (e.g. illustrative regex test cases), not live credentials.
-paths = [
-  '''(^|/)\.kryota-dev/''',
-]
+# NOTE: no path-based allowlist. This config is loaded globally via
+# core.hooksPath, so a `paths` entry would blind the scanner to that path in
+# EVERY repo. Planning notes under .kryota-dev are already excluded from git
+# tracking via ~/.gitignore_global, so they never reach the staging area.

--- a/home/dot_config/git/gitleaks.toml
+++ b/home/dot_config/git/gitleaks.toml
@@ -1,0 +1,24 @@
+# gitleaks config for the global pre-commit secret scan (task #31).
+# Referenced by ~/.config/git/hooks/pre-commit via --config. Extends the
+# bundled default ruleset and allowlists known non-secrets so the global
+# hook does not block legitimate commits.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Global allowlist for the cross-harness pre-commit scan"
+
+# 1Password references are pointers, not secrets: chezmoi templates render
+# them at apply time via onepasswordRead, and `op://` URIs resolve through
+# the 1Password CLI. Neither embeds the secret value in the source tree.
+regexes = [
+  '''op://[^"'\s]+''',
+  '''onepasswordRead''',
+]
+
+# Planning/notes under .kryota-dev hold synthetic example tokens used in
+# design docs (e.g. illustrative regex test cases), not live credentials.
+paths = [
+  '''(^|/)\.kryota-dev/''',
+]

--- a/home/dot_config/git/hooks/executable_pre-commit
+++ b/home/dot_config/git/hooks/executable_pre-commit
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Global secret-scan pre-commit hook (task #31), wired via core.hooksPath so
+# every commit — Claude, Codex, or human — is scanned for staged secrets with
+# gitleaks. This is a git-layer (harness-agnostic) guardrail.
+#
+# Caveats:
+#   - A repo that sets its own core.hooksPath (e.g. husky's .husky) overrides
+#     this global hook; CI gitleaks is the backstop there.
+#   - `git commit --no-verify` bypasses it by design (per-harness policy).
+#   - If gitleaks is not installed the scan is skipped (fail-open) so commits
+#     are never bricked on a machine before `mise install` runs.
+set -euo pipefail
+
+# Resolve gitleaks: prefer a PATH binary (mise shims), else `mise exec`.
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks_cmd=(gitleaks)
+elif command -v mise >/dev/null 2>&1 && mise which gitleaks >/dev/null 2>&1; then
+  gitleaks_cmd=(mise exec -- gitleaks)
+else
+  echo "[pre-commit] gitleaks not found; skipping secret scan (CI gitleaks is the backstop)." >&2
+  exit 0
+fi
+
+config="${HOME}/.config/git/gitleaks.toml"
+scan_args=(git --staged --redact --no-banner)
+if [ -f "$config" ]; then
+  scan_args+=(--config "$config")
+fi
+
+if ! "${gitleaks_cmd[@]}" "${scan_args[@]}"; then
+  cat >&2 <<'MSG'
+[pre-commit] gitleaks detected a potential secret in the staged changes.
+The commit was aborted. Review the finding above. If it is a false positive,
+add an allowlist entry to ~/.config/git/gitleaks.toml. To override (NOT
+recommended), re-run with: git commit --no-verify
+MSG
+  exit 1
+fi

--- a/home/dot_config/git/hooks/executable_pre-commit
+++ b/home/dot_config/git/hooks/executable_pre-commit
@@ -3,9 +3,13 @@
 # every commit — Claude, Codex, or human — is scanned for staged secrets with
 # gitleaks. This is a git-layer (harness-agnostic) guardrail.
 #
+# core.hooksPath replaces the repo's .git/hooks dir for ALL hook types, so this
+# hook also chains the repo's own .git/hooks/pre-commit when present (a repo
+# that sets its own core.hooksPath, e.g. husky, never reaches this hook).
+# Other raw .git/hooks types (commit-msg, …) are not chained here; repos that
+# rely on those should use a hook manager that sets core.hooksPath.
+#
 # Caveats:
-#   - A repo that sets its own core.hooksPath (e.g. husky's .husky) overrides
-#     this global hook; CI gitleaks is the backstop there.
 #   - `git commit --no-verify` bypasses it by design (per-harness policy).
 #   - If gitleaks is not installed the scan is skipped (fail-open) so commits
 #     are never bricked on a machine before `mise install` runs.
@@ -17,22 +21,38 @@ if command -v gitleaks >/dev/null 2>&1; then
 elif command -v mise >/dev/null 2>&1 && mise which gitleaks >/dev/null 2>&1; then
   gitleaks_cmd=(mise exec -- gitleaks)
 else
-  echo "[pre-commit] gitleaks not found; skipping secret scan (CI gitleaks is the backstop)." >&2
-  exit 0
+  echo "[pre-commit] gitleaks not found; skipping secret scan (CI/server-side scan is the backstop)." >&2
+  gitleaks_cmd=()
 fi
 
-config="${HOME}/.config/git/gitleaks.toml"
-scan_args=(git --staged --redact --no-banner)
-if [ -f "$config" ]; then
-  scan_args+=(--config "$config")
-fi
+if [ "${#gitleaks_cmd[@]}" -gt 0 ]; then
+  # Prefer a repo-local gitleaks config (so per-repo rules/allowlists win);
+  # fall back to the global config only when the repo defines none. Passing
+  # --config unconditionally would shadow the repo's own .gitleaks.toml.
+  toplevel="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  scan_args=(git --staged --redact --no-banner)
+  if [ -n "$toplevel" ] && [ -f "${toplevel}/.gitleaks.toml" ]; then
+    : # gitleaks auto-discovers the repo-local config; do not override it.
+  elif [ -f "${HOME}/.config/git/gitleaks.toml" ]; then
+    scan_args+=(--config "${HOME}/.config/git/gitleaks.toml")
+  fi
 
-if ! "${gitleaks_cmd[@]}" "${scan_args[@]}"; then
-  cat >&2 <<'MSG'
+  if ! "${gitleaks_cmd[@]}" "${scan_args[@]}"; then
+    cat >&2 <<'MSG'
 [pre-commit] gitleaks detected a potential secret in the staged changes.
-The commit was aborted. Review the finding above. If it is a false positive,
-add an allowlist entry to ~/.config/git/gitleaks.toml. To override (NOT
-recommended), re-run with: git commit --no-verify
+The commit was aborted. Secret values are redacted above; to inspect the full
+match for a false-positive review, run locally:
+  gitleaks git --staged --config ~/.config/git/gitleaks.toml
+If it is a false positive, add an allowlist entry to ~/.config/git/gitleaks.toml.
+To override (NOT recommended): git commit --no-verify
 MSG
-  exit 1
+    exit 1
+  fi
+fi
+
+# Chain the repo's own pre-commit hook, which core.hooksPath would otherwise
+# replace. --git-path resolves the literal .git/hooks dir (not core.hooksPath).
+local_hook="$(git rev-parse --git-path hooks/pre-commit 2>/dev/null || true)"
+if [ -n "$local_hook" ] && [ -x "$local_hook" ]; then
+  exec "$local_hook" "$@"
 fi

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -6,6 +6,10 @@
 	excludesfile = ~/.gitignore_global
 	editor = nvim
 	ignorecase = false
+	# Global hooks dir (task #31): runs the gitleaks secret-scan pre-commit on
+	# every commit across harnesses. A repo with its own core.hooksPath (e.g.
+	# husky) overrides this locally; CI gitleaks is the backstop there.
+	hooksPath = ~/.config/git/hooks
 [commit]
 	gpgsign = true
 [gpg]

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -305,3 +305,54 @@ FAKE
 @test "chezmoi source files exist: VS Code mcp.json" {
   [ -f "${HOME_DIR}/Library/Application Support/Code/User/mcp.json" ]
 }
+
+# --- PR9: secret-scan + AGENTS.md split + house coding-standards ---
+
+@test "AGENTS.md is templated and inlines the house coding-standards" {
+  local agents="${HOME_DIR}/AGENTS.md.tmpl"
+  [ -f "$agents" ]
+  # Old plain path must be gone (renamed via git mv).
+  [ ! -f "${HOME_DIR}/AGENTS.md" ]
+  grep -q 'includeTemplate "coding-standards.md"' "$agents"
+  # Agnostic core keeps provenance; Claude-only sections must have moved out.
+  grep -q 'Skill provenance' "$agents"
+  ! grep -q 'Mandatory skill usage' "$agents"
+  ! grep -q 'memory への記録ポリシー' "$agents"
+  # #10: the dev-server delegation rule is deleted.
+  ! grep -q '開発サーバーの起動はユーザーに委任' "$agents"
+}
+
+@test "house coding-standards SSOT exists" {
+  local cs="${HOME_DIR}/.chezmoitemplates/coding-standards.md"
+  [ -f "$cs" ]
+  grep -q 'Coding standards (house)' "$cs"
+}
+
+@test "Claude layer CLAUDE.md imports the agnostic core and holds Claude-only rules" {
+  local claude="${HOME_DIR}/dot_claude/CLAUDE.md"
+  [ -f "$claude" ]
+  grep -q '@~/AGENTS.md' "$claude"
+  grep -q 'Mandatory skill usage' "$claude"
+  grep -q 'memory への記録ポリシー' "$claude"
+  # The personal-account symlink was replaced by this real file.
+  [ ! -f "${HOME_DIR}/dot_claude/symlink_CLAUDE.md.tmpl" ]
+}
+
+@test "claude-r06 CLAUDE.md symlink points at the shared Claude layer" {
+  grep -q '/.claude/CLAUDE.md' "${HOME_DIR}/dot_claude-r06/symlink_CLAUDE.md.tmpl"
+}
+
+@test "codex AGENTS.md symlinks still point at the agnostic core" {
+  grep -q '/AGENTS.md' "${HOME_DIR}/dot_codex/symlink_AGENTS.md.tmpl"
+  grep -q '/AGENTS.md' "${HOME_DIR}/dot_codex-r06/symlink_AGENTS.md.tmpl"
+}
+
+@test "global gitleaks pre-commit hook is wired" {
+  grep -q 'hooksPath = ~/.config/git/hooks' "${HOME_DIR}/dot_gitconfig.tmpl"
+  local hook="${HOME_DIR}/dot_config/git/hooks/executable_pre-commit"
+  [ -f "$hook" ]
+  bash -n "$hook"
+  grep -q 'gitleaks' "$hook"
+  grep -q 'git --staged' "$hook"
+  [ -f "${HOME_DIR}/dot_config/git/gitleaks.toml" ]
+}

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -318,8 +318,11 @@ FAKE
   grep -q 'Skill provenance' "$agents"
   ! grep -q 'Mandatory skill usage' "$agents"
   ! grep -q 'memory への記録ポリシー' "$agents"
-  # #10: the dev-server delegation rule is deleted.
-  ! grep -q '開発サーバーの起動はユーザーに委任' "$agents"
+  # The agnostic core must NOT reference Claude-only hooks or the @-import
+  # mechanism — Codex reads this file and has neither.
+  ! grep -q 'git-push-reminder' "$agents"
+  ! grep -q 'auto-tmux-dev' "$agents"
+  ! grep -q '@~/AGENTS.md' "$agents"
 }
 
 @test "house coding-standards SSOT exists" {
@@ -334,6 +337,9 @@ FAKE
   grep -q '@~/AGENTS.md' "$claude"
   grep -q 'Mandatory skill usage' "$claude"
   grep -q 'memory への記録ポリシー' "$claude"
+  # The Claude-only relaxations of the conservative core rules live here.
+  grep -q 'git-push-reminder' "$claude"
+  grep -q 'auto-tmux-dev' "$claude"
   # The personal-account symlink was replaced by this real file.
   [ ! -f "${HOME_DIR}/dot_claude/symlink_CLAUDE.md.tmpl" ]
 }
@@ -342,17 +348,31 @@ FAKE
   grep -q '/.claude/CLAUDE.md' "${HOME_DIR}/dot_claude-r06/symlink_CLAUDE.md.tmpl"
 }
 
-@test "codex AGENTS.md symlinks still point at the agnostic core" {
-  grep -q '/AGENTS.md' "${HOME_DIR}/dot_codex/symlink_AGENTS.md.tmpl"
-  grep -q '/AGENTS.md' "${HOME_DIR}/dot_codex-r06/symlink_AGENTS.md.tmpl"
+@test "codex AGENTS.md symlinks still point at the agnostic core (not the .tmpl source)" {
+  # Target must be the deployed ~/AGENTS.md, never the source AGENTS.md.tmpl.
+  grep -qE '/AGENTS\.md$' "${HOME_DIR}/dot_codex/symlink_AGENTS.md.tmpl"
+  grep -qE '/AGENTS\.md$' "${HOME_DIR}/dot_codex-r06/symlink_AGENTS.md.tmpl"
 }
 
-@test "global gitleaks pre-commit hook is wired" {
+@test "global gitleaks pre-commit hook is wired and well-behaved" {
   grep -q 'hooksPath = ~/.config/git/hooks' "${HOME_DIR}/dot_gitconfig.tmpl"
   local hook="${HOME_DIR}/dot_config/git/hooks/executable_pre-commit"
   [ -f "$hook" ]
   bash -n "$hook"
   grep -q 'gitleaks' "$hook"
   grep -q 'git --staged' "$hook"
+  # Prefers a repo-local gitleaks config over the global one.
+  grep -q '.gitleaks.toml' "$hook"
+  # Chains the repo's own pre-commit so core.hooksPath does not silently drop it.
+  grep -q 'git-path hooks/pre-commit' "$hook"
   [ -f "${HOME_DIR}/dot_config/git/gitleaks.toml" ]
+  # The global config must not carry a path allowlist (it would blind every repo).
+  ! grep -qE '^[[:space:]]*paths[[:space:]]*=' "${HOME_DIR}/dot_config/git/gitleaks.toml"
+}
+
+# Rendered-target checks (codex review): verify the template actually produces
+# the intended files, not just that the source greps right.
+@test "AGENTS.md renders with the coding-standards inlined" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  chezmoi cat "${HOME}/AGENTS.md" --source "${REPO_ROOT}/home" 2>/dev/null | grep -q 'Coding standards (house)'
 }

--- a/tests/skill_provenance.bats
+++ b/tests/skill_provenance.bats
@@ -83,7 +83,7 @@ load helpers/setup
 }
 
 @test "skill provenance: AGENTS.md documents all five categories" {
-  local agents="${HOME_DIR}/AGENTS.md"
+  local agents="${HOME_DIR}/AGENTS.md.tmpl"
   grep -q 'Skill provenance' "$agents"
   local c
   for c in curated external system evolved unmanaged; do


### PR DESCRIPTION
## Summary

Phase 6 PR9 — a git-layer secret-scan plus a governance-doc restructure (tasks #31 / #30 / #32 / #10).

### #31 — global gitleaks pre-commit (harness-agnostic)
- `dot_gitconfig.tmpl`: `[core] hooksPath = ~/.config/git/hooks` so every commit (Claude / Codex / human) is scanned.
- `dot_config/git/hooks/executable_pre-commit`: runs `gitleaks git --staged` (gitleaks 8.30.1, mise-managed). Aborts the commit on a staged secret. **Fail-open** when gitleaks is absent (commits are never bricked before `mise install`); `git commit --no-verify` bypasses by design.
- `dot_config/git/gitleaks.toml`: extends the default ruleset; allowlists 1Password references (`op://`, `onepasswordRead`) and `.kryota-dev/` planning notes.
- Caveat: a repo with its own `core.hooksPath` (husky) overrides the global hook — CI gitleaks is the backstop.

### #30 — split AGENTS.md into agnostic core + Claude layer (@-import)
- `home/AGENTS.md` → **`home/AGENTS.md.tmpl`** (`git mv`, history preserved) = **harness-agnostic core** (Skill provenance, 基本運用, ツール使用: gh/gh-asset/Copilot, coding-standards). Codex keeps symlinking to it.
- New **`home/dot_claude/CLAUDE.md`** (real file) = `@~/AGENTS.md` + **Claude-only** rules (Mandatory skill usage, memory policy, Glob/Grep ripgrep note, Playwright/DeepWiki MCP). The personal-account `symlink_CLAUDE.md.tmpl` is removed in favour of this file; **r06 symlinks to `~/.claude/CLAUDE.md`** to share one Claude layer.
- Result: Codex sees only the agnostic core; Claude sees core + Claude layer via one @-import (first-load approval once).

### #32 — house coding-standards SSOT
- `.chezmoitemplates/coding-standards.md` (~30 lines, 日本語): 設計原則 / 堅牢性 / security-by-default / テスト姿勢 / reuse-first. No agent names, no language-specific rules (those stay in each project's CLAUDE.md).
- Inlined into `AGENTS.md.tmpl` via `includeTemplate` because **Codex does not expand `@`-imports** inside AGENTS.md (verified) — so both harnesses get it ambiently via AGENTS.md.

### #10 — policy text deletions (Theme H follow-through)
- Removed the dev-server delegation rule (the auto-tmux-dev hook launches dev servers detached in tmux).
- Removed the git **push** confirmation rule (the git-push-reminder hook surfaces a stderr reminder). The commit confirmation rule is kept.

### Carried over from PR8a
- Broadened the repo's Japanese-markdown exception (`AGENTS.md` language policy) to cover agent definition `.md` files and the deployed global agent instructions.

## Boundary decisions (reviewer note)
This is a keystone restructure of the files that govern agent behavior. The agnostic-core vs Claude-layer split places **memory policy / Glob-Grep / Playwright-DeepWiki MCP → Claude layer** and **Skill provenance / gh / Copilot / coding-standards → agnostic core**. These boundary calls are reversible via review feedback before merge.

## Test plan
- [x] `make lint` (shellcheck + shfmt + zsh syntax)
- [x] `make test` (79 bats: AGENTS.md.tmpl split + coding-standards SSOT + CLAUDE.md @-import + r06 symlink repoint + codex core symlink + gitleaks wiring; provenance test repointed to `.tmpl`)
- [x] `chezmoi diff` / `chezmoi cat`: `~/AGENTS.md` inlines coding-standards; `~/.claude/CLAUDE.md` renders `@~/AGENTS.md`; gitconfig, pre-commit (0755), gitleaks.toml deploy
- [x] `gitleaks git --staged` dry-run on this PR's diff → **no leaks**, exit 0 (no false positive on `op://` / regex examples)
- [ ] **User runtime:** `chezmoi apply` → 4 deploy targets (.claude/.claude-r06 × CLAUDE.md) + codex AGENTS.md unchanged; `@~/AGENTS.md` first-load approval (once); a `git commit` with a planted fake secret is blocked; Codex reads only the agnostic core

🤖 Generated with [Claude Code](https://claude.com/claude-code)
