### PR TITLE
feat(cli): ecc-status / ecc-sessions / ecc-work-items as node:sqlite readers

### DIFF
--- a/home/dot_claude/hooks-fork/ecc-state-reader.js
+++ b/home/dot_claude/hooks-fork/ecc-state-reader.js
@@ -80,8 +80,10 @@ function buildStatus(db) {
   const activeSessions = tableExists(db, 'sessions')
     ? db.prepare("SELECT count(*) c FROM sessions WHERE ended_at IS NULL AND state IN ('active','running','idle')").get().c
     : 0;
+  // Mirror ECC's CLOSED_WORK_ITEM_STATUSES (queries.js) exactly so the count matches ECC's
+  // own dashboard — resolved/merged are closed there, not open.
   const openWorkItems = tableExists(db, 'work_items')
-    ? db.prepare("SELECT count(*) c FROM work_items WHERE status NOT IN ('closed','done','cancelled')").get().c
+    ? db.prepare("SELECT count(*) c FROM work_items WHERE status NOT IN ('done','closed','resolved','merged','cancelled')").get().c
     : 0;
   return {
     pendingGovernanceEvents: pending,
@@ -133,8 +135,16 @@ function renderWorkItems(rows) {
     .join('\n');
 }
 
+const SUBCOMMANDS = new Set(['status', 'sessions', 'work-items', 'work_items']);
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
+  // Validate the subcommand BEFORE touching the db, so an unknown subcommand always reports
+  // exit 2 — even on a fresh account where openDb() would otherwise short-circuit to a note.
+  if (!SUBCOMMANDS.has(args.sub)) {
+    process.stderr.write(`Unknown subcommand: ${args.sub} (use status|sessions|work-items)\n`);
+    return 2;
+  }
   const dbPath = args.db || stateDbPath();
 
   const opened = openDb(dbPath);
@@ -161,9 +171,6 @@ function main() {
         payload = { workItems: listWorkItems(db) };
         text = renderWorkItems(payload.workItems);
         break;
-      default:
-        process.stderr.write(`Unknown subcommand: ${args.sub} (use status|sessions|work-items)\n`);
-        return 2;
     }
     process.stdout.write((args.json ? JSON.stringify(payload) : text) + '\n');
     return 0;
@@ -172,4 +179,6 @@ function main() {
   }
 }
 
-process.exit(main());
+// Set exitCode rather than process.exit() so a large buffered stdout write drains fully
+// before the process ends (process.exit() can truncate it).
+process.exitCode = main();

--- a/home/dot_claude/hooks-fork/ecc-state-reader.js
+++ b/home/dot_claude/hooks-fork/ecc-state-reader.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+'use strict';
+
+// ecc-* CLI reader (Phase 7 PR-C, #4/#5).
+//
+// Renders ecc-status / ecc-sessions / ecc-work-items from the per-account ECC state.db that
+// the governance-capture fork (PR4, hooks-fork/governance-capture.js) writes via node:sqlite.
+//
+// Why a fork instead of ECC's own CLI: ECC's query layer
+// (scripts/lib/state-store/queries.js) loads ./schema, which pulls in `ajv` — absent here
+// because the chezmoi external fetches only ECC's hook/lib *source*, not node_modules, and we
+// deliberately do not provision sql.js/ajv (the adopted skills need neither). So the SELECTs
+// are reimplemented on the built-in node:sqlite, mirroring governance-capture.js's rationale.
+//
+// Read-only. Account isolation comes from ECC_AGENT_DATA_HOME (exported by the cld / cld-r06
+// wrappers): cld reads ~/.claude/ecc/state.db, cld-r06 reads ~/.claude-r06/ecc/state.db.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Mirror governance-capture.js stateDbPath() exactly, so the reader sees what the writer wrote.
+function stateDbPath() {
+  const base = process.env.ECC_AGENT_DATA_HOME || path.join(os.homedir(), '.claude');
+  return path.join(base, 'ecc', 'state.db');
+}
+
+function parseArgs(argv) {
+  const out = { sub: null, db: null, json: false };
+  const rest = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') out.json = true;
+    else if (a === '--db') out.db = argv[++i];
+    else rest.push(a);
+  }
+  out.sub = rest[0] || 'status';
+  return out;
+}
+
+// Returns { db } on success, or { note } for the graceful "nothing to show" cases.
+function openDb(dbPath) {
+  let DatabaseSync;
+  try {
+    ({ DatabaseSync } = require('node:sqlite'));
+  } catch {
+    return { note: 'node:sqlite unavailable (needs Node >= 22.5); cannot read state.db.' };
+  }
+  // readOnly throws if the file is missing, so check first and report gracefully.
+  if (!fs.existsSync(dbPath)) {
+    return { note: `No state.db at ${dbPath} — this account has not captured any events yet.` };
+  }
+  try {
+    const db = new DatabaseSync(dbPath, { readOnly: true, enableForeignKeyConstraints: false });
+    return { db };
+  } catch (e) {
+    return { note: `Cannot open ${dbPath}: ${e.message}` };
+  }
+}
+
+function tableExists(db, name) {
+  return !!db.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?").get(name);
+}
+
+function buildStatus(db) {
+  const hasGov = tableExists(db, 'governance_events');
+  const pending = hasGov
+    ? db.prepare('SELECT count(*) c FROM governance_events WHERE resolved_at IS NULL').get().c
+    : 0;
+  const byType = hasGov
+    ? db.prepare(
+        "SELECT event_type, count(*) c FROM governance_events WHERE resolved_at IS NULL GROUP BY event_type ORDER BY c DESC"
+      ).all()
+    : [];
+  const recent = hasGov
+    ? db.prepare(
+        "SELECT event_type, created_at FROM governance_events WHERE resolved_at IS NULL ORDER BY created_at DESC LIMIT 5"
+      ).all()
+    : [];
+  const activeSessions = tableExists(db, 'sessions')
+    ? db.prepare("SELECT count(*) c FROM sessions WHERE ended_at IS NULL AND state IN ('active','running','idle')").get().c
+    : 0;
+  const openWorkItems = tableExists(db, 'work_items')
+    ? db.prepare("SELECT count(*) c FROM work_items WHERE status NOT IN ('closed','done','cancelled')").get().c
+    : 0;
+  return {
+    pendingGovernanceEvents: pending,
+    governanceByType: byType,
+    recentGovernance: recent,
+    activeSessions,
+    openWorkItems,
+  };
+}
+
+function listSessions(db, limit = 20) {
+  if (!tableExists(db, 'sessions')) return [];
+  return db
+    .prepare('SELECT id, harness, state, repo_root, started_at, ended_at FROM sessions ORDER BY started_at DESC LIMIT ?')
+    .all(limit);
+}
+
+function listWorkItems(db, limit = 50) {
+  if (!tableExists(db, 'work_items')) return [];
+  return db
+    .prepare('SELECT id, source, title, status, priority, url, updated_at FROM work_items ORDER BY updated_at DESC LIMIT ?')
+    .all(limit);
+}
+
+function renderStatus(s) {
+  const lines = [];
+  lines.push(`Pending governance events: ${s.pendingGovernanceEvents}`);
+  for (const r of s.governanceByType) lines.push(`  ${r.event_type}: ${r.c}`);
+  if (s.recentGovernance.length) {
+    lines.push('Most recent pending:');
+    for (const r of s.recentGovernance) lines.push(`  ${r.created_at}  ${r.event_type}`);
+  }
+  lines.push(`Active sessions: ${s.activeSessions}`);
+  lines.push(`Open work items: ${s.openWorkItems}`);
+  return lines.join('\n');
+}
+
+function renderSessions(rows) {
+  if (!rows.length) return 'No sessions recorded.';
+  return rows
+    .map((r) => `${r.started_at || '?'}  ${r.state || '?'}  ${r.harness || '?'}  ${r.repo_root || ''}`)
+    .join('\n');
+}
+
+function renderWorkItems(rows) {
+  if (!rows.length) return 'No work items.';
+  return rows
+    .map((r) => `[${r.status || '?'}] ${r.title || '(untitled)'}  ${r.source || ''}  ${r.url || ''}`)
+    .join('\n');
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const dbPath = args.db || stateDbPath();
+
+  const opened = openDb(dbPath);
+  if (opened.note) {
+    // Graceful: no data is a normal state, not an error.
+    process.stdout.write((args.json ? JSON.stringify({ note: opened.note }) : opened.note) + '\n');
+    return 0;
+  }
+  const db = opened.db;
+  try {
+    let payload;
+    let text;
+    switch (args.sub) {
+      case 'status':
+        payload = buildStatus(db);
+        text = renderStatus(payload);
+        break;
+      case 'sessions':
+        payload = { sessions: listSessions(db) };
+        text = renderSessions(payload.sessions);
+        break;
+      case 'work-items':
+      case 'work_items':
+        payload = { workItems: listWorkItems(db) };
+        text = renderWorkItems(payload.workItems);
+        break;
+      default:
+        process.stderr.write(`Unknown subcommand: ${args.sub} (use status|sessions|work-items)\n`);
+        return 2;
+    }
+    process.stdout.write((args.json ? JSON.stringify(payload) : text) + '\n');
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
+process.exit(main());

--- a/home/dot_config/zsh/claude.zsh
+++ b/home/dot_config/zsh/claude.zsh
@@ -33,6 +33,16 @@ alias hcld-r06='_claude_with_home "$HOME/.claude-r06" happy claude'
 #   ECC_DISABLED_HOOKS=pre:config-protection,pre:edit-write:gateguard-fact-force cld-r06
 alias claude-config='ECC_DISABLED_HOOKS=pre:config-protection,pre:edit-write:gateguard-fact-force _claude_with_home "$HOME/.claude" claude'
 
+# ecc-* CLIs (PR-C, #4/#5): inspect the per-account ECC governance state.db that the
+# governance-capture fork writes. Account is selected by ECC_AGENT_DATA_HOME; the reader
+# defaults to ~/.claude when it is unset, so a plain shell shows the default account. To
+# inspect the r06 account, prefix it: `ECC_AGENT_DATA_HOME=$HOME/.claude-r06 ecc-status`.
+# Functions (not aliases) so flags like --json pass through. The reader lives under the
+# default account dir and is shared by both accounts (same as the governance-capture fork).
+ecc-status()     { node "$HOME/.claude/hooks-fork/ecc-state-reader.js" status "$@"; }
+ecc-sessions()   { node "$HOME/.claude/hooks-fork/ecc-state-reader.js" sessions "$@"; }
+ecc-work-items() { node "$HOME/.claude/hooks-fork/ecc-state-reader.js" work-items "$@"; }
+
 alias ccdcmds='ccdcommands'
 
 function ccdpaths() {

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -404,6 +404,35 @@ load helpers/setup
   rm -rf "$tmp"
 }
 
+@test "ecc-state-reader counts only non-closed work items (ECC status domain)" {
+  local reader="${HOME_DIR}/dot_claude/hooks-fork/ecc-state-reader.js"
+  node -e 'require("node:sqlite")' 2>/dev/null || skip "node:sqlite unavailable"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local tmp; tmp=$(mktemp -d); mkdir -p "$tmp/ecc"
+  # Only "open" is non-closed; resolved/merged/done/cancelled are all closed in ECC's domain.
+  node -e '
+    const {DatabaseSync}=require("node:sqlite");
+    const db=new DatabaseSync(process.argv[1],{enableForeignKeyConstraints:false});
+    db.exec("CREATE TABLE work_items(id TEXT PRIMARY KEY, source TEXT NOT NULL, source_id TEXT, title TEXT NOT NULL, status TEXT NOT NULL, priority TEXT, url TEXT, owner TEXT, repo_root TEXT, session_id TEXT, metadata TEXT, created_at TEXT, updated_at TEXT NOT NULL)");
+    const ins=db.prepare("INSERT INTO work_items(id,source,title,status,updated_at) VALUES(?,?,?,?,?)");
+    for (const [id,st] of [["w1","open"],["w2","resolved"],["w3","merged"],["w4","done"],["w5","cancelled"]]) ins.run(id,"gh",id,st,"2026-01-01");
+    db.close();
+  ' "$tmp/ecc/state.db"
+  local out; out=$(ECC_AGENT_DATA_HOME="$tmp" node "$reader" status --json)
+  [ "$(echo "$out" | jq -r '.openWorkItems')" = "1" ]
+  rm -rf "$tmp"
+}
+
+@test "ecc-state-reader rejects an unknown subcommand with exit 2 even on a fresh account" {
+  local reader="${HOME_DIR}/dot_claude/hooks-fork/ecc-state-reader.js"
+  node -e 'require("node:sqlite")' 2>/dev/null || skip "node:sqlite unavailable"
+  local tmp; tmp=$(mktemp -d)
+  # No state.db: validation must still fire before the graceful "no db" path.
+  run env "ECC_AGENT_DATA_HOME=$tmp" node "$reader" bogus-subcommand
+  [ "$status" -eq 2 ]
+  rm -rf "$tmp"
+}
+
 @test "claude.zsh defines the ecc-* reader functions" {
   grep -q 'ecc-status()' "${HOME_DIR}/dot_config/zsh/claude.zsh"
   grep -q 'ecc-sessions()' "${HOME_DIR}/dot_config/zsh/claude.zsh"

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -363,6 +363,54 @@ load helpers/setup
   node --check "$fork"
 }
 
+@test "ecc-state-reader aggregates pending governance events from a sandbox state.db" {
+  local reader="${HOME_DIR}/dot_claude/hooks-fork/ecc-state-reader.js"
+  [ -f "$reader" ]
+  node --check "$reader"
+  node -e 'require("node:sqlite")' 2>/dev/null || skip "node:sqlite unavailable"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local tmp; tmp=$(mktemp -d)
+  mkdir -p "$tmp/ecc"
+  # Seed 2 pending + 1 resolved event; the reader must count only the 2 pending ones.
+  node -e '
+    const {DatabaseSync}=require("node:sqlite");
+    const db=new DatabaseSync(process.argv[1],{enableForeignKeyConstraints:false});
+    db.exec("CREATE TABLE governance_events(id TEXT PRIMARY KEY, session_id TEXT, event_type TEXT NOT NULL, payload TEXT NOT NULL, resolved_at TEXT, resolution TEXT, created_at TEXT NOT NULL)");
+    const ins=db.prepare("INSERT INTO governance_events(id,session_id,event_type,payload,resolved_at,created_at) VALUES(?,?,?,?,?,?)");
+    ins.run("1","s","approval_requested","{}",null,"2026-01-01T01:00:00Z");
+    ins.run("2","s","secret_detected","{}",null,"2026-01-01T02:00:00Z");
+    ins.run("3","s","approval_requested","{}","2026-01-01T03:00:00Z","2026-01-01T00:30:00Z");
+    db.close();
+  ' "$tmp/ecc/state.db"
+  local out
+  out=$(ECC_AGENT_DATA_HOME="$tmp" node "$reader" status --json)
+  [ "$(echo "$out" | jq -r '.pendingGovernanceEvents')" = "2" ]
+  [ "$(echo "$out" | jq -r '[.governanceByType[].c] | add')" = "2" ]
+  # sessions / work-items tables are absent in this sandbox → graceful empty, never a crash.
+  [ "$(ECC_AGENT_DATA_HOME="$tmp" node "$reader" sessions)" = "No sessions recorded." ]
+  [ "$(ECC_AGENT_DATA_HOME="$tmp" node "$reader" work-items)" = "No work items." ]
+  rm -rf "$tmp"
+}
+
+@test "ecc-state-reader is graceful when state.db is absent and creates nothing" {
+  local reader="${HOME_DIR}/dot_claude/hooks-fork/ecc-state-reader.js"
+  node -e 'require("node:sqlite")' 2>/dev/null || skip "node:sqlite unavailable"
+  local tmp; tmp=$(mktemp -d)
+  run env "ECC_AGENT_DATA_HOME=$tmp" node "$reader" status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No state.db"* ]]
+  # A read-only CLI must never materialize a database on a fresh account.
+  [ ! -e "$tmp/ecc/state.db" ]
+  rm -rf "$tmp"
+}
+
+@test "claude.zsh defines the ecc-* reader functions" {
+  grep -q 'ecc-status()' "${HOME_DIR}/dot_config/zsh/claude.zsh"
+  grep -q 'ecc-sessions()' "${HOME_DIR}/dot_config/zsh/claude.zsh"
+  grep -q 'ecc-work-items()' "${HOME_DIR}/dot_config/zsh/claude.zsh"
+  grep -q 'ecc-state-reader.js' "${HOME_DIR}/dot_config/zsh/claude.zsh"
+}
+
 # Regression guard: a bare process.exit() after stdout.write() truncates output
 # larger than the OS pipe buffer (~64 KB). The fork must pass the PostToolUse Bash
 # payload through byte-for-byte regardless of size. No ECC runtime needed (logging


### PR DESCRIPTION
## Summary

Phase 7 PR-C (#4/#5). Surfaces the per-account ECC governance `state.db` (written by the PR4 `governance-capture` fork) through three CLIs, **without** ECC's `sql.js`/`ajv` query layer — which this project deliberately does not provision (the adopted skills need neither).

## Changes

- **`hooks-fork/ecc-state-reader.js`** (new): a read-only `node:sqlite` reader. ECC's own `scripts/lib/state-store/queries.js` can't be `require`d here — it loads `./schema` → `ajv`, absent because the chezmoi external fetches source, not `node_modules`. So the SELECTs are reimplemented on the built-in `node:sqlite`, mirroring the `governance-capture` fork's rationale. `stateDbPath()` matches the fork exactly (`$ECC_AGENT_DATA_HOME/ecc/state.db`).
  - `status`: pending governance events + per-type breakdown (`approval_requested` / `secret_detected` / `security_finding`) + active sessions / open work items.
  - `sessions` / `work-items`: render empty in this environment (the tables exist but have no writer — ECC's session/work-item ingest is not deployed). Stated plainly rather than faked.
  - Graceful: missing db or Node < 22.5 → exit 0 with a note, **never creates a db**. Opens `readOnly`.
- **`claude.zsh`**: `ecc-status` / `ecc-sessions` / `ecc-work-items` functions (so `--json` passes through). Account is selected by `ECC_AGENT_DATA_HOME` (defaults to `~/.claude`); prefix `ECC_AGENT_DATA_HOME=$HOME/.claude-r06` for the r06 account.
- **`files.bats`**: aggregation (pending count **excludes resolved**), graceful-absent (creates nothing), and function-presence tests.

## Verification

- `make lint` ✅ / `make test` ✅ (103 bats, +3 new).
- Smoke against a sandbox `state.db`: `status --json` → `pendingGovernanceEvents: 2` (correctly excludes a resolved event), correct per-type counts; `sessions`/`work-items` → empty messages; absent-db → graceful exit 0.

## Notes

- Only `ecc-status` carries live signal today (governance pending). `ecc-sessions` / `ecc-work-items` are wired for when/if ECC's session & work-item writers are adopted; until then they honestly report empty.

## User runtime checklist (post-merge `make apply`)

- [ ] `ecc-status` in a `cld` shell shows the pending governance count for `~/.claude/ecc/state.db`
- [ ] `ECC_AGENT_DATA_HOME=$HOME/.claude-r06 ecc-status` (or a `cld-r06` shell) shows the r06 account's count
- [ ] `ecc-sessions` / `ecc-work-items` report empty without error
- [ ] On an account with no captured events, `ecc-status` prints the "No state.db" note and exits 0