### PR TITLE
fix(hooks): prevent global pre-commit hook self-recursion under core.hooksPath

### DIFF
--- a/home/dot_config/git/hooks/executable_pre-commit
+++ b/home/dot_config/git/hooks/executable_pre-commit
@@ -51,8 +51,15 @@ MSG
 fi
 
 # Chain the repo's own pre-commit hook, which core.hooksPath would otherwise
-# replace. --git-path resolves the literal .git/hooks dir (not core.hooksPath).
-local_hook="$(git rev-parse --git-path hooks/pre-commit 2>/dev/null || true)"
-if [ -n "$local_hook" ] && [ -x "$local_hook" ]; then
-  exec "$local_hook" "$@"
+# replace. IMPORTANT: `git rev-parse --git-path hooks/pre-commit` RESPECTS
+# core.hooksPath (git 2.x), so it resolves back to THIS global hook and would
+# infinite-loop via exec. Resolve the literal .git/hooks dir from --git-dir
+# instead (which ignores core.hooksPath), and skip if it points back at this
+# script (self-reference guard via -ef, defending against symlinks too).
+git_dir="$(git rev-parse --git-dir 2>/dev/null || true)"
+if [ -n "$git_dir" ]; then
+  local_hook="${git_dir}/hooks/pre-commit"
+  if [ -x "$local_hook" ] && ! [ "$local_hook" -ef "${BASH_SOURCE[0]}" ]; then
+    exec "$local_hook" "$@"
+  fi
 fi

--- a/home/dot_config/git/hooks/executable_pre-commit
+++ b/home/dot_config/git/hooks/executable_pre-commit
@@ -53,12 +53,14 @@ fi
 # Chain the repo's own pre-commit hook, which core.hooksPath would otherwise
 # replace. IMPORTANT: `git rev-parse --git-path hooks/pre-commit` RESPECTS
 # core.hooksPath (git 2.x), so it resolves back to THIS global hook and would
-# infinite-loop via exec. Resolve the literal .git/hooks dir from --git-dir
-# instead (which ignores core.hooksPath), and skip if it points back at this
-# script (self-reference guard via -ef, defending against symlinks too).
-git_dir="$(git rev-parse --git-dir 2>/dev/null || true)"
-if [ -n "$git_dir" ]; then
-  local_hook="${git_dir}/hooks/pre-commit"
+# infinite-loop via exec. Resolve the default hooks dir from --git-common-dir
+# instead: it ignores core.hooksPath (no loop) AND points at the shared .git, so
+# linked worktrees — whose per-worktree --git-dir has no hooks/ — still chain.
+# --path-format=absolute avoids a relative-path ambiguity. Skip if it points
+# back at this script (self-reference guard via -ef, covers symlink deploys too).
+common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [ -n "$common_dir" ]; then
+  local_hook="${common_dir}/hooks/pre-commit"
   if [ -x "$local_hook" ] && ! [ "$local_hook" -ef "${BASH_SOURCE[0]}" ]; then
     exec "$local_hook" "$@"
   fi

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -592,10 +592,12 @@ _gate_decision() {
   # Chains the repo's own pre-commit so core.hooksPath does not silently drop it,
   # WITHOUT self-recursion: `git rev-parse --git-path hooks/pre-commit` respects
   # core.hooksPath and would resolve back to THIS global hook (infinite loop), so
-  # the hook must resolve the literal .git dir via --git-dir and guard against
-  # self-reference with -ef.
+  # the hook must resolve the default hooks dir via --git-common-dir (ignores
+  # core.hooksPath and also works in linked worktrees) and guard self-reference
+  # with -ef against ${BASH_SOURCE[0]}.
   ! grep -q 'git-path hooks/pre-commit' "$hook"
-  grep -q 'rev-parse --git-dir' "$hook"
+  grep -q 'git-common-dir' "$hook"
+  grep -q 'BASH_SOURCE' "$hook"
   grep -q -- '-ef' "$hook"
   [ -f "${HOME_DIR}/dot_config/git/gitleaks.toml" ]
   # The global config must not carry a path allowlist (it would blind every repo).
@@ -606,7 +608,10 @@ _gate_decision() {
 # points at the global hook's own dir. Drives a real commit through a temp repo
 # whose core.hooksPath is the hook dir; the buggy idiom would exec itself forever.
 @test "global pre-commit hook does not self-recurse under core.hooksPath" {
-  command -v timeout >/dev/null 2>&1 || skip "timeout not available"
+  local to
+  if command -v timeout >/dev/null 2>&1; then to=timeout
+  elif command -v gtimeout >/dev/null 2>&1; then to=gtimeout
+  else skip "timeout not available"; fi
   local hooksdir repo
   hooksdir=$(mktemp -d)
   cp "${HOME_DIR}/dot_config/git/hooks/executable_pre-commit" "${hooksdir}/pre-commit"
@@ -620,8 +625,46 @@ _gate_decision() {
   printf 'x\n' >"${repo}/f"
   git -C "$repo" add f
   # timeout returns 124 if the hook loops; a clean commit returns 0.
-  run timeout 15 git -C "$repo" commit -q -m regression
+  run "$to" 15 git -C "$repo" commit -q -m regression
+  rm -rf "$hooksdir" "$repo"
   [ "$status" -eq 0 ]
+}
+
+# Regression (this PR): in a linked worktree the chain must still reach the
+# common-dir repo-local hook. The earlier --git-dir idiom resolved the
+# per-worktree gitdir (which has no hooks/) and silently dropped the chain;
+# --git-common-dir points at the shared .git so the repo-local hook still runs.
+@test "global pre-commit chains the common-dir hook from a linked worktree" {
+  local to
+  if command -v timeout >/dev/null 2>&1; then to=timeout
+  elif command -v gtimeout >/dev/null 2>&1; then to=gtimeout
+  else skip "timeout not available"; fi
+  local hooksdir repo wt
+  hooksdir=$(mktemp -d)
+  cp "${HOME_DIR}/dot_config/git/hooks/executable_pre-commit" "${hooksdir}/pre-commit"
+  chmod +x "${hooksdir}/pre-commit"
+  repo=$(mktemp -d)
+  git -C "$repo" init -q
+  git -C "$repo" config core.hooksPath "$hooksdir"
+  git -C "$repo" config commit.gpgsign false
+  git -C "$repo" config user.email t@example.com
+  git -C "$repo" config user.name t
+  git -C "$repo" commit --allow-empty -qm init
+  wt=$(mktemp -d)
+  git -C "$repo" worktree add -q "$wt" -b wt
+  # Repo-local hook that drops a marker into the shared .git dir when it runs.
+  printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' \
+    'printf ran >"$(git rev-parse --path-format=absolute --git-common-dir)/local-hook-ran"' \
+    >"${repo}/.git/hooks/pre-commit"
+  chmod +x "${repo}/.git/hooks/pre-commit"
+  printf 'x\n' >"${wt}/f"
+  git -C "$wt" add f
+  run "$to" 15 git -C "$wt" commit -q -m wt
+  local marker=no
+  [ -f "${repo}/.git/local-hook-ran" ] && marker=yes
+  rm -rf "$hooksdir" "$repo" "$wt"
+  [ "$status" -eq 0 ]
+  [ "$marker" = yes ]
 }
 
 # Rendered-target checks (codex review): verify the template actually produces

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -589,11 +589,39 @@ _gate_decision() {
   grep -q 'git --staged' "$hook"
   # Prefers a repo-local gitleaks config over the global one.
   grep -q '.gitleaks.toml' "$hook"
-  # Chains the repo's own pre-commit so core.hooksPath does not silently drop it.
-  grep -q 'git-path hooks/pre-commit' "$hook"
+  # Chains the repo's own pre-commit so core.hooksPath does not silently drop it,
+  # WITHOUT self-recursion: `git rev-parse --git-path hooks/pre-commit` respects
+  # core.hooksPath and would resolve back to THIS global hook (infinite loop), so
+  # the hook must resolve the literal .git dir via --git-dir and guard against
+  # self-reference with -ef.
+  ! grep -q 'git-path hooks/pre-commit' "$hook"
+  grep -q 'rev-parse --git-dir' "$hook"
+  grep -q -- '-ef' "$hook"
   [ -f "${HOME_DIR}/dot_config/git/gitleaks.toml" ]
   # The global config must not carry a path allowlist (it would blind every repo).
   ! grep -qE '^[[:space:]]*paths[[:space:]]*=' "${HOME_DIR}/dot_config/git/gitleaks.toml"
+}
+
+# Regression (this PR): the chain step must not infinite-loop when core.hooksPath
+# points at the global hook's own dir. Drives a real commit through a temp repo
+# whose core.hooksPath is the hook dir; the buggy idiom would exec itself forever.
+@test "global pre-commit hook does not self-recurse under core.hooksPath" {
+  command -v timeout >/dev/null 2>&1 || skip "timeout not available"
+  local hooksdir repo
+  hooksdir=$(mktemp -d)
+  cp "${HOME_DIR}/dot_config/git/hooks/executable_pre-commit" "${hooksdir}/pre-commit"
+  chmod +x "${hooksdir}/pre-commit"
+  repo=$(mktemp -d)
+  git -C "$repo" init -q
+  git -C "$repo" config core.hooksPath "$hooksdir"
+  git -C "$repo" config commit.gpgsign false
+  git -C "$repo" config user.email t@example.com
+  git -C "$repo" config user.name t
+  printf 'x\n' >"${repo}/f"
+  git -C "$repo" add f
+  # timeout returns 124 if the hook loops; a clean commit returns 0.
+  run timeout 15 git -C "$repo" commit -q -m regression
+  [ "$status" -eq 0 ]
 }
 
 # Rendered-target checks (codex review): verify the template actually produces


### PR DESCRIPTION
## Summary
- The global gitleaks pre-commit hook (PR #182) chained the repo-local hook via
  `git rev-parse --git-path hooks/pre-commit`. In git 2.x, `--git-path` resolves
  against `core.hooksPath`, so it returned **this global hook itself** and
  re-exec'd it in an **infinite loop** — every commit on the machine hung once
  the hook was deployed via `chezmoi apply`.
- Fix: resolve the literal `.git` dir via `git rev-parse --git-dir` (which
  ignores `core.hooksPath`) and guard against self-reference with `-ef` (covers
  symlinks too).
- Add a functional regression test driving a real commit through a temp repo
  whose `core.hooksPath` points at the hook dir; the previous idiom would loop
  and `timeout` would kill it.

## Why it matters
This is a regression in already-merged PR #182. The bug only surfaced on the
first *local* commit after `chezmoi apply` (deps PRs were merged server-side via
`gh`). It bricks all local commits machine-wide, so it ships as its own fix PR
ahead of unrelated feature work.

## Test plan
- [x] `make test` — 95 bats pass (updated hook test #62 + new regression #63)
- [x] Manual: scratch-repo commit completes in one gitleaks scan, no recursion
- [x] Deployed hook hot-patched locally to unblock commits immediately
- [ ] runtime: `make apply` re-deploys the fixed hook from source