### PR TITLE
feat(mcp): declare exa + firecrawl user-scope MCP with 1Password-injected keys

### DIFF
--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -64,6 +64,7 @@ jobs:
           mkdir -p /tmp/chezmoi-excluded
           for f in \
             home/private_dot_aws/config.tmpl \
+            home/dot_config/zsh/private_claude-secrets.zsh.tmpl \
             home/run_once_before_00-install-prerequisites.sh.tmpl \
             home/run_onchange_before_10-brew-bundle.sh.tmpl \
             home/run_once_after_11-validate-1password.sh.tmpl \
@@ -243,6 +244,7 @@ jobs:
           mkdir -p /tmp/chezmoi-excluded
           for f in \
             home/private_dot_aws/config.tmpl \
+            home/dot_config/zsh/private_claude-secrets.zsh.tmpl \
             home/run_once_before_00-install-prerequisites.sh.tmpl \
             home/run_onchange_before_10-brew-bundle.sh.tmpl \
             home/run_once_after_11-validate-1password.sh.tmpl; do

--- a/home/dot_config/zsh/claude.zsh
+++ b/home/dot_config/zsh/claude.zsh
@@ -3,17 +3,29 @@
 # cld-r06 never share sessions, governance state.db, instincts, or hook caches.
 # The command to run is passed after the home dir ("claude ..." or "happy claude ..."),
 # so the happy wrapper inherits the exact same per-account environment.
+
+# MCP API keys (exa, firecrawl) rendered from 1Password into a 0600 file. Sourced (not
+# exported) so the keys stay out of the general shell environment; _claude_with_home re-exports
+# them scoped to the claude subprocess. Absent until `chezmoi apply` provisions it, in which
+# case the MCP servers just launch without a key.
+[[ -r "${HOME}/.config/zsh/claude-secrets.zsh" ]] && source "${HOME}/.config/zsh/claude-secrets.zsh"
+
 _claude_with_home() {
   local home_dir="$1"
   shift
   # Default to plain `claude` when no command is given, so a direct call still launches
   # Claude Code (the aliases always pass an explicit command).
   (($#)) || set -- claude
+  # EXA_API_KEY/FIRECRAWL_API_KEY are exported here (scoped to "$@") so Claude Code can expand
+  # the "${EXA_API_KEY}" / "${FIRECRAWL_API_KEY}" placeholders in its MCP env at spawn. The :-
+  # default keeps this safe when the secrets file is absent.
   CLAUDE_CONFIG_DIR="$home_dir" \
     ECC_AGENT_DATA_HOME="$home_dir" \
     CLV2_HOMUNCULUS_DIR="$home_dir/ecc-homunculus" \
     ECC_MCP_HEALTH_STATE_PATH="$home_dir/mcp-health-cache.json" \
     GATEGUARD_STATE_DIR="$home_dir/.gateguard" \
+    EXA_API_KEY="${EXA_API_KEY:-}" \
+    FIRECRAWL_API_KEY="${FIRECRAWL_API_KEY:-}" \
     "$@"
 }
 alias cld='_claude_with_home "$HOME/.claude" claude'

--- a/home/dot_config/zsh/private_claude-secrets.zsh.tmpl
+++ b/home/dot_config/zsh/private_claude-secrets.zsh.tmpl
@@ -7,7 +7,13 @@
 #
 # We deliberately do NOT `export` here: that would leak the keys into every child process of
 # the interactive shell. Instead _claude_with_home (dot_config/zsh/claude.zsh) re-exports them
-# scoped to the claude subprocess only. claude.zsh sources this file if present, so a machine
-# without these 1Password items simply runs the MCP servers without a key (graceful degrade).
-EXA_API_KEY={{ onepasswordRead "op://kryota.dev/Dotfiles - Exa API/credential" | quote }}
-FIRECRAWL_API_KEY={{ onepasswordRead "op://kryota.dev/Dotfiles - Firecrawl API/credential" | quote }}
+# scoped to the claude subprocess only. The values are single-quoted (squote, not quote) so the
+# shell treats them as literals — a key containing $ or a backtick cannot trigger expansion or
+# command substitution when claude.zsh sources this file.
+#
+# `chezmoi apply` requires the two 1Password items (run_once_after_11 validates them and
+# onepasswordRead fails otherwise), so apply is not graceful about missing items. The graceful
+# path is purely at runtime: claude.zsh only sources this file if it exists and otherwise falls
+# back to an empty key.
+EXA_API_KEY={{ onepasswordRead "op://kryota.dev/Dotfiles - Exa API/credential" | squote }}
+FIRECRAWL_API_KEY={{ onepasswordRead "op://kryota.dev/Dotfiles - Firecrawl API/credential" | squote }}

--- a/home/dot_config/zsh/private_claude-secrets.zsh.tmpl
+++ b/home/dot_config/zsh/private_claude-secrets.zsh.tmpl
@@ -1,0 +1,13 @@
+# Claude Code MCP API keys, rendered from 1Password at `chezmoi apply` (mode 0600).
+#
+# These back the exa / firecrawl user-scope MCP servers (run_onchange_after_13-setup-mcp).
+# Those servers store only the literal "${EXA_API_KEY}" / "${FIRECRAWL_API_KEY}" placeholders
+# in .claude.json; Claude Code expands them from the process environment at server spawn, so
+# the keys must be present in the env of the shell that launches claude.
+#
+# We deliberately do NOT `export` here: that would leak the keys into every child process of
+# the interactive shell. Instead _claude_with_home (dot_config/zsh/claude.zsh) re-exports them
+# scoped to the claude subprocess only. claude.zsh sources this file if present, so a machine
+# without these 1Password items simply runs the MCP servers without a key (graceful degrade).
+EXA_API_KEY={{ onepasswordRead "op://kryota.dev/Dotfiles - Exa API/credential" | quote }}
+FIRECRAWL_API_KEY={{ onepasswordRead "op://kryota.dev/Dotfiles - Firecrawl API/credential" | quote }}

--- a/home/run_once_after_11-validate-1password.sh.tmpl
+++ b/home/run_once_after_11-validate-1password.sh.tmpl
@@ -27,6 +27,10 @@ echo "==> Verifying required 1Password items exist..."
 
 ITEMS=(
   "op://kryota.dev/Dotfiles - AWS Config/notesPlain"
+  # API keys for the exa / firecrawl user-scope MCP servers (rendered into the 0600
+  # ~/.config/zsh/claude-secrets.zsh). Create these as items exposing a `credential` field.
+  "op://kryota.dev/Dotfiles - Exa API/credential"
+  "op://kryota.dev/Dotfiles - Firecrawl API/credential"
 )
 
 for item in "${ITEMS[@]}"; do

--- a/home/run_onchange_after_13-setup-mcp.sh.tmpl
+++ b/home/run_onchange_after_13-setup-mcp.sh.tmpl
@@ -41,14 +41,19 @@ config_dirs=("$HOME/.claude" "$HOME/.claude-r06")
 # spawn time from the per-account env set by _claude_with_home. Single-quoted here so the shell
 # stores the literal placeholder rather than expanding it now. Keep in sync with the project's
 # .mcp.json removal of context7/deepwiki.
+#
+# exa/firecrawl are version-pinned: they receive an API key in their env, so we shrink the
+# supply-chain surface by spawning a known version rather than whatever "latest" npx resolves.
+# Bumping the pin re-keys this run_onchange (intentional updates only). context7/deepwiki carry
+# no secret, so they stay on latest to track upstream tool changes.
 mcp_names=("context7" "deepwiki" "exa" "firecrawl")
 # shellcheck disable=SC2016  # the ${EXA_API_KEY}/${FIRECRAWL_API_KEY} placeholders are stored
 # literally on purpose: Claude Code expands them at server spawn, not this script.
 mcp_configs=(
   '{"type":"stdio","command":"npx","args":["-y","@upstash/context7-mcp"]}'
   '{"type":"stdio","command":"npx","args":["-y","mcp-remote","https://mcp.deepwiki.com/mcp"]}'
-  '{"type":"stdio","command":"npx","args":["-y","exa-mcp-server"],"env":{"EXA_API_KEY":"${EXA_API_KEY}"}}'
-  '{"type":"stdio","command":"npx","args":["-y","firecrawl-mcp"],"env":{"FIRECRAWL_API_KEY":"${FIRECRAWL_API_KEY}"}}'
+  '{"type":"stdio","command":"npx","args":["-y","exa-mcp-server@3.2.1"],"env":{"EXA_API_KEY":"${EXA_API_KEY}"}}'
+  '{"type":"stdio","command":"npx","args":["-y","firecrawl-mcp@3.22.0"],"env":{"FIRECRAWL_API_KEY":"${FIRECRAWL_API_KEY}"}}'
 )
 
 failed=0

--- a/home/run_onchange_after_13-setup-mcp.sh.tmpl
+++ b/home/run_onchange_after_13-setup-mcp.sh.tmpl
@@ -13,9 +13,17 @@ set -euo pipefail
 # ~/.local/bin/claude launcher symlink is created (run_once_after_16), so `command -v claude`
 # is not yet reliable on a fresh apply. mise + the mise-installed claude are both present by 13.
 #
-# Only globally-useful servers belong here: context7 (library docs) and deepwiki (repo Q&A)
-# are wanted in every project. Project-specific servers (e.g. spec-workflow) stay in each
-# repo's own .mcp.json. claude.ai connectors and the Chrome extension are configured manually.
+# Only globally-useful servers belong here: context7 (library docs), deepwiki (repo Q&A),
+# exa (neural web/code search) and firecrawl (web scraping/crawling) are wanted in every
+# project. Project-specific servers (e.g. spec-workflow) stay in each repo's own .mcp.json.
+# claude.ai connectors and the Chrome extension are configured manually.
+#
+# exa/firecrawl need API keys. We do NOT bake them into .claude.json: the JSON below stores
+# the literal "${EXA_API_KEY}" / "${FIRECRAWL_API_KEY}" placeholders, which Claude Code expands
+# from the launching process's environment when it spawns the server (verified: add-json keeps
+# the literal, expansion happens at spawn). The keys themselves are rendered from 1Password into
+# a 0600 ~/.config/zsh/claude-secrets.zsh and injected per-account by _claude_with_home, so this
+# rendered script body stays secret-free and the keys never sit at rest in .claude.json.
 
 if ! command -v mise &>/dev/null; then
   echo "WARNING: mise is not installed; skipping user-scope MCP setup."
@@ -27,13 +35,20 @@ fi
 # them once per account.
 config_dirs=("$HOME/.claude" "$HOME/.claude-r06")
 
-# Server name -> canonical JSON. Both are stdio (npx-launched, -y so the first run never blocks
-# on an install prompt); deepwiki bridges to its remote HTTP endpoint via mcp-remote. Keep in
-# sync with the project's .mcp.json removal of these two.
-mcp_names=("context7" "deepwiki")
+# Server name -> canonical JSON. All stdio (npx-launched, -y so the first run never blocks on an
+# install prompt); deepwiki bridges to its remote HTTP endpoint via mcp-remote. exa/firecrawl
+# carry an env placeholder ("${EXA_API_KEY}" / "${FIRECRAWL_API_KEY}") expanded by Claude Code at
+# spawn time from the per-account env set by _claude_with_home. Single-quoted here so the shell
+# stores the literal placeholder rather than expanding it now. Keep in sync with the project's
+# .mcp.json removal of context7/deepwiki.
+mcp_names=("context7" "deepwiki" "exa" "firecrawl")
+# shellcheck disable=SC2016  # the ${EXA_API_KEY}/${FIRECRAWL_API_KEY} placeholders are stored
+# literally on purpose: Claude Code expands them at server spawn, not this script.
 mcp_configs=(
   '{"type":"stdio","command":"npx","args":["-y","@upstash/context7-mcp"]}'
   '{"type":"stdio","command":"npx","args":["-y","mcp-remote","https://mcp.deepwiki.com/mcp"]}'
+  '{"type":"stdio","command":"npx","args":["-y","exa-mcp-server"],"env":{"EXA_API_KEY":"${EXA_API_KEY}"}}'
+  '{"type":"stdio","command":"npx","args":["-y","firecrawl-mcp"],"env":{"FIRECRAWL_API_KEY":"${FIRECRAWL_API_KEY}"}}'
 )
 
 failed=0

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -545,9 +545,14 @@ FAKE
   done
 
   # exa/firecrawl carry the literal env placeholder (expanded by Claude Code at spawn, never
-  # baked here). The single quotes must survive into the logged add-json invocation.
+  # baked here): the ${EXA_API_KEY} / ${FIRECRAWL_API_KEY} text must survive verbatim into the
+  # logged add-json invocation.
   grep -qF '"EXA_API_KEY":"${EXA_API_KEY}"' "$tmp/log"
   grep -qF '"FIRECRAWL_API_KEY":"${FIRECRAWL_API_KEY}"' "$tmp/log"
+
+  # The key-bearing servers are version-pinned to shrink the npx supply-chain surface.
+  grep -qE 'exa-mcp-server@[0-9]+\.[0-9]+\.[0-9]+' "$tmp/log"
+  grep -qE 'firecrawl-mcp@[0-9]+\.[0-9]+\.[0-9]+' "$tmp/log"
 }
 
 @test "mcp setup script declares valid JSON server configs" {
@@ -582,6 +587,35 @@ FAKE
   # _claude_with_home re-exports both keys (with :- defaults) into the launched command's env.
   grep -qE 'EXA_API_KEY="\$\{EXA_API_KEY:-\}"' "$zsh"
   grep -qE 'FIRECRAWL_API_KEY="\$\{FIRECRAWL_API_KEY:-\}"' "$zsh"
+}
+
+@test "claude.zsh injects MCP keys into the subprocess but not the parent shell" {
+  command -v zsh >/dev/null || skip "zsh not available"
+  local zsh="${HOME_DIR}/dot_config/zsh/claude.zsh"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/.config/zsh"
+  # Stand in for the 1Password-rendered secrets file (non-exported assignments, single-quoted).
+  cat >"$tmp/.config/zsh/claude-secrets.zsh" <<'SECRETS'
+EXA_API_KEY='exa-test-key'
+FIRECRAWL_API_KEY='fc-test-key'
+SECRETS
+
+  # -f: no rc files. Source claude.zsh, then check (a) the keys do NOT leak into the parent
+  # shell's exported env, and (b) they DO reach a subprocess launched via _claude_with_home.
+  run zsh -fc "
+    export HOME='$tmp'
+    source '$zsh'
+    printf 'PARENT_EXA=[%s]\n' \"\$(printenv EXA_API_KEY)\"
+    printf 'SUB_EXA=[%s]\n' \"\$(_claude_with_home '$tmp' printenv EXA_API_KEY)\"
+    printf 'SUB_FC=[%s]\n' \"\$(_claude_with_home '$tmp' printenv FIRECRAWL_API_KEY)\"
+  "
+  [ "$status" -eq 0 ]
+  # Non-exported in the parent: printenv finds nothing.
+  echo "$output" | grep -qF 'PARENT_EXA=[]'
+  # Exported (scoped) into the subprocess: the values come through.
+  echo "$output" | grep -qF 'SUB_EXA=[exa-test-key]'
+  echo "$output" | grep -qF 'SUB_FC=[fc-test-key]'
 }
 
 @test "1Password validation requires the exa and firecrawl API keys" {

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -512,7 +512,7 @@ load helpers/setup
   grep -Eq '^[[:space:]]*"npm:dmux"[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$config"
 }
 
-@test "mcp setup registers both servers as user scope for every account config dir" {
+@test "mcp setup registers all servers as user scope for every account config dir" {
   local script="${HOME_DIR}/run_onchange_after_13-setup-mcp.sh.tmpl"
   [ -f "$script" ]
   local tmp
@@ -535,13 +535,19 @@ FAKE
     bash "$script"
   [ "$status" -eq 0 ]
 
-  # Both servers are add-json'd with user scope for both account config dirs. The trailing
+  # Every server is add-json'd with user scope for both account config dirs. The trailing
   # " :::" anchors ".claude" so it does not also match ".claude-r06".
-  local d
+  local d name
   for d in '\.claude' '\.claude-r06'; do
-    grep -qE "/home/${d} ::: claude mcp add-json context7 .* --scope user" "$tmp/log"
-    grep -qE "/home/${d} ::: claude mcp add-json deepwiki .* --scope user" "$tmp/log"
+    for name in context7 deepwiki exa firecrawl; do
+      grep -qE "/home/${d} ::: claude mcp add-json ${name} .* --scope user" "$tmp/log"
+    done
   done
+
+  # exa/firecrawl carry the literal env placeholder (expanded by Claude Code at spawn, never
+  # baked here). The single quotes must survive into the logged add-json invocation.
+  grep -qF '"EXA_API_KEY":"${EXA_API_KEY}"' "$tmp/log"
+  grep -qF '"FIRECRAWL_API_KEY":"${FIRECRAWL_API_KEY}"' "$tmp/log"
 }
 
 @test "mcp setup script declares valid JSON server configs" {
@@ -553,7 +559,35 @@ FAKE
     echo "$json" | jq -e . >/dev/null
     count=$((count + 1))
   done < <(grep -oE "'\{[^']*\}'" "$script" | tr -d "'")
-  [ "$count" -ge 2 ]
+  [ "$count" -ge 4 ]
+}
+
+@test "claude MCP secrets are a private 1Password template, never committed in clear" {
+  # The keys are rendered from 1Password into a 0600 file; the source must be a private_
+  # template that reads via onepasswordRead and must not contain a literal key.
+  local tmpl="${HOME_DIR}/dot_config/zsh/private_claude-secrets.zsh.tmpl"
+  [ -f "$tmpl" ]
+  grep -q 'onepasswordRead' "$tmpl"
+  grep -qE 'EXA_API_KEY=.*onepasswordRead' "$tmpl"
+  grep -qE 'FIRECRAWL_API_KEY=.*onepasswordRead' "$tmpl"
+  # Not exported in the secrets file (scoping is done by _claude_with_home).
+  ! grep -qE '^export ' "$tmpl"
+}
+
+@test "claude.zsh sources the MCP secrets and scopes the keys to the claude subprocess" {
+  local zsh="${HOME_DIR}/dot_config/zsh/claude.zsh"
+  # Sourced only when present, so a machine without the 1Password items still works.
+  grep -qF 'claude-secrets.zsh' "$zsh"
+  grep -qE '\[\[ -r .* \]\] && source' "$zsh"
+  # _claude_with_home re-exports both keys (with :- defaults) into the launched command's env.
+  grep -qE 'EXA_API_KEY="\$\{EXA_API_KEY:-\}"' "$zsh"
+  grep -qE 'FIRECRAWL_API_KEY="\$\{FIRECRAWL_API_KEY:-\}"' "$zsh"
+}
+
+@test "1Password validation requires the exa and firecrawl API keys" {
+  local script="${HOME_DIR}/run_once_after_11-validate-1password.sh.tmpl"
+  grep -qF 'op://kryota.dev/Dotfiles - Exa API/credential' "$script"
+  grep -qF 'op://kryota.dev/Dotfiles - Firecrawl API/credential' "$script"
 }
 
 @test "project .mcp.json keeps only project-scoped servers" {


### PR DESCRIPTION
## Summary

Extends the user-scope MCP setup (currently context7 + deepwiki) with **exa**
(neural web/code search) and **firecrawl** (web scraping/crawling) for every
Claude Code account, backing the adopted `exa-search` and `deep-research` skills.
Completes the MCP leg of Phase 7 (#17).

## Secret handling (no key at rest in `.claude.json`)

The server configs store only the literal `${EXA_API_KEY}` / `${FIRECRAWL_API_KEY}`
placeholders. Claude Code expands them from the launching process's environment at
**server spawn** — verified two ways:

- Docs: env-var expansion is supported in `env` (and `command`/`args`/`url`/`headers`)
  for both project and user-scoped MCP config.
- Empirically: `claude mcp add-json` stores `{"EXA_API_KEY":"${EXA_API_KEY}"}` literally.

The keys themselves are rendered from 1Password into a **0600** `~/.config/zsh/claude-secrets.zsh`
(not exported). `_claude_with_home` re-exports them **scoped to the claude subprocess only**,
so they never leak into the general shell environment and never sit at rest in `.claude.json`.

## Changes

- `run_onchange_after_13-setup-mcp.sh.tmpl` — register exa/firecrawl per account with env placeholders.
- `dot_config/zsh/private_claude-secrets.zsh.tmpl` — 1Password-rendered, 0600 key file (graceful absence).
- `dot_config/zsh/claude.zsh` — source the secrets file if present; inject keys with `:-` defaults.
- `run_once_after_11-validate-1password.sh.tmpl` — require the two new API key items (fail-fast).
- `tests/files.bats` — per-account registration, literal placeholders, private template, wiring, validation.

## Required 1Password items (kryota.dev vault)

`make apply` validates these up front:

- `op://kryota.dev/Dotfiles - Exa API/credential`
- `op://kryota.dev/Dotfiles - Firecrawl API/credential`

## Verification

- `make lint` — pass (incl. an inline `SC2016` disable where the literal placeholder is intentional)
- `make test` — 109/109 bats pass
- `chezmoi execute-template` on the setup script renders secret-free