### PR TITLE
feat(tools): provision dmux via mise npm backend (security-reviewed)

### DIFF
--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -40,15 +40,16 @@ zoxide = "0.9.9"
 # (electron/slack/dogfood/...) via `agent-browser skills get`, so they are loaded at
 # runtime instead of being vendored; only the discovery stub is chezmoi-managed.
 "npm:agent-browser" = "0.29.1"
+# dmux (standardagents/dmux): a tmux-based pane manager for orchestrating parallel AI
+# agent sessions; backs the dmux-workflows skill. Security-reviewed before adoption: MIT,
+# and the published package declares no preinstall/install/postinstall/prepare lifecycle
+# scripts (its build/release steps run only at publish time, never on `npm install`),
+# mainstream deps (ink/react/chalk/chokidar). Requires tmux, already provisioned above.
+"npm:dmux" = "5.9.0"
 # happy (slopus/happy): a wrapper that runs Claude Code / Codex with phone control and
 # end-to-end encryption (`happy claude` / `happy codex`). CLI only; the mobile/web apps
 # are installed separately and paired at runtime.
 "npm:happy" = "1.1.10"
-# dmux (standardagents/dmux): a tmux-based pane manager for orchestrating parallel AI
-# agent sessions; backs the dmux-workflows skill. Security-reviewed before adoption: MIT,
-# no install/postinstall/prepare lifecycle scripts (build steps run only at publish time),
-# mainstream deps (ink/react/chalk/chokidar). Requires tmux, already provisioned above.
-"npm:dmux" = "5.9.0"
 
 [settings]
 # Pin precompiled CPython to a flavor that ships lib/; latest mise otherwise

--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -44,6 +44,11 @@ zoxide = "0.9.9"
 # end-to-end encryption (`happy claude` / `happy codex`). CLI only; the mobile/web apps
 # are installed separately and paired at runtime.
 "npm:happy" = "1.1.10"
+# dmux (standardagents/dmux): a tmux-based pane manager for orchestrating parallel AI
+# agent sessions; backs the dmux-workflows skill. Security-reviewed before adoption: MIT,
+# no install/postinstall/prepare lifecycle scripts (build steps run only at publish time),
+# mainstream deps (ink/react/chalk/chokidar). Requires tmux, already provisioned above.
+"npm:dmux" = "5.9.0"
 
 [settings]
 # Pin precompiled CPython to a flavor that ships lib/; latest mise otherwise

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -503,6 +503,12 @@ load helpers/setup
   [ -f "${HOME_DIR}/run_onchange_after_12-setup-mise.sh.tmpl" ]
 }
 
+@test "mise config declares dmux as a pinned npm-backed CLI" {
+  local config="${HOME_DIR}/dot_config/mise/config.toml"
+  # dmux backs the dmux-workflows skill; provisioned via the npm backend at a fixed version.
+  grep -Eq '^"npm:dmux"[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$config"
+}
+
 @test "mcp setup registers both servers as user scope for every account config dir" {
   local script="${HOME_DIR}/run_onchange_after_13-setup-mcp.sh.tmpl"
   [ -f "$script" ]

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -505,8 +505,11 @@ load helpers/setup
 
 @test "mise config declares dmux as a pinned npm-backed CLI" {
   local config="${HOME_DIR}/dot_config/mise/config.toml"
-  # dmux backs the dmux-workflows skill; provisioned via the npm backend at a fixed version.
-  grep -Eq '^"npm:dmux"[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$config"
+  # dmux backs the dmux-workflows skill; provisioned via the npm backend. The trailing
+  # quote pins a fixed SemVer core (X.Y.Z) — ranges and pre-releases are intentionally
+  # rejected so mise resolves a single immutable version. The leading [[:space:]]* keeps
+  # the guard robust if the key is ever indented under [tools].
+  grep -Eq '^[[:space:]]*"npm:dmux"[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$config"
 }
 
 @test "mcp setup registers both servers as user scope for every account config dir" {


### PR DESCRIPTION
## Summary

Provisions **dmux** (`standardagents/dmux`, MIT) via the mise npm backend so the
adopted `dmux-workflows` skill has its runtime dependency available. Completes the
tool-provisioning leg of Phase 7 (#16 AgentShield / #18 dmux).

- `home/dot_config/mise/config.toml`: add `"npm:dmux" = "5.9.0"` (pinned), alongside
  the existing `npm:agent-browser` / `npm:happy` CLIs. dmux is a tmux-based pane
  manager for orchestrating parallel agent sessions; **tmux is already provisioned**
  in the same config.
- `tests/files.bats`: regression guard asserting dmux is declared at a fixed SemVer.

## Security review (dmux@5.9.0)

Reviewed before adoption per the third-party intake policy:

- **License**: MIT, repository matches (`git+https://github.com/standardagents/dmux.git`).
- **Install footprint**: no `install` / `preinstall` / `postinstall` / `prepare`
  lifecycle scripts — build steps (`prepack`, `prepublishOnly`, `prerelease`) run only
  at publish time on the maintainer's machine, never on the consumer's `npm install`.
- **Dependencies**: mainstream only (ink/react/chalk/chokidar/p-queue/qrcode-terminal/
  string-width/cli-highlight/vue).
- **Runtime**: requires `tmux`, already pinned in this mise config.

## AgentShield (#16) — intentionally no dotfiles change

The `security-scan` skill invokes AgentShield via `npx ecc-agentshield scan` (no
install needed; the skill documents the npx fallback). Per decision F-7 it stays
npx-only with zero install footprint, so this PR adds nothing for it.

## Verification

- `make lint` — pass (shellcheck / shfmt / zsh syntax)
- `bats tests/files.bats` — 74/74 pass (incl. new dmux declaration test)
- TOML validity + pinned version confirmed