### PR TITLE
docs(codex): note happy codex is remote-control only, no local TUI

### DIFF
--- a/docs/agents/codex.ja.md
+++ b/docs/agents/codex.ja.md
@@ -137,6 +137,10 @@ cdx-r06  → CODEX_HOME=$HOME/.codex-r06 codex --profile shared "$@"
 ```
 
 `hcdx` と `hcdx-r06` は phone-control コンテキスト用のバリアントです（happy ラッパー経由）。
+ただし `happy codex` は `codex app-server` 経由で Codex を **headless** 起動し、ローカル端末は
+read-only ビューア（"Codex Agent Messages / Waiting for messages…"）で対話プロンプトを持ちません。
+セッション操作は Happy モバイル/Web アプリ側から行います。ローカルで対話的に Codex を使う場合は
+`cdx` / `cdx-r06` を使用してください（フル TUI をローカル起動する `happy claude` とは非対称です）。
 
 ### dmux PATH シム
 

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -137,6 +137,11 @@ cdx-r06  → CODEX_HOME=$HOME/.codex-r06 codex --profile shared "$@"
 ```
 
 Variants `hcdx` and `hcdx-r06` exist for phone-control contexts (via the happy wrapper).
+Note that `happy codex` runs Codex **headless** via `codex app-server`: the local terminal
+is a read-only viewer ("Codex Agent Messages / Waiting for messages…") with no interactive
+prompt, so the session is driven from the Happy mobile/web app. For a local interactive
+Codex terminal, use `cdx` / `cdx-r06` instead. (This is asymmetric with `happy claude`,
+which spawns a full local TUI.)
 
 ### dmux PATH shim
 

--- a/home/dot_config/zsh/codex.zsh
+++ b/home/dot_config/zsh/codex.zsh
@@ -14,5 +14,11 @@ alias cdx-r06='CODEX_HOME=$HOME/.codex-r06 codex --profile shared'
 # `happy codex` forwards `--profile shared` to codex and respects CODEX_HOME, so each
 # account keeps its SSOT config and isolation; happy's own state (~/.happy) is shared
 # across accounts (one pairing controls every account).
+#
+# NOTE: `happy codex` runs Codex HEADLESS via `codex app-server`. The local terminal is a
+#       read-only viewer ("Codex Agent Messages / Waiting for messages…") with NO local
+#       interactive prompt — drive the session from the Happy mobile/web app. For a local
+#       interactive Codex terminal, use `cdx` / `cdx-r06` instead. (This is asymmetric with
+#       `happy claude`/`hcld`, which spawns a full local TUI.)
 alias hcdx='happy codex --profile shared'
 alias hcdx-r06='CODEX_HOME=$HOME/.codex-r06 happy codex --profile shared'


### PR DESCRIPTION
## Summary

Document that `hcdx` / `hcdx-r06` (the `happy codex` wrapper aliases) do **not** provide a
local interactive Codex session — investigated after the terminal appeared "stuck" on
Happy's `Codex Agent Messages / Waiting for messages…` panel.

This is **working as designed**, not a bug: `happy codex` runs Codex headless via
`codex app-server` and the local terminal is a read-only viewer with no input. The session
is driven from the Happy mobile/web app. For a local interactive Codex terminal, use the
plain `cdx` / `cdx-r06` aliases. This is asymmetric with `happy claude` (`hcld`), which
spawns a full local TUI via `claude_local_launcher`.

## Findings (evidence)

- Happy session log shows a healthy connect: `codex app-server --listen stdio://` spawned,
  `initialize` → `initialized` OK, MCP server ready, socket connected,
  `[MessageQueue2] Waiting for messages...` (idle).
- The `Codex Agent Messages` panel is a read-only Ink component (no `TextInput` / `onSubmit`
  / `readline`; `useInput` is only the Ctrl-C exit handler).
- No `codex_local_launcher` exists in Happy; only `claude_local_launcher` does — so Codex
  has no local-TUI path, unlike Claude.
- Environment: happy `1.1.10` (latest on npm, pinned via mise `npm:happy`),
  codex-cli `0.139.0`, node `24.18.0`, macOS arm64.

## Changes

- `home/dot_config/zsh/codex.zsh`: add a `NOTE` next to the `hcdx` / `hcdx-r06` aliases.
- `docs/agents/codex.md` + `codex.ja.md`: mirror the same clarification.

Docs-only / comment-only; no behavior change.

## Test plan

- [x] `make lint` (shellcheck + shfmt + zsh syntax) passes
- [x] `bats tests/docs_facts.bats` passes (FACT markers, link resolution, EN/JA mirror)
