### PR TITLE
feat(dmux): wire OPENROUTER_API_KEY via 1Password-rendered scoped export

### DIFF
--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -65,6 +65,7 @@ jobs:
           for f in \
             home/private_dot_aws/config.tmpl \
             home/dot_config/zsh/private_claude-secrets.zsh.tmpl \
+            home/dot_config/zsh/private_dmux-secrets.zsh.tmpl \
             home/run_once_before_00-install-prerequisites.sh.tmpl \
             home/run_onchange_before_10-brew-bundle.sh.tmpl \
             home/run_once_after_11-validate-1password.sh.tmpl \
@@ -245,6 +246,7 @@ jobs:
           for f in \
             home/private_dot_aws/config.tmpl \
             home/dot_config/zsh/private_claude-secrets.zsh.tmpl \
+            home/dot_config/zsh/private_dmux-secrets.zsh.tmpl \
             home/run_once_before_00-install-prerequisites.sh.tmpl \
             home/run_onchange_before_10-brew-bundle.sh.tmpl \
             home/run_once_after_11-validate-1password.sh.tmpl; do

--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Verify zsh modules deployed
         run: |
-          for mod in aliases git docker claude functions completions wtp ghq; do
+          for mod in aliases git docker claude dmux functions completions wtp ghq; do
             f=~/.config/zsh/${mod}.zsh
             if [ -f "$f" ]; then
               echo "OK: $f"
@@ -316,7 +316,7 @@ jobs:
 
       - name: Verify zsh modules deployed
         run: |
-          for mod in aliases git docker claude functions completions wtp ghq; do
+          for mod in aliases git docker claude dmux functions completions wtp ghq; do
             f=~/.config/zsh/${mod}.zsh
             if [ -f "$f" ]; then
               echo "OK: $f"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Temporary Items
 
 # Environment variables
 .env
+.dmux/

--- a/home/dot_config/sheldon/plugins.toml
+++ b/home/dot_config/sheldon/plugins.toml
@@ -47,6 +47,11 @@ local = "~/.config/zsh"
 use = ["codex.zsh"]
 apply = ["defer"]
 
+[plugins.dmux-helpers]
+local = "~/.config/zsh"
+use = ["dmux.zsh"]
+apply = ["defer"]
+
 [plugins.functions]
 local = "~/.config/zsh"
 use = ["functions.zsh"]

--- a/home/dot_config/zsh/dmux.zsh
+++ b/home/dot_config/zsh/dmux.zsh
@@ -1,0 +1,16 @@
+# dmux (standardagents/dmux): a tmux-based pane manager for orchestrating parallel AI agent
+# sessions. Its AI features — smart branch slugs, AI commit messages, pane-state analysis, and
+# aiMerge conflict assistance — read OPENROUTER_API_KEY from the environment; without it dmux
+# still runs, falling back to dmux-{timestamp} branch names and skipping the AI assists.
+#
+# The key is rendered from 1Password into a 0600 ~/.config/zsh/dmux-secrets.zsh and sourced
+# (not exported), so it stays out of the general shell environment. The wrapper re-exports it
+# scoped to the dmux subprocess only, mirroring _claude_with_home. Absent until chezmoi apply
+# provisions it, in which case dmux just launches without a key.
+[[ -r "${HOME}/.config/zsh/dmux-secrets.zsh" ]] && source "${HOME}/.config/zsh/dmux-secrets.zsh"
+
+dmux() {
+  # Scope OPENROUTER_API_KEY to the dmux process only; the :- default keeps this safe when the
+  # secrets file is absent. `command` bypasses this function to reach the mise-shimmed binary.
+  OPENROUTER_API_KEY="${OPENROUTER_API_KEY:-}" command dmux "$@"
+}

--- a/home/dot_config/zsh/private_dmux-secrets.zsh.tmpl
+++ b/home/dot_config/zsh/private_dmux-secrets.zsh.tmpl
@@ -1,0 +1,5 @@
+# dmux (standardagents/dmux) reads OPENROUTER_API_KEY from the environment for its AI features
+# (smart branch slugs, AI commit messages, pane-state analysis, aiMerge). Rendered by chezmoi
+# from 1Password into a 0600 ~/.config/zsh/dmux-secrets.zsh and sourced (not exported) by
+# dmux.zsh; the dmux wrapper re-exports it scoped to the dmux subprocess only. Do not edit by hand.
+OPENROUTER_API_KEY={{ onepasswordRead "op://kryota.dev/Dotfiles - OpenRouter API/credential" | quote }}

--- a/home/dot_config/zsh/private_dmux-secrets.zsh.tmpl
+++ b/home/dot_config/zsh/private_dmux-secrets.zsh.tmpl
@@ -2,4 +2,7 @@
 # (smart branch slugs, AI commit messages, pane-state analysis, aiMerge). Rendered by chezmoi
 # from 1Password into a 0600 ~/.config/zsh/dmux-secrets.zsh and sourced (not exported) by
 # dmux.zsh; the dmux wrapper re-exports it scoped to the dmux subprocess only. Do not edit by hand.
-OPENROUTER_API_KEY={{ onepasswordRead "op://kryota.dev/Dotfiles - OpenRouter API/credential" | quote }}
+# The value is single-quoted (squote, not quote) so the shell treats it as a literal — a key
+# containing $ or a backtick cannot trigger expansion or command substitution when dmux.zsh
+# sources this file (matches private_claude-secrets.zsh.tmpl).
+OPENROUTER_API_KEY={{ onepasswordRead "op://kryota.dev/Dotfiles - OpenRouter API/credential" | squote }}

--- a/home/run_once_after_11-validate-1password.sh.tmpl
+++ b/home/run_once_after_11-validate-1password.sh.tmpl
@@ -31,6 +31,9 @@ ITEMS=(
   # ~/.config/zsh/claude-secrets.zsh). Create these as items exposing a `credential` field.
   "op://kryota.dev/Dotfiles - Exa API/credential"
   "op://kryota.dev/Dotfiles - Firecrawl API/credential"
+  # API key for dmux's OpenRouter-backed AI features (rendered into the 0600
+  # ~/.config/zsh/dmux-secrets.zsh). Create as an item exposing a `credential` field.
+  "op://kryota.dev/Dotfiles - OpenRouter API/credential"
 )
 
 for item in "${ITEMS[@]}"; do

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -55,7 +55,7 @@ load helpers/setup
 }
 
 @test "zsh modules exist" {
-  local modules=(git docker claude codex functions completions wtp ghq)
+  local modules=(git docker claude codex dmux functions completions wtp ghq)
   for mod in "${modules[@]}"; do
     [ -f "${HOME_DIR}/dot_config/zsh/${mod}.zsh" ]
   done
@@ -914,6 +914,9 @@ _gate_decision() {
   local tmpl="${HOME_DIR}/dot_config/zsh/private_dmux-secrets.zsh.tmpl"
   [ -f "$tmpl" ]
   grep -qE 'OPENROUTER_API_KEY=.*onepasswordRead' "$tmpl"
+  # Single-quoted (squote, not quote) so a key with $ or a backtick cannot expand when sourced.
+  grep -qE 'OPENROUTER_API_KEY=.*\| squote' "$tmpl"
+  ! grep -qE 'OPENROUTER_API_KEY=.*\| quote' "$tmpl"
   # Not exported in the secrets file (scoping is done by the dmux wrapper).
   ! grep -qE '^export ' "$tmpl"
 }

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -909,3 +909,54 @@ _gate_decision() {
   command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
   chezmoi cat "${HOME}/AGENTS.md" --source "${REPO_ROOT}/home" 2>/dev/null | grep -q 'Coding standards (house)'
 }
+
+@test "dmux OpenRouter secret is a private 1Password template, never committed in clear" {
+  local tmpl="${HOME_DIR}/dot_config/zsh/private_dmux-secrets.zsh.tmpl"
+  [ -f "$tmpl" ]
+  grep -qE 'OPENROUTER_API_KEY=.*onepasswordRead' "$tmpl"
+  # Not exported in the secrets file (scoping is done by the dmux wrapper).
+  ! grep -qE '^export ' "$tmpl"
+}
+
+@test "dmux.zsh sources the OpenRouter secret and scopes it to the dmux subprocess" {
+  local zsh="${HOME_DIR}/dot_config/zsh/dmux.zsh"
+  [ -f "$zsh" ]
+  grep -qF 'dmux-secrets.zsh' "$zsh"
+  grep -qE '\[\[ -r .* \]\] && source' "$zsh"
+  grep -qE 'OPENROUTER_API_KEY="\$\{OPENROUTER_API_KEY:-\}"' "$zsh"
+  # Must reach the real binary, not recurse into the function.
+  grep -qF 'command dmux' "$zsh"
+}
+
+@test "dmux.zsh injects OPENROUTER_API_KEY into the dmux subprocess but not the parent shell" {
+  command -v zsh >/dev/null || skip "zsh not available"
+  local zsh="${HOME_DIR}/dot_config/zsh/dmux.zsh"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/.config/zsh" "$tmp/bin"
+  # Stand in for the 1Password-rendered secrets file (non-exported, single-quoted).
+  cat >"$tmp/.config/zsh/dmux-secrets.zsh" <<'SECRETS'
+OPENROUTER_API_KEY='or-test-key'
+SECRETS
+  # Stub dmux binary that reports what it received.
+  cat >"$tmp/bin/dmux" <<'STUB'
+#!/usr/bin/env bash
+printf 'SUB_OR=[%s]\n' "$(printenv OPENROUTER_API_KEY)"
+STUB
+  chmod +x "$tmp/bin/dmux"
+  run zsh -fc "
+    export HOME='$tmp'
+    export PATH=\"$tmp/bin:\$PATH\"
+    source '$zsh'
+    printf 'PARENT_OR=[%s]\n' \"\$(printenv OPENROUTER_API_KEY)\"
+    dmux
+  "
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF 'PARENT_OR=[]'
+  echo "$output" | grep -qF 'SUB_OR=[or-test-key]'
+}
+
+@test "1Password validation requires the OpenRouter API key" {
+  local script="${HOME_DIR}/run_once_after_11-validate-1password.sh.tmpl"
+  grep -qF 'op://kryota.dev/Dotfiles - OpenRouter API/credential' "$script"
+}


### PR DESCRIPTION
## Summary

`dmux` (provisioned via `npm:dmux` in #194) reads `OPENROUTER_API_KEY` from the
environment for its AI features — smart branch slugs, AI commit messages,
pane-state analysis, and `aiMerge` conflict assistance. Without the key dmux
still runs, falling back to `dmux-{timestamp}` branch names and skipping the AI
assists, so the key is **optional** but enables the full UX.

This wires the key through the repo's established secret pattern (the same one
used for the exa/firecrawl MCP keys in #195): render from 1Password into a
`0600` file, keep it **out of the general shell environment**, and re-export it
**scoped to the dmux subprocess only**.

## How it works

- `home/dot_config/zsh/private_dmux-secrets.zsh.tmpl` — chezmoi renders
  `OPENROUTER_API_KEY` from 1Password (`onepasswordRead`) into a `0600`
  `~/.config/zsh/dmux-secrets.zsh`. Non-exported assignment; never a literal key.
- `home/dot_config/zsh/dmux.zsh` — sources that file (only if present) and
  defines a `dmux()` wrapper that re-exports the key scoped to the process:
  `OPENROUTER_API_KEY="${OPENROUTER_API_KEY:-}" command dmux "$@"`. `command`
  reaches the mise-shimmed binary instead of recursing. This mirrors
  `_claude_with_home`, so the key never leaks into the parent shell.
- `home/dot_config/sheldon/plugins.toml` — load `dmux.zsh` as a deferred local
  module (`[plugins.dmux-helpers]`).
- `home/run_once_after_11-validate-1password.sh.tmpl` — require the
  `op://kryota.dev/Dotfiles - OpenRouter API/credential` item at setup time.
- `.github/workflows/setup-validation.yml` — exclude the new secrets template
  from CI's `chezmoi apply` (both the macOS and Ubuntu jobs), matching the
  existing op-dependent templates.
- `.gitignore` — ignore dmux's per-project `.dmux/` runtime state dir.

## Tests

`tests/files.bats` gains 4 tests mirroring the claude-secrets coverage:
1. the secrets template renders via `onepasswordRead` and is never exported / no literal key;
2. `dmux.zsh` sources the secrets and wraps `command dmux` with the scoped export;
3. runtime check: a stub `dmux` on `PATH` receives the key, but it does **not** leak to the parent shell;
4. 1Password validation requires the OpenRouter credential item.

`make lint` passes; all new bats tests are green. (The pre-existing
`claude.zsh injects MCP keys ...` test fails **only** when run inside a session
that already exports the real `EXA_API_KEY`/`FIRECRAWL_API_KEY` — it fails on
`main` too and is unrelated to this change; it passes in CI.)

## Follow-up (manual)

Create the 1Password item `Dotfiles - OpenRouter API` with a `credential` field
in the `kryota.dev` vault, then `chezmoi apply` to render the secrets file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
