### PR TITLE
feat(clv2): wire and enable the continuous-learning-v2 observer

### DIFF
--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -226,6 +226,19 @@
         ],
         "description": "Warn when creating non-standard scratch documentation files (TODO.md/NOTES.md/etc.) outside structured directories",
         "id": "pre:write:doc-file-warning"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.agents/skills/continuous-learning-v2/hooks/observe.sh pre",
+            "async": true,
+            "timeout": 10
+          }
+        ],
+        "description": "CLV2 observer (PreToolUse): capture tool_start to observations.jsonl and lazy-start the Haiku observer. observe.sh is invoked directly (not via the ECC observe-runner.js) because the ECC plugin root has no skills/ tree, so the runner cannot locate it; observe.sh resolves its own SKILL_ROOT from $0. async so it never adds per-tool latency.",
+        "id": "pre:observe:continuous-learning"
       }
     ],
     "PostToolUse": [
@@ -252,6 +265,19 @@
         ],
         "description": "Inject agent warnings on context exhaustion, high cost, scope creep, or tool loops",
         "id": "post:ecc-context-monitor"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.agents/skills/continuous-learning-v2/hooks/observe.sh post",
+            "async": true,
+            "timeout": 10
+          }
+        ],
+        "description": "CLV2 observer (PostToolUse): capture tool_complete to observations.jsonl and signal the observer. Direct observe.sh invocation, async — see pre:observe:continuous-learning.",
+        "id": "post:observe:continuous-learning"
       },
       {
         "matcher": "Bash|Write|Edit|MultiEdit",

--- a/home/run_onchange_after_14-enable-clv2-observer.sh.tmpl
+++ b/home/run_onchange_after_14-enable-clv2-observer.sh.tmpl
@@ -6,29 +6,43 @@
 # $CLV2_HOMUNCULUS_DIR/config.json FIRST, falling back to the skill's own config. That
 # homunculus dir is per-account runtime state — NOT chezmoi-managed — so writing the enable
 # flag there both (a) turns the observer on and (b) survives the external's 168h refresh,
-# which would otherwise clobber an edit to the skill's own config.json.
+# which would clobber an edit to the skill's own config.json.
 #
-# The cld / cld-r06 wrappers point CLV2_HOMUNCULUS_DIR at "<account>/ecc-homunculus", so we
-# enable it under each account config dir that exists. Idempotent.
+# Privacy note: with the observer on, observe.sh records tool input/output to a local
+# observations.jsonl (secret redaction + truncation are upstream observe.sh's responsibility).
+# This is local at-rest data under each homunculus dir; nothing leaves the machine.
+#
+# Homunculus dirs (all that apply): the cld / cld-r06 wrappers point CLV2_HOMUNCULUS_DIR at
+# "<account>/ecc-homunculus"; bare `claude` (no wrapper, env unset) falls back to
+# $XDG_DATA_HOME/ecc-homunculus or ~/.local/share/ecc-homunculus. Idempotent.
 set -euo pipefail
 
-if ! command -v jq >/dev/null 2>&1; then
-  echo "[clv2-observer] jq not found; skipping observer enable (re-run after mise/brew provisions jq)." >&2
-  exit 0
+# jq merge-enables without clobbering other fields. Prefer a PATH jq (brew installs it in
+# run_onchange_before_10), else the mise-managed jq (mirrors after_13's `mise exec` pattern,
+# since a fresh apply may run before the ~/.local/bin shims exist). Fail loudly rather than
+# exit 0: a silent skip would mark this run_onchange "done" and never retry once jq lands.
+if command -v jq >/dev/null 2>&1; then
+  jq_cmd=(jq)
+elif command -v mise >/dev/null 2>&1; then
+  jq_cmd=(mise exec -- jq)
+else
+  echo "[clv2-observer] neither jq nor mise found; cannot enable observer." >&2
+  exit 1
 fi
 
 # Defaults mirror the upstream skill config (continuous-learning-v2/config.json).
 enable_config='{"version":"2.1","observer":{"enabled":true,"run_interval_minutes":5,"min_observations_to_analyze":20}}'
 
-for account in "${HOME}/.claude" "${HOME}/.claude-r06"; do
-  [ -d "$account" ] || continue
-  dir="${account}/ecc-homunculus"
+_enable_in() {
+  local dir="$1"
   mkdir -p "$dir"
-  cfg="${dir}/config.json"
+  local cfg="${dir}/config.json"
   if [ -f "$cfg" ]; then
-    # Preserve any existing fields; only force observer.enabled=true.
-    tmp="$(mktemp)"
-    if jq '.observer.enabled = true' "$cfg" >"$tmp" 2>/dev/null; then
+    # Preserve any existing fields; only force observer.enabled=true. mktemp in the target
+    # dir so the mv is an atomic same-filesystem rename.
+    local tmp
+    tmp="$(mktemp "${dir}/config.json.XXXXXX")"
+    if "${jq_cmd[@]}" '.observer.enabled = true' "$cfg" >"$tmp" 2>/dev/null; then
       mv "$tmp" "$cfg"
     else
       rm -f "$tmp"
@@ -38,4 +52,19 @@ for account in "${HOME}/.claude" "${HOME}/.claude-r06"; do
     printf '%s\n' "$enable_config" >"$cfg"
   fi
   echo "[clv2-observer] observer enabled in ${cfg}" >&2
+}
+
+# Wrapper accounts: enable under each account config dir that exists.
+for account in "${HOME}/.claude" "${HOME}/.claude-r06"; do
+  if [ -d "$account" ]; then
+    _enable_in "${account}/ecc-homunculus"
+  fi
 done
+
+# Bare `claude` fallback (CLV2_HOMUNCULUS_DIR unset): only enable if the dir already exists,
+# so we don't create speculative state for a path that may never be used.
+# Use `if` (not `&&`) so a missing fallback dir does not leave the script's exit status at 1.
+fallback="${XDG_DATA_HOME:-${HOME}/.local/share}/ecc-homunculus"
+if [ -d "$fallback" ]; then
+  _enable_in "$fallback"
+fi

--- a/home/run_onchange_after_14-enable-clv2-observer.sh.tmpl
+++ b/home/run_onchange_after_14-enable-clv2-observer.sh.tmpl
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Enable the continuous-learning-v2 (CLV2) Haiku observer per account (Phase 7 PR-B, #7/#34).
+#
+# The CLV2 engine is deployed read-only via chezmoi external (PR-A) and its own config.json
+# ships observer.enabled=false. observe.sh resolves the EFFECTIVE config from
+# $CLV2_HOMUNCULUS_DIR/config.json FIRST, falling back to the skill's own config. That
+# homunculus dir is per-account runtime state — NOT chezmoi-managed — so writing the enable
+# flag there both (a) turns the observer on and (b) survives the external's 168h refresh,
+# which would otherwise clobber an edit to the skill's own config.json.
+#
+# The cld / cld-r06 wrappers point CLV2_HOMUNCULUS_DIR at "<account>/ecc-homunculus", so we
+# enable it under each account config dir that exists. Idempotent.
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[clv2-observer] jq not found; skipping observer enable (re-run after mise/brew provisions jq)." >&2
+  exit 0
+fi
+
+# Defaults mirror the upstream skill config (continuous-learning-v2/config.json).
+enable_config='{"version":"2.1","observer":{"enabled":true,"run_interval_minutes":5,"min_observations_to_analyze":20}}'
+
+for account in "${HOME}/.claude" "${HOME}/.claude-r06"; do
+  [ -d "$account" ] || continue
+  dir="${account}/ecc-homunculus"
+  mkdir -p "$dir"
+  cfg="${dir}/config.json"
+  if [ -f "$cfg" ]; then
+    # Preserve any existing fields; only force observer.enabled=true.
+    tmp="$(mktemp)"
+    if jq '.observer.enabled = true' "$cfg" >"$tmp" 2>/dev/null; then
+      mv "$tmp" "$cfg"
+    else
+      rm -f "$tmp"
+      printf '%s\n' "$enable_config" >"$cfg"
+    fi
+  else
+    printf '%s\n' "$enable_config" >"$cfg"
+  fi
+  echo "[clv2-observer] observer enabled in ${cfg}" >&2
+done

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -255,6 +255,45 @@ load helpers/setup
   [ -f "${HOME_DIR}/dot_claude/executable_ecc-hook.sh" ]
 }
 
+@test "settings.json wires the CLV2 observer as direct observe.sh hooks (pre + post)" {
+  local s="${HOME_DIR}/dot_claude/settings.json"
+  [ -f "$s" ]
+  local pre post
+  pre=$(jq -r '.hooks.PreToolUse[] | select(.id=="pre:observe:continuous-learning") | .hooks[0].command' "$s")
+  post=$(jq -r '.hooks.PostToolUse[] | select(.id=="post:observe:continuous-learning") | .hooks[0].command' "$s")
+  # Must invoke observe.sh directly with the correct phase argument.
+  [[ "$pre" == *"continuous-learning-v2/hooks/observe.sh pre"* ]]
+  [[ "$post" == *"continuous-learning-v2/hooks/observe.sh post"* ]]
+  # Must NOT go through observe-runner.js: under this layout the ECC plugin root has no
+  # skills/ tree, so the runner cannot resolve observe.sh and would silently no-op.
+  [[ "$pre" != *"observe-runner"* ]]
+  [[ "$post" != *"observe-runner"* ]]
+}
+
+@test "clv2 observer enable script is present and idempotently forces observer.enabled" {
+  local script="${HOME_DIR}/run_onchange_after_14-enable-clv2-observer.sh.tmpl"
+  [ -f "$script" ]
+  bash -n "$script"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local tmp; tmp=$(mktemp -d)
+  # Seed a pre-existing config (disabled + unrelated keys) to exercise the jq-merge branch:
+  # it must force enabled=true while preserving every other field, and stay stable on re-run.
+  mkdir -p "$tmp/.claude/ecc-homunculus"
+  printf '%s' '{"version":"2.1","observer":{"enabled":false,"run_interval_minutes":7},"custom":42}' \
+    > "$tmp/.claude/ecc-homunculus/config.json"
+  HOME="$tmp" bash "$script" >/dev/null 2>&1
+  HOME="$tmp" bash "$script" >/dev/null 2>&1
+  local cfg="$tmp/.claude/ecc-homunculus/config.json"
+  [ "$(jq -r '.observer.enabled' "$cfg")" = "true" ]
+  [ "$(jq -r '.observer.run_interval_minutes' "$cfg")" = "7" ]
+  [ "$(jq -r '.custom' "$cfg")" = "42" ]
+  # Fresh-write branch: an account dir with no prior config gets a fully-formed enabled config.
+  mkdir -p "$tmp/.claude-r06"
+  HOME="$tmp" bash "$script" >/dev/null 2>&1
+  [ "$(jq -r '.observer.enabled' "$tmp/.claude-r06/ecc-homunculus/config.json")" = "true" ]
+  rm -rf "$tmp"
+}
+
 @test "ecc governance-capture fork exists and passes node syntax check" {
   local fork="${HOME_DIR}/dot_claude/hooks-fork/governance-capture.js"
   [ -f "$fork" ]

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -258,16 +258,31 @@ load helpers/setup
 @test "settings.json wires the CLV2 observer as direct observe.sh hooks (pre + post)" {
   local s="${HOME_DIR}/dot_claude/settings.json"
   [ -f "$s" ]
-  local pre post
-  pre=$(jq -r '.hooks.PreToolUse[] | select(.id=="pre:observe:continuous-learning") | .hooks[0].command' "$s")
-  post=$(jq -r '.hooks.PostToolUse[] | select(.id=="post:observe:continuous-learning") | .hooks[0].command' "$s")
-  # Must invoke observe.sh directly with the correct phase argument.
-  [[ "$pre" == *"continuous-learning-v2/hooks/observe.sh pre"* ]]
-  [[ "$post" == *"continuous-learning-v2/hooks/observe.sh post"* ]]
-  # Must NOT go through observe-runner.js: under this layout the ECC plugin root has no
-  # skills/ tree, so the runner cannot resolve observe.sh and would silently no-op.
-  [[ "$pre" != *"observe-runner"* ]]
-  [[ "$post" != *"observe-runner"* ]]
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  # Structural assertion (not a substring grep): exactly one pre + one post observe entry,
+  # each matcher "*", a command-type hook, async, timeout 10, invoking observe.sh directly
+  # with the right phase — and NOT observe-runner.js (which can't resolve observe.sh under
+  # this layout and would silently no-op).
+  jq -e '
+    [.hooks.PreToolUse[] | select(.id=="pre:observe:continuous-learning")] as $m
+    | ($m|length)==1
+      and $m[0].matcher=="*"
+      and $m[0].hooks[0].type=="command"
+      and $m[0].hooks[0].async==true
+      and $m[0].hooks[0].timeout==10
+      and ($m[0].hooks[0].command|endswith("/continuous-learning-v2/hooks/observe.sh pre"))
+      and ($m[0].hooks[0].command|contains("observe-runner")|not)
+  ' "$s" >/dev/null
+  jq -e '
+    [.hooks.PostToolUse[] | select(.id=="post:observe:continuous-learning")] as $m
+    | ($m|length)==1
+      and $m[0].matcher=="*"
+      and $m[0].hooks[0].type=="command"
+      and $m[0].hooks[0].async==true
+      and $m[0].hooks[0].timeout==10
+      and ($m[0].hooks[0].command|endswith("/continuous-learning-v2/hooks/observe.sh post"))
+      and ($m[0].hooks[0].command|contains("observe-runner")|not)
+  ' "$s" >/dev/null
 }
 
 @test "clv2 observer enable script is present and idempotently forces observer.enabled" {
@@ -276,21 +291,29 @@ load helpers/setup
   bash -n "$script"
   command -v jq >/dev/null 2>&1 || skip "jq unavailable"
   local tmp; tmp=$(mktemp -d)
+  # Pin XDG_DATA_HOME inside the sandbox so the bare-`claude` fallback branch can never
+  # touch the developer's real ~/.local/share/ecc-homunculus.
+  local run=(env "HOME=$tmp" "XDG_DATA_HOME=$tmp/.local/share" bash "$script")
   # Seed a pre-existing config (disabled + unrelated keys) to exercise the jq-merge branch:
   # it must force enabled=true while preserving every other field, and stay stable on re-run.
   mkdir -p "$tmp/.claude/ecc-homunculus"
   printf '%s' '{"version":"2.1","observer":{"enabled":false,"run_interval_minutes":7},"custom":42}' \
     > "$tmp/.claude/ecc-homunculus/config.json"
-  HOME="$tmp" bash "$script" >/dev/null 2>&1
-  HOME="$tmp" bash "$script" >/dev/null 2>&1
+  "${run[@]}" >/dev/null 2>&1
+  "${run[@]}" >/dev/null 2>&1
   local cfg="$tmp/.claude/ecc-homunculus/config.json"
   [ "$(jq -r '.observer.enabled' "$cfg")" = "true" ]
   [ "$(jq -r '.observer.run_interval_minutes' "$cfg")" = "7" ]
   [ "$(jq -r '.custom' "$cfg")" = "42" ]
   # Fresh-write branch: an account dir with no prior config gets a fully-formed enabled config.
   mkdir -p "$tmp/.claude-r06"
-  HOME="$tmp" bash "$script" >/dev/null 2>&1
+  "${run[@]}" >/dev/null 2>&1
   [ "$(jq -r '.observer.enabled' "$tmp/.claude-r06/ecc-homunculus/config.json")" = "true" ]
+  # Bare-`claude` fallback: not created speculatively, but enabled once it exists.
+  [ ! -e "$tmp/.local/share/ecc-homunculus/config.json" ]
+  mkdir -p "$tmp/.local/share/ecc-homunculus"
+  "${run[@]}" >/dev/null 2>&1
+  [ "$(jq -r '.observer.enabled' "$tmp/.local/share/ecc-homunculus/config.json")" = "true" ]
   rm -rf "$tmp"
 }
 


### PR DESCRIPTION
## Summary

Phase 7 PR-B. PR-A (#191) deployed the CLV2 engine to `~/.agents/skills/continuous-learning-v2` via chezmoi external; this PR wires its observer into Claude Code and enables it per account. Resolves the no-op that deferred the observer from Phase 6 (the engine was off-disk then).

## Changes

- **`settings.json`**: register `observe.sh` as `PreToolUse` / `PostToolUse` hooks (matcher `*`, `async: true`, `timeout: 10`). Invoked **directly**, not via the ECC `observe-runner.js`: the ECC plugin root (`~/.agents/skills/ecc`) has no `skills/` tree, so the runner resolves `$root/skills/continuous-learning-v2/hooks/observe.sh` → nonexistent → silent no-op. `observe.sh` resolves its own `SKILL_ROOT` from `$0`, so the direct path works. `async` keeps per-tool latency at zero (upstream runs it synchronously with a 9s `spawnSync` guard).
- **`run_onchange_after_14-enable-clv2-observer.sh.tmpl`** (new): idempotently force `observer.enabled=true` in each account's `$CLV2_HOMUNCULUS_DIR/config.json` (`~/.claude{,-r06}/ecc-homunculus`). `observe.sh` reads that homunculus config **before** the skill's own (which ships `enabled:false`), so writing there both enables the observer and **survives the external's 168h refresh** — editing the skill's own config.json would be clobbered. jq-merge preserves any other fields.
- **`tests/files.bats`**: assert the observer hooks are direct `observe.sh` (with a **negative assert on `observe-runner.js`** to guard the no-op regression), and that the enable script is idempotent and preserves unrelated config fields.

## Verification

- `make test` ✅ (100 bats tests, +2 new).
- `make lint` ✅.
- **End-to-end smoke**: piping a sample `PreToolUse` payload to `observe.sh pre` (with an enabled homunculus config) exits 0, appends to `observations.jsonl`, and lazy-starts the observer (`.observer.pid` written). Observer process killed + temp dirs cleaned after the check.

## Notes / perf

- The observer spawns a Haiku analysis session every `run_interval_minutes` (5) once `min_observations_to_analyze` (20) accumulate — a background cost inherent to CLV2, opted into for this track. The hooks themselves are `async`, so they add no synchronous per-tool latency.
- The instinct→skill flow (SessionStart push, statusline 🧬N, `/evolve` wiring) is **PR-F**, not this PR.

## User runtime checklist (post-merge `make apply`)

- [ ] `make apply` runs the enable script → `~/.claude/ecc-homunculus/config.json` (and `-r06`) has `observer.enabled: true`
- [ ] In a `cld` / `cld-r06` session, tool calls append to `observations.jsonl` under the account's homunculus dir
- [ ] After ~20 observations the Haiku observer starts and begins writing instinct YAML; `.observer.pid` present
- [ ] Both accounts stay isolated (each writes to its own `ecc-homunculus`)