### PR TITLE
feat(dmux): wire dmux to the r06 account and load codex SSOT config

### DIFF
--- a/home/dot_config/dmux/bin/executable_codex
+++ b/home/dot_config/dmux/bin/executable_codex
@@ -4,25 +4,35 @@
 # chezmoi-managed SSOT static config ($CODEX_HOME/shared.config.toml). The dmux / dmux-r06
 # zsh wrappers prepend this shim's directory to PATH; dmux's PATH sanitiser only strips
 # node_modules/.bin entries (dist/utils/pathEnvironment.js), so the shim survives and
-# intercepts `codex` in every pane, re-injecting `--profile shared` before exec-ing the
-# real codex. (claude needs no shim: its account is selected purely by CLAUDE_CONFIG_DIR.)
+# intercepts `codex` in every pane, re-injecting `--profile shared`. (claude needs no shim:
+# its account is selected purely by CLAUDE_CONFIG_DIR.)
 #
-# To avoid recursing into itself, it drops its own directory from PATH first. When resolved
-# via PATH, $0 is "<matched PATH entry>/codex", so the directory part equals a PATH entry
-# verbatim — no canonicalisation needed. Falls back to the install dir if invoked by bare name.
+# Recursion is structurally impossible: rather than stripping itself from PATH and letting a
+# bare `exec codex` re-search (which loops if the self-match ever fails), it walks PATH itself,
+# skips its own directory, and execs the FIRST other `codex` by absolute path. Trailing slashes
+# on both sides are normalised so the self-skip is exact even for `…/bin/` style entries. When
+# resolved via PATH, $0 is "<matched PATH entry>/codex"; the bare-name fallback covers a direct
+# invocation by name.
 case "$0" in
   */*) self_dir="${0%/*}" ;;
   *) self_dir="${HOME}/.config/dmux/bin" ;;
 esac
+self_dir="${self_dir%/}"
 
-newpath=""
+real=""
 IFS=:
 for dir in $PATH; do
-  [ "$dir" = "$self_dir" ] && continue
-  newpath="${newpath:+$newpath:}$dir"
+  d="${dir%/}"
+  [ "$d" = "$self_dir" ] && continue
+  if [ -x "$d/codex" ]; then
+    real="$d/codex"
+    break
+  fi
 done
 unset IFS
 
-PATH="$newpath"
-export PATH
-exec codex --profile shared "$@"
+[ -n "$real" ] || {
+  printf '%s\n' "dmux codex shim: no real codex found on PATH" >&2
+  exit 127
+}
+exec "$real" --profile shared "$@"

--- a/home/dot_config/dmux/bin/executable_codex
+++ b/home/dot_config/dmux/bin/executable_codex
@@ -1,0 +1,28 @@
+#!/bin/sh
+# dmux launches the bare `codex` binary — paneBootstrapRunner spawns `sh -c "codex …"`
+# (dist/utils/paneBootstrapRunner.js), so it cannot pass `--profile shared`, the
+# chezmoi-managed SSOT static config ($CODEX_HOME/shared.config.toml). The dmux / dmux-r06
+# zsh wrappers prepend this shim's directory to PATH; dmux's PATH sanitiser only strips
+# node_modules/.bin entries (dist/utils/pathEnvironment.js), so the shim survives and
+# intercepts `codex` in every pane, re-injecting `--profile shared` before exec-ing the
+# real codex. (claude needs no shim: its account is selected purely by CLAUDE_CONFIG_DIR.)
+#
+# To avoid recursing into itself, it drops its own directory from PATH first. When resolved
+# via PATH, $0 is "<matched PATH entry>/codex", so the directory part equals a PATH entry
+# verbatim — no canonicalisation needed. Falls back to the install dir if invoked by bare name.
+case "$0" in
+  */*) self_dir="${0%/*}" ;;
+  *) self_dir="${HOME}/.config/dmux/bin" ;;
+esac
+
+newpath=""
+IFS=:
+for dir in $PATH; do
+  [ "$dir" = "$self_dir" ] && continue
+  newpath="${newpath:+$newpath:}$dir"
+done
+unset IFS
+
+PATH="$newpath"
+export PATH
+exec codex --profile shared "$@"

--- a/home/dot_config/zsh/dmux.zsh
+++ b/home/dot_config/zsh/dmux.zsh
@@ -9,8 +9,42 @@
 # provisions it, in which case dmux just launches without a key.
 [[ -r "${HOME}/.config/zsh/dmux-secrets.zsh" ]] && source "${HOME}/.config/zsh/dmux-secrets.zsh"
 
+# Directory holding the `codex` PATH shim. dmux launches the bare `codex` binary (it spawns
+# `sh -c "codex …"`), so it cannot pass `--profile shared`, the chezmoi-managed SSOT static
+# config ($CODEX_HOME/shared.config.toml). Prepending this dir to PATH makes dmux pick up the
+# shim, which re-injects `--profile shared` for every codex pane (both accounts). dmux's PATH
+# sanitiser only strips node_modules/.bin, so the shim dir survives into the panes. claude
+# needs no shim: its account is selected purely by CLAUDE_CONFIG_DIR.
+_DMUX_SHIM_DIR="${HOME}/.config/dmux/bin"
+
 dmux() {
   # Scope OPENROUTER_API_KEY to the dmux process only; the :- default keeps this safe when the
-  # secrets file is absent. `command` bypasses this function to reach the mise-shimmed binary.
-  OPENROUTER_API_KEY="${OPENROUTER_API_KEY:-}" command dmux "$@"
+  # secrets file is absent. The shim dir is prepended so dmux's bare `codex` loads the SSOT
+  # config. `command` bypasses this function to reach the mise-shimmed binary.
+  PATH="${_DMUX_SHIM_DIR}:${PATH}" \
+    OPENROUTER_API_KEY="${OPENROUTER_API_KEY:-}" \
+    command dmux "$@"
+}
+
+# dmux-r06: run a whole dmux session bound to the r06 (work) account, mirroring cld-r06 /
+# cdx-r06. dmux launches bare `claude` / `codex` with no per-account env injection, and tmux
+# captures a session's environment from the server at creation time — so with a default-socket
+# server already running (e.g. the auto-tmux-dev hook), a plain pre-launch export would not
+# reach new panes. To guarantee propagation this points tmux at a dedicated socket via
+# TMUX_TMPDIR: the first dmux-r06 starts a *fresh* tmux server whose global environment is
+# captured from the r06 env below, so every pane (and the codex shim) inherits it. The r06
+# env set mirrors _claude_with_home (claude.zsh) plus CODEX_HOME (codex.zsh).
+dmux-r06() {
+  local tmpdir="${HOME}/.dmux-r06"
+  [[ -d "$tmpdir" ]] || mkdir -p "$tmpdir" || return 1
+  TMUX_TMPDIR="$tmpdir" \
+    PATH="${_DMUX_SHIM_DIR}:${PATH}" \
+    CLAUDE_CONFIG_DIR="${HOME}/.claude-r06" \
+    ECC_AGENT_DATA_HOME="${HOME}/.claude-r06" \
+    CLV2_HOMUNCULUS_DIR="${HOME}/.claude-r06/ecc-homunculus" \
+    ECC_MCP_HEALTH_STATE_PATH="${HOME}/.claude-r06/mcp-health-cache.json" \
+    GATEGUARD_STATE_DIR="${HOME}/.claude-r06/.gateguard" \
+    CODEX_HOME="${HOME}/.codex-r06" \
+    OPENROUTER_API_KEY="${OPENROUTER_API_KEY:-}" \
+    command dmux "$@"
 }

--- a/home/dot_config/zsh/dmux.zsh
+++ b/home/dot_config/zsh/dmux.zsh
@@ -9,6 +9,14 @@
 # provisions it, in which case dmux just launches without a key.
 [[ -r "${HOME}/.config/zsh/dmux-secrets.zsh" ]] && source "${HOME}/.config/zsh/dmux-secrets.zsh"
 
+# claude's MCP API keys (exa, firecrawl) live in the same 0600 secrets file claude.zsh sources
+# (non-exported). dmux launches claude without _claude_with_home, so the wrappers below re-pass
+# these keys (scoped to the dmux subprocess) for parity with cld / cld-r06 — claude expands the
+# ${EXA_API_KEY} / ${FIRECRAWL_API_KEY} placeholders in its MCP env at spawn. Sourced here too
+# (not only in claude.zsh) so this file does not depend on plugin load order. Absent until
+# chezmoi apply provisions it, in which case the MCP servers just launch without a key.
+[[ -r "${HOME}/.config/zsh/claude-secrets.zsh" ]] && source "${HOME}/.config/zsh/claude-secrets.zsh"
+
 # Directory holding the `codex` PATH shim. dmux launches the bare `codex` binary (it spawns
 # `sh -c "codex …"`), so it cannot pass `--profile shared`, the chezmoi-managed SSOT static
 # config ($CODEX_HOME/shared.config.toml). Prepending this dir to PATH makes dmux pick up the
@@ -18,25 +26,32 @@
 _DMUX_SHIM_DIR="${HOME}/.config/dmux/bin"
 
 dmux() {
-  # Scope OPENROUTER_API_KEY to the dmux process only; the :- default keeps this safe when the
-  # secrets file is absent. The shim dir is prepended so dmux's bare `codex` loads the SSOT
-  # config. `command` bypasses this function to reach the mise-shimmed binary.
+  # Scope the API keys to the dmux process only; the :- defaults keep this safe when a secrets
+  # file is absent. The shim dir is prepended so dmux's bare `codex` loads the SSOT config.
+  # `command` bypasses this function to reach the mise-shimmed binary.
   PATH="${_DMUX_SHIM_DIR}:${PATH}" \
     OPENROUTER_API_KEY="${OPENROUTER_API_KEY:-}" \
+    EXA_API_KEY="${EXA_API_KEY:-}" \
+    FIRECRAWL_API_KEY="${FIRECRAWL_API_KEY:-}" \
     command dmux "$@"
 }
 
 # dmux-r06: run a whole dmux session bound to the r06 (work) account, mirroring cld-r06 /
-# cdx-r06. dmux launches bare `claude` / `codex` with no per-account env injection, and tmux
-# captures a session's environment from the server at creation time — so with a default-socket
-# server already running (e.g. the auto-tmux-dev hook), a plain pre-launch export would not
-# reach new panes. To guarantee propagation this points tmux at a dedicated socket via
-# TMUX_TMPDIR: the first dmux-r06 starts a *fresh* tmux server whose global environment is
-# captured from the r06 env below, so every pane (and the codex shim) inherits it. The r06
-# env set mirrors _claude_with_home (claude.zsh) plus CODEX_HOME (codex.zsh).
+# cdx-r06. dmux launches bare `claude` / `codex` with no per-account env injection. tmux
+# captures a session's environment from the client that runs `new-session`, and new agent panes
+# (created via `split-window`) inherit that captured session env — so the r06 env below, passed
+# to the outer dmux, reaches every pane. The dedicated TMUX_TMPDIR socket is what makes this
+# account-correct: dmux keys sessions by project name and ATTACHES to an existing one instead of
+# recreating it, so without a separate server a dmux-r06 started where a default-account dmux
+# session already exists would attach to the wrong account. A dedicated server gives r06 its own
+# session namespace. (Caveat: a reused session keeps the env captured at its creation; the r06
+# paths are static so this is moot, but newly-provisioned secrets need `tmux -L … kill-server`
+# to refresh.) The per-account env set must stay in sync with _claude_with_home (claude.zsh);
+# CODEX_HOME mirrors cdx-r06 (codex.zsh).
 dmux-r06() {
   local tmpdir="${HOME}/.dmux-r06"
-  [[ -d "$tmpdir" ]] || mkdir -p "$tmpdir" || return 1
+  # 0700 keeps the tmux socket dir as private as tmux's default $TMPDIR-based socket.
+  [[ -d "$tmpdir" ]] || mkdir -m 700 -p "$tmpdir" || return 1
   TMUX_TMPDIR="$tmpdir" \
     PATH="${_DMUX_SHIM_DIR}:${PATH}" \
     CLAUDE_CONFIG_DIR="${HOME}/.claude-r06" \
@@ -46,5 +61,7 @@ dmux-r06() {
     GATEGUARD_STATE_DIR="${HOME}/.claude-r06/.gateguard" \
     CODEX_HOME="${HOME}/.codex-r06" \
     OPENROUTER_API_KEY="${OPENROUTER_API_KEY:-}" \
+    EXA_API_KEY="${EXA_API_KEY:-}" \
+    FIRECRAWL_API_KEY="${FIRECRAWL_API_KEY:-}" \
     command dmux "$@"
 }

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1072,6 +1072,99 @@ STUB
   echo "$output" | grep -qF 'SUB_OR=[or-test-key]'
 }
 
+@test "dmux codex shim deploys as ~/.config/dmux/bin/codex and re-injects --profile shared" {
+  local shim="${HOME_DIR}/dot_config/dmux/bin/executable_codex"
+  [ -f "$shim" ]
+  # executable_ prefix → chezmoi deploys 0755 as `codex` (no extension), which dmux invokes.
+  head -1 "$shim" | grep -qE '^#!/bin/sh'
+  grep -qF 'exec codex --profile shared "$@"' "$shim"
+}
+
+@test "dmux codex shim passes shellcheck as POSIX sh" {
+  command -v shellcheck >/dev/null || skip "shellcheck not available"
+  shellcheck --shell=sh --exclude=SC1091,SC2034,SC2086,SC2317,SC2329 \
+    "${HOME_DIR}/dot_config/dmux/bin/executable_codex"
+}
+
+@test "dmux codex shim injects --profile shared and drops its own dir to avoid recursion" {
+  local shimsrc="${HOME_DIR}/dot_config/dmux/bin/executable_codex"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/shim" "$tmp/real"
+  cp "$shimsrc" "$tmp/shim/codex"
+  chmod +x "$tmp/shim/codex"
+  # Real codex stub (in a separate dir) reports the args it was handed.
+  cat >"$tmp/real/codex" <<'STUB'
+#!/usr/bin/env bash
+printf 'REAL_CODEX_ARGS=[%s]\n' "$*"
+STUB
+  chmod +x "$tmp/real/codex"
+  # shim dir first, real dir second: the shim must drop its own dir, then resolve the real codex.
+  run env PATH="$tmp/shim:$tmp/real:/usr/bin:/bin" "$tmp/shim/codex" exec --foo
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF 'REAL_CODEX_ARGS=[--profile shared exec --foo]'
+}
+
+@test "dmux (default account) prepends the codex shim dir to PATH" {
+  local zsh="${HOME_DIR}/dot_config/zsh/dmux.zsh"
+  grep -qF '_DMUX_SHIM_DIR="${HOME}/.config/dmux/bin"' "$zsh"
+  # The default dmux wrapper must put the shim dir on PATH so its bare codex loads the SSOT.
+  grep -qE 'PATH="\$\{_DMUX_SHIM_DIR\}:\$\{PATH\}"' "$zsh"
+}
+
+@test "dmux-r06 binds the r06 account env, a dedicated tmux socket and the codex shim" {
+  local zsh="${HOME_DIR}/dot_config/zsh/dmux.zsh"
+  grep -qE '^dmux-r06\(\) \{' "$zsh"
+  # Dedicated fresh tmux server so the env reaches every pane.
+  grep -qF 'TMUX_TMPDIR="$tmpdir"' "$zsh"
+  # Full per-account env set (mirrors _claude_with_home + CODEX_HOME).
+  grep -qF 'CLAUDE_CONFIG_DIR="${HOME}/.claude-r06"' "$zsh"
+  grep -qF 'ECC_AGENT_DATA_HOME="${HOME}/.claude-r06"' "$zsh"
+  grep -qF 'CLV2_HOMUNCULUS_DIR="${HOME}/.claude-r06/ecc-homunculus"' "$zsh"
+  grep -qF 'ECC_MCP_HEALTH_STATE_PATH="${HOME}/.claude-r06/mcp-health-cache.json"' "$zsh"
+  grep -qF 'GATEGUARD_STATE_DIR="${HOME}/.claude-r06/.gateguard"' "$zsh"
+  grep -qF 'CODEX_HOME="${HOME}/.codex-r06"' "$zsh"
+  grep -qF 'command dmux "$@"' "$zsh"
+}
+
+@test "dmux-r06 injects the r06 account env into the dmux subprocess but not the parent shell" {
+  command -v zsh >/dev/null || skip "zsh not available"
+  local zsh="${HOME_DIR}/dot_config/zsh/dmux.zsh"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/.config/zsh" "$tmp/bin"
+  # Stub dmux binary that reports the per-account env it received.
+  cat >"$tmp/bin/dmux" <<'STUB'
+#!/usr/bin/env bash
+printf 'SUB_CC=[%s]\n' "$(printenv CLAUDE_CONFIG_DIR)"
+printf 'SUB_CODEX=[%s]\n' "$(printenv CODEX_HOME)"
+printf 'SUB_TMPDIR=[%s]\n' "$(printenv TMUX_TMPDIR)"
+case ":$PATH:" in
+*":$HOME/.config/dmux/bin:"*) printf 'SUB_SHIM=[yes]\n' ;;
+*) printf 'SUB_SHIM=[no]\n' ;;
+esac
+STUB
+  chmod +x "$tmp/bin/dmux"
+  run zsh -fc "
+    export HOME='$tmp'
+    export PATH=\"$tmp/bin:\$PATH\"
+    # Start from a clean baseline: the outer test environment may already export these.
+    unset CLAUDE_CONFIG_DIR CODEX_HOME TMUX_TMPDIR
+    source '$zsh'
+    dmux-r06
+    printf 'PARENT_CC=[%s]\n' \"\$(printenv CLAUDE_CONFIG_DIR)\"
+    printf 'PARENT_CODEX=[%s]\n' \"\$(printenv CODEX_HOME)\"
+  "
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF "SUB_CC=[$tmp/.claude-r06]"
+  echo "$output" | grep -qF "SUB_CODEX=[$tmp/.codex-r06]"
+  echo "$output" | grep -qF "SUB_TMPDIR=[$tmp/.dmux-r06]"
+  echo "$output" | grep -qF 'SUB_SHIM=[yes]'
+  # Parent shell must stay clean (env was scoped to the dmux subprocess only).
+  echo "$output" | grep -qF 'PARENT_CC=[]'
+  echo "$output" | grep -qF 'PARENT_CODEX=[]'
+}
+
 @test "1Password validation requires the OpenRouter API key" {
   local script="${HOME_DIR}/run_once_after_11-validate-1password.sh.tmpl"
   grep -qF 'op://kryota.dev/Dotfiles - OpenRouter API/credential' "$script"

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1077,13 +1077,19 @@ STUB
   [ -f "$shim" ]
   # executable_ prefix → chezmoi deploys 0755 as `codex` (no extension), which dmux invokes.
   head -1 "$shim" | grep -qE '^#!/bin/sh'
-  grep -qF 'exec codex --profile shared "$@"' "$shim"
+  # Execs the resolved real codex (never the bare name) with the SSOT profile re-injected.
+  grep -qF 'exec "$real" --profile shared "$@"' "$shim"
 }
 
-@test "dmux codex shim passes shellcheck as POSIX sh" {
-  command -v shellcheck >/dev/null || skip "shellcheck not available"
-  shellcheck --shell=sh --exclude=SC1091,SC2034,SC2086,SC2317,SC2329 \
-    "${HOME_DIR}/dot_config/dmux/bin/executable_codex"
+@test "dmux codex shim passes shellcheck and shfmt as POSIX sh" {
+  local shim="${HOME_DIR}/dot_config/dmux/bin/executable_codex"
+  # make lint only globs *.sh/*.sh.tmpl, so the extension-less shim needs explicit coverage.
+  if command -v shellcheck >/dev/null; then
+    shellcheck --shell=sh --exclude=SC1091,SC2034,SC2086,SC2317,SC2329 "$shim"
+  fi
+  if command -v shfmt >/dev/null; then
+    shfmt -d -i 2 -ci "$shim"
+  fi
 }
 
 @test "dmux codex shim injects --profile shared and drops its own dir to avoid recursion" {
@@ -1099,46 +1105,95 @@ STUB
 printf 'REAL_CODEX_ARGS=[%s]\n' "$*"
 STUB
   chmod +x "$tmp/real/codex"
-  # shim dir first, real dir second: the shim must drop its own dir, then resolve the real codex.
+  # shim dir first, real dir second: the shim must skip its own dir, then resolve the real codex.
   run env PATH="$tmp/shim:$tmp/real:/usr/bin:/bin" "$tmp/shim/codex" exec --foo
   [ "$status" -eq 0 ]
   echo "$output" | grep -qF 'REAL_CODEX_ARGS=[--profile shared exec --foo]'
 }
 
-@test "dmux (default account) prepends the codex shim dir to PATH" {
+@test "dmux codex shim resolves correctly via PATH lookup (dmux's real sh -c launch path)" {
+  # dmux runs `sh -c "codex …"`, so codex is found by PATH lookup and $0 becomes the resolved
+  # full path. This exercises that path (vs the direct-invocation test above) to guard the
+  # verbatim self-skip premise against regressions.
+  local shimsrc="${HOME_DIR}/dot_config/dmux/bin/executable_codex"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/shim" "$tmp/real"
+  cp "$shimsrc" "$tmp/shim/codex"
+  chmod +x "$tmp/shim/codex"
+  cat >"$tmp/real/codex" <<'STUB'
+#!/usr/bin/env bash
+printf 'REAL_CODEX_ARGS=[%s]\n' "$*"
+STUB
+  chmod +x "$tmp/real/codex"
+  run env PATH="$tmp/shim:$tmp/real:/usr/bin:/bin" sh -c 'codex exec --foo'
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF 'REAL_CODEX_ARGS=[--profile shared exec --foo]'
+}
+
+@test "dmux codex shim exits non-zero (no fork bomb) when no real codex is on PATH" {
+  local shimsrc="${HOME_DIR}/dot_config/dmux/bin/executable_codex"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/shim"
+  cp "$shimsrc" "$tmp/shim/codex"
+  chmod +x "$tmp/shim/codex"
+  # Only the shim is reachable as `codex`: it must fail cleanly, never recurse into itself.
+  run env PATH="$tmp/shim:/usr/bin:/bin" "$tmp/shim/codex" exec
+  [ "$status" -eq 127 ]
+  echo "$output" | grep -qF 'no real codex found on PATH'
+}
+
+@test "dmux (default account) prepends the codex shim dir to PATH and passes the MCP keys" {
   local zsh="${HOME_DIR}/dot_config/zsh/dmux.zsh"
   grep -qF '_DMUX_SHIM_DIR="${HOME}/.config/dmux/bin"' "$zsh"
   # The default dmux wrapper must put the shim dir on PATH so its bare codex loads the SSOT.
   grep -qE 'PATH="\$\{_DMUX_SHIM_DIR\}:\$\{PATH\}"' "$zsh"
+  # MCP keys re-passed for parity with cld (claude expands the placeholders at spawn).
+  grep -qF 'EXA_API_KEY="${EXA_API_KEY:-}"' "$zsh"
+  grep -qF 'FIRECRAWL_API_KEY="${FIRECRAWL_API_KEY:-}"' "$zsh"
+  # claude's MCP keys are sourced here too so the wrapper does not depend on plugin load order.
+  grep -qF 'claude-secrets.zsh' "$zsh"
 }
 
 @test "dmux-r06 binds the r06 account env, a dedicated tmux socket and the codex shim" {
   local zsh="${HOME_DIR}/dot_config/zsh/dmux.zsh"
   grep -qE '^dmux-r06\(\) \{' "$zsh"
-  # Dedicated fresh tmux server so the env reaches every pane.
+  # Dedicated tmux server (own session namespace) so dmux-r06 never attaches to a default-account
+  # session of the same project; socket dir created 0700 to match tmux's default privacy.
   grep -qF 'TMUX_TMPDIR="$tmpdir"' "$zsh"
-  # Full per-account env set (mirrors _claude_with_home + CODEX_HOME).
+  grep -qF 'mkdir -m 700 -p "$tmpdir"' "$zsh"
+  # Full per-account env set (mirrors _claude_with_home + CODEX_HOME + the MCP keys).
   grep -qF 'CLAUDE_CONFIG_DIR="${HOME}/.claude-r06"' "$zsh"
   grep -qF 'ECC_AGENT_DATA_HOME="${HOME}/.claude-r06"' "$zsh"
   grep -qF 'CLV2_HOMUNCULUS_DIR="${HOME}/.claude-r06/ecc-homunculus"' "$zsh"
   grep -qF 'ECC_MCP_HEALTH_STATE_PATH="${HOME}/.claude-r06/mcp-health-cache.json"' "$zsh"
   grep -qF 'GATEGUARD_STATE_DIR="${HOME}/.claude-r06/.gateguard"' "$zsh"
   grep -qF 'CODEX_HOME="${HOME}/.codex-r06"' "$zsh"
+  grep -qF 'EXA_API_KEY="${EXA_API_KEY:-}"' "$zsh"
+  grep -qF 'FIRECRAWL_API_KEY="${FIRECRAWL_API_KEY:-}"' "$zsh"
   grep -qF 'command dmux "$@"' "$zsh"
 }
 
-@test "dmux-r06 injects the r06 account env into the dmux subprocess but not the parent shell" {
+@test "dmux-r06 injects the r06 account env and MCP keys into the subprocess but not the parent" {
   command -v zsh >/dev/null || skip "zsh not available"
   local zsh="${HOME_DIR}/dot_config/zsh/dmux.zsh"
   local tmp
   tmp="$(mktemp -d)"
   mkdir -p "$tmp/.config/zsh" "$tmp/bin"
+  # Stand in for the 1Password-rendered claude secrets (non-exported, sourced by dmux.zsh).
+  cat >"$tmp/.config/zsh/claude-secrets.zsh" <<'SECRETS'
+EXA_API_KEY='exa-test-key'
+FIRECRAWL_API_KEY='fc-test-key'
+SECRETS
   # Stub dmux binary that reports the per-account env it received.
   cat >"$tmp/bin/dmux" <<'STUB'
 #!/usr/bin/env bash
 printf 'SUB_CC=[%s]\n' "$(printenv CLAUDE_CONFIG_DIR)"
 printf 'SUB_CODEX=[%s]\n' "$(printenv CODEX_HOME)"
 printf 'SUB_TMPDIR=[%s]\n' "$(printenv TMUX_TMPDIR)"
+printf 'SUB_EXA=[%s]\n' "$(printenv EXA_API_KEY)"
+printf 'SUB_FIRE=[%s]\n' "$(printenv FIRECRAWL_API_KEY)"
 case ":$PATH:" in
 *":$HOME/.config/dmux/bin:"*) printf 'SUB_SHIM=[yes]\n' ;;
 *) printf 'SUB_SHIM=[no]\n' ;;
@@ -1149,20 +1204,26 @@ STUB
     export HOME='$tmp'
     export PATH=\"$tmp/bin:\$PATH\"
     # Start from a clean baseline: the outer test environment may already export these.
-    unset CLAUDE_CONFIG_DIR CODEX_HOME TMUX_TMPDIR
+    unset CLAUDE_CONFIG_DIR CODEX_HOME TMUX_TMPDIR EXA_API_KEY FIRECRAWL_API_KEY
     source '$zsh'
     dmux-r06
     printf 'PARENT_CC=[%s]\n' \"\$(printenv CLAUDE_CONFIG_DIR)\"
     printf 'PARENT_CODEX=[%s]\n' \"\$(printenv CODEX_HOME)\"
+    printf 'PARENT_EXA=[%s]\n' \"\$(printenv EXA_API_KEY)\"
   "
   [ "$status" -eq 0 ]
   echo "$output" | grep -qF "SUB_CC=[$tmp/.claude-r06]"
   echo "$output" | grep -qF "SUB_CODEX=[$tmp/.codex-r06]"
   echo "$output" | grep -qF "SUB_TMPDIR=[$tmp/.dmux-r06]"
+  echo "$output" | grep -qF 'SUB_EXA=[exa-test-key]'
+  echo "$output" | grep -qF 'SUB_FIRE=[fc-test-key]'
   echo "$output" | grep -qF 'SUB_SHIM=[yes]'
   # Parent shell must stay clean (env was scoped to the dmux subprocess only).
   echo "$output" | grep -qF 'PARENT_CC=[]'
   echo "$output" | grep -qF 'PARENT_CODEX=[]'
+  # EXA was sourced (non-exported) into the parent, but must NOT be exported to child env leak-style;
+  # printenv in the parent reflects the sourced shell var only if exported — it is not, so empty.
+  echo "$output" | grep -qF 'PARENT_EXA=[]'
 }
 
 @test "1Password validation requires the OpenRouter API key" {


### PR DESCRIPTION
## Summary

`dmux` launches the bare `claude` / `codex` binaries (it spawns `sh -c "codex …"` in `paneBootstrapRunner.js`), so the subprocess-scoped `cld-r06` / `cdx-r06` aliases never apply. Two consequences:

1. Every dmux pane runs the **default account** — there is no way to drive a whole dmux session in the r06 (work) account.
2. Codex runs **without `--profile shared`**, so the chezmoi-managed SSOT static config (`$CODEX_HOME/shared.config.toml`) is not loaded under dmux — for **either** account.

This wires both gaps. Primary-source verified against dmux 5.9.0 (`agentLaunch.js` / `paneBootstrapRunner.js` / `pathEnvironment.js` / `index.js`).

## Changes

- **`codex` PATH shim** (`~/.config/dmux/bin/codex`): re-injects `--profile shared` and execs the real codex, dropping its own dir from PATH first to avoid recursion. dmux launches `codex` via PATH lookup and its PATH sanitiser only strips `node_modules/.bin`, so the shim dir survives into every pane. Codex's only profile mechanism is the `-p/--profile` flag (the `profile = "…"` config key is a deprecated legacy selector; there is no env var), so a PATH shim is the only forward-compatible way to apply the SSOT under dmux.
- **`dmux` (default account)**: now prepends the shim dir so its codex panes load the SSOT config too.
- **`dmux-r06`** (new): binds the full r06 account env (`CLAUDE_CONFIG_DIR`, `ECC_AGENT_DATA_HOME`, `CLV2_HOMUNCULUS_DIR`, `ECC_MCP_HEALTH_STATE_PATH`, `GATEGUARD_STATE_DIR`, `CODEX_HOME`) and points tmux at a **dedicated socket via `TMUX_TMPDIR`**. tmux captures a session's environment from the server at creation time, so with a default-socket server already running (e.g. the auto-tmux-dev hook) a plain pre-launch export would not reach new panes; a dedicated fresh server captures the r06 env and every pane (and the shim) inherits it.
- **`claude` needs no shim**: its account is selected purely by `CLAUDE_CONFIG_DIR`, which the env set above provides.

## Decision recorded (issue AC #2)

Codex `--profile shared` **is** applied under dmux, via the PATH shim, for **both** accounts. Rejected alternatives: a legacy `profile = "shared"` config key (deprecated by codex, and lives in the codex-owned, runtime-rewritten `config.toml`); no `CODEX_PROFILE` env exists.

## Tests (`tests/files.bats`, +7)

- codex shim: structural, `shellcheck --shell=sh`, behavioral (injects `--profile shared` + drops own dir → no recursion against a stub real codex).
- `dmux` prepends the shim dir to PATH.
- `dmux-r06`: structural (env set + dedicated socket + shim) and behavioral (injects account env / `CODEX_HOME` / `TMUX_TMPDIR` / shim into the dmux subprocess, leaves the parent shell clean).

## Verification

- `make lint` — pass
- `bats tests/*.bats` — 127 passing, 0 failures

Closes #200