### PR TITLE
Use a generic workspace package placeholder in fix-migration-leftover

### DIFF
--- a/home/dot_agents/skills/fix-migration-leftover/SKILL.md
+++ b/home/dot_agents/skills/fix-migration-leftover/SKILL.md
@@ -98,7 +98,7 @@ docker exec <コンテナ名> psql -U postgres -d <DB名> -c \
 ### Step 7: マイグレーション再実行
 
 ```bash
-pnpm -F @acsim/api db:migrate
+pnpm -F <api-package> db:migrate
 ```
 
 ### Step 8: 結果の確認


### PR DESCRIPTION
## Summary

The Step 7 example in `fix-migration-leftover/SKILL.md` hard-coded a concrete pnpm filter scope. Replace it with the same `<...>` placeholder style used throughout the rest of the doc (e.g. `<コンテナ名>`, `<DB名>`), so the example is project-agnostic and carries no specific package name.

## Change

- `home/dot_agents/skills/fix-migration-leftover/SKILL.md`: `pnpm -F <api-package> db:migrate` in the migration re-run example.

## Verification

Docs-only single-line change; no lint/test impact. `git grep` confirms no remaining concrete scope name in tracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)