### PR TITLE
test: add a documentation freshness harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - 'home/**'
       - 'tests/**'
       - 'scripts/**'
+      - 'docs/**'
       - 'Makefile'
       - '.github/workflows/ci.yml'
   pull_request:
@@ -15,6 +16,7 @@ on:
       - 'home/**'
       - 'tests/**'
       - 'scripts/**'
+      - 'docs/**'
       - 'Makefile'
       - '.github/workflows/ci.yml'
   workflow_dispatch:

--- a/tests/docs_facts.bats
+++ b/tests/docs_facts.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+
+load helpers/setup
+
+# Documentation freshness checks: keep the docs/ tree from silently drifting out of sync
+# with the source it describes, the same way skill_provenance.bats keeps the skill taxonomy
+# honest. Dependency-free on purpose — CI's bats job installs only bats/shellcheck/zsh (no
+# chezmoi), so every assertion parses source with awk/grep.
+#
+# Scope is deliberately narrow: only IDENTITY facts that change on intentional restructuring
+# are pinned. Volatile, Renovate-bumped values (tool versions, the ECC commit SHA, the
+# externals total) are NOT asserted — they live as source pointers in the docs so a
+# dependency bump never fails this suite. Load-bearing counts are wrapped in
+# `<!-- FACT:name -->VALUE<!-- /FACT -->` markers, so only the numbers a human marked
+# authoritative are pinned; everything else is implicitly illustrative.
+
+@test "docs_facts: every <!-- FACT:ecc-skill-count --> marker matches the [ecc].skills length" {
+  local actual
+  actual="$(_ecc_skill_list | grep -c .)"
+  [ "$actual" -ge 100 ] || {
+    echo "sanity: [ecc].skills resolved to $actual (<100) — the extractor likely broke"
+    false
+  }
+  local found=0 f val
+  while IFS= read -r f; do
+    while IFS= read -r val; do
+      found=1
+      [ "$val" = "$actual" ] || {
+        echo "${f#"${REPO_ROOT}/"}: FACT:ecc-skill-count is $val but [ecc].skills has $actual entries"
+        false
+      }
+    done < <(grep -oE 'FACT:ecc-skill-count[^0-9]*[0-9]+' "$f" | grep -oE '[0-9]+$')
+  done < <(grep -rlF 'FACT:ecc-skill-count' "${DOCS_DIR}")
+  [ "$found" = 1 ] || {
+    echo "no FACT:ecc-skill-count markers found under ${DOCS_DIR} — the docs refactor regressed"
+    false
+  }
+}
+
+@test "docs_facts: every lifecycle script in home/ is documented in lifecycle-scripts.md" {
+  local doc="${DOCS_DIR}/architecture/lifecycle-scripts.md"
+  [ -f "$doc" ]
+  local f slug
+  for f in "${HOME_DIR}"/run_*.sh.tmpl; do
+    [ -e "$f" ] || continue
+    slug="$(basename "$f")"
+    slug="${slug#run_once_}"
+    slug="${slug#run_onchange_}"
+    slug="${slug#before_}"
+    slug="${slug#after_}"
+    slug="${slug%.sh.tmpl}"
+    grep -qF "$slug" "$doc" || {
+      echo "lifecycle script '$slug' exists in home/ but is not documented in lifecycle-scripts.md"
+      false
+    }
+  done
+}
+
+@test "docs_facts: every Makefile target is documented in contributing/local-dev.md" {
+  local doc="${DOCS_DIR}/contributing/local-dev.md"
+  [ -f "$doc" ]
+  local t
+  while IFS= read -r t; do
+    # `all` is the meta default (-> help); it is not a user-facing command in the table.
+    [ "$t" = "all" ] && continue
+    grep -qF "\`${t}\`" "$doc" || {
+      echo "Makefile target '$t' is not documented in local-dev.md"
+      false
+    }
+  done < <(grep -oE '^[a-z][a-z-]*:' "${REPO_ROOT}/Makefile" | sed 's/:$//')
+}
+
+@test "docs_facts: every relative .md link in docs resolves to an existing file" {
+  local f dir target broken=0
+  while IFS= read -r f; do
+    dir="$(dirname "$f")"
+    while IFS= read -r target; do
+      target="${target%%#*}" # drop #anchor
+      [ -z "$target" ] && continue
+      case "$target" in
+      http://* | https://* | mailto:*) continue ;;
+      esac
+      case "$target" in
+      *.md) ;;
+      *) continue ;;
+      esac
+      # The OS resolves any ../ in the joined path at access time.
+      [ -f "${dir}/${target}" ] || {
+        echo "broken relative link in ${f#"${REPO_ROOT}/"}: ${target}"
+        broken=1
+      }
+    done < <(grep -oE '\]\([^)]+\)' "$f" | sed -E 's/^\]\(//; s/\)$//')
+  done < <(find "${DOCS_DIR}" -name '*.md')
+  [ "$broken" -eq 0 ]
+}
+
+@test "docs_facts: every EN doc has a .ja.md mirror and vice versa" {
+  local f sibling missing=0
+  while IFS= read -r f; do
+    case "$f" in
+    *.ja.md)
+      sibling="${f%.ja.md}.md"
+      [ -f "$sibling" ] || {
+        echo "JA doc without an EN canonical sibling: ${f#"${REPO_ROOT}/"}"
+        missing=1
+      }
+      ;;
+    *.md)
+      sibling="${f%.md}.ja.md"
+      [ -f "$sibling" ] || {
+        echo "EN doc without a JA mirror: ${f#"${REPO_ROOT}/"}"
+        missing=1
+      }
+      ;;
+    esac
+  done < <(find "${DOCS_DIR}" -name '*.md')
+  [ "$missing" -eq 0 ]
+}

--- a/tests/helpers/setup.bash
+++ b/tests/helpers/setup.bash
@@ -3,3 +3,23 @@
 # Common test helpers
 REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
 HOME_DIR="${REPO_ROOT}/home"
+DOCS_DIR="${REPO_ROOT}/docs"
+
+# Resolve the [ecc].skills array from .chezmoidata.toml. Shared by skill_provenance.bats
+# and docs_facts.bats so the two suites can't diverge on how they count ECC skills.
+#
+# The .chezmoiexternal.toml range over [ecc].skills emits one [".agents/skills/<name>"]
+# entry per element, so a literal grep of that file (which only sees the `{{ $skill }}`
+# template var) can't see the expanded names — resolve the list directly here. Scoped
+# strictly to the [ecc] table's `skills = [ ... ]` array so an unrelated section gaining a
+# `skills` key (or a formatter changing the indent) can't perturb the result. Kept
+# dependency-free on purpose: CI's bats job installs only bats/shellcheck/zsh, no chezmoi.
+_ecc_skill_list() {
+  awk '
+    /^\[ecc\]$/        { in_ecc = 1; next }
+    /^\[/              { in_ecc = 0; in_list = 0 }
+    in_ecc && /^[[:space:]]*skills[[:space:]]*=[[:space:]]*\[/ { in_list = 1; next }
+    in_ecc && in_list && /^[[:space:]]*\]/ { in_list = 0; next }
+    in_ecc && in_list  { print }
+  ' "${HOME_DIR}/.chezmoidata.toml" | grep -oE '"[^"]+"' | tr -d '"'
+}

--- a/tests/skill_provenance.bats
+++ b/tests/skill_provenance.bats
@@ -2,22 +2,8 @@
 
 load helpers/setup
 
-# Names declared external via the templated range over .chezmoidata.toml [ecc].skills.
-# That range emits one [".agents/skills/<name>"] entry per list element, so a literal grep
-# of .chezmoiexternal.toml (which only sees the `{{ $skill }}` template var) can't see the
-# expanded names — resolve the list directly. Kept dependency-free on purpose: CI's bats
-# job installs only bats/shellcheck/zsh, no chezmoi to render the template.
-_ecc_skill_list() {
-  # Scope strictly to the [ecc] table's `skills = [ ... ]` array so an unrelated section
-  # gaining a `skills` key (or a formatter changing the indent) can't perturb the result.
-  awk '
-    /^\[ecc\]$/        { in_ecc = 1; next }
-    /^\[/              { in_ecc = 0; in_list = 0 }
-    in_ecc && /^[[:space:]]*skills[[:space:]]*=[[:space:]]*\[/ { in_list = 1; next }
-    in_ecc && in_list && /^[[:space:]]*\]/ { in_list = 0; next }
-    in_ecc && in_list  { print }
-  ' "${HOME_DIR}/.chezmoidata.toml" | grep -oE '"[^"]+"' | tr -d '"'
-}
+# _ecc_skill_list (resolves the [ecc].skills array) lives in helpers/setup.bash so this
+# suite and docs_facts.bats share one definition and can't diverge on how they count.
 
 # True if <name> is declared external: either a literal [".agents/skills/<name>..."] table
 # header in .chezmoiexternal.toml, or an element of the [ecc].skills range source above.


### PR DESCRIPTION
## Summary

Follow-up to #203. Adds a small, chezmoi-free **documentation freshness harness** so the
new `docs/` tree stops silently drifting out of sync with the source it describes — the same
way `tests/skill_provenance.bats` already keeps the skill taxonomy honest.

Building #203 surfaced exactly this drift class: a count written as 127 vs 124 vs 147, a
referenced lifecycle script (`30-setup-fonts`) that does not exist, the wrong `ci.yml` job
count, `cdx` wrongly said to set `CODEX_HOME`, etc. Most of those are mechanically
checkable against source — this suite checks the high-value, low-false-positive ones.

## What it asserts — `tests/docs_facts.bats` (5 checks)

1. **ECC skill count** — every `<!-- FACT:ecc-skill-count -->N<!-- /FACT -->` marker in
   `docs/` equals the resolved `[ecc].skills` length (the flagship check; the markers were
   added in #203).
2. **Lifecycle coverage** — every `home/run_*` script is documented in
   `architecture/lifecycle-scripts.md` (catches a new script that nobody documented).
3. **Make targets** — every `Makefile` target is documented in `contributing/local-dev.md`.
4. **Cross-links** — every relative `*.md` link under `docs/` resolves (http/anchor-only
   targets are skipped).
5. **Bilingual parity** — every EN doc has a `.ja.md` mirror and vice versa.

## Design — pin identity, not churn

Volatile, **Renovate-bumped** values (tool versions, the ECC commit SHA, the externals
total) are deliberately **not** asserted — asserting them would make the suite fail on every
dependency bump that has nothing to do with docs correctness. #203 already moved those to
source pointers (`see home/dot_config/mise/config.toml`, etc.). Only the handful of
human-marked `FACT:` numbers are pinned; everything else is implicitly illustrative.

## Wiring

- Chezmoi-free: every assertion parses `home/` / `docs/` / `Makefile` with `awk`/`grep`,
  exactly like `skill_provenance.bats` (CI's bats job installs only bats/shellcheck/zsh).
- `make test-bats` already globs `tests/*.bats`, so the file is auto-picked-up — no Makefile
  change.
- `_ecc_skill_list` is moved to `tests/helpers/setup.bash` so this suite and
  `skill_provenance.bats` share one definition (no duplicated extractor to drift).
- `docs/**` is added to the `ci.yml` push + pull_request path filters so the suite runs on
  docs-only PRs, which previously triggered no CI.

## Verification

- `make lint` + `make test-bats` green locally; the 5 new checks pass (134 tests total).
- Negative-tested: a drifted `FACT:ecc-skill-count` value (e.g. `999`) fails the count check
  as intended — the harness is not a no-op.

## Considered but deferred

An "inverted" guard that asserts `setup-validation.yml` still references the stale
`30-setup-fonts` (so the Known-Issue note in `ci-and-tests.md` stays truthful until the
source is fixed) was considered but left out as too clever for now; the underlying
`setup-validation.yml` `cp home/.chezmoi.toml` / stale-font issues remain tracked for a
separate fix, as documented in #203.
