### PR TITLE
feat(dmux): add opt-in happy-claude shim (DMUX_HAPPY)

### DIFF
--- a/docs/agents/codex.ja.md
+++ b/docs/agents/codex.ja.md
@@ -153,6 +153,20 @@ dmux は素の `codex` 呼び出しで Codex ペインをスポーンし、`--pr
 
 このシムなしでは、dmux ペインは SSOT `shared.config.toml` なしでサイレントに実行されます。
 
+#### オプトインの happy-claude シム（`DMUX_HAPPY`）
+
+同じシムディレクトリには `executable_claude` も同梱されます。これは Claude ペインを happy
+ラッパー経由（スマホ操作）で起動するための**オプトイン**コンパニオンです。デフォルトでは
+透過パススルー（`PATH` 上の最初の実 `claude` を exec）なので、dmux の既定挙動は変わりません。
+`DMUX_HAPPY=1 dmux` で `happy claude` に切り替わります。exec 前に `DMUX_HAPPY` を `unset` する
+ため、happy が spawn する入れ子の `claude` はパススルー側に入り、再帰は構造的に不可能です
+（codex シムと同じ原理）。
+
+Codex はこの方式で**ラップしません**。`happy codex` は `codex app-server` 経由で Codex を
+headless 起動し、ローカル端末は入力欄のない read-only ビューアになる（上の
+`cdx / cdx-r06 aliases` 節を参照）ため、対話的な dmux ペインを駆動できません。スマホ操作の
+Codex は `hcdx` を単体起動し、dmux 内では `cdx` / `cdx-r06` を使ってください。
+
 ### 素の codex は SSOT 設定をスキップする
 
 エイリアスや dmux シムなしの直接 `codex` 呼び出しは `shared.config.toml` を**ロードしません**。`--profile shared` フラグが適用する唯一のメカニズムです。これは意図的なもの（Codex ではプロファイルはオプトイン）ですが、`codex` を直接呼び出すスクリプト、CI、またはエディタ統合では気づきにくい落とし穴です。

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -154,6 +154,20 @@ dmux spawns Codex panes with a bare `codex` invocation and cannot pass `--profil
 
 Without this shim, dmux panes would silently run without the SSOT `shared.config.toml`.
 
+#### Opt-in happy-claude shim (`DMUX_HAPPY`)
+
+The same shim directory also ships `executable_claude`, an **opt-in** companion for running
+Claude panes through the happy wrapper (phone control). By default it is a transparent
+passthrough — it execs the first real `claude` on `PATH`, so default dmux behavior is
+unchanged. Running `DMUX_HAPPY=1 dmux` flips it to `happy claude`; it `unset`s `DMUX_HAPPY`
+before exec so the nested `claude` happy spawns passes through (recursion is structurally
+impossible, same as the codex shim).
+
+Codex is deliberately **not** wrapped this way: `happy codex` runs Codex headless via
+`codex app-server` and the local terminal is a read-only viewer with no input (see the
+`cdx / cdx-r06 aliases` section above), so it cannot drive an interactive dmux pane. Use
+`hcdx` standalone for phone-controlled Codex, and keep `cdx` / `cdx-r06` inside dmux.
+
 ### Bare codex skips the SSOT config
 
 A direct `codex` invocation — without the aliases or the dmux shim in `PATH` — does **not** load `shared.config.toml`. The `--profile shared` flag is the only mechanism that applies it. This is intentional (profiles are opt-in in Codex), but easy to trip over in scripts, CI, or editor integrations that invoke `codex` directly.

--- a/home/dot_config/dmux/bin/executable_claude
+++ b/home/dot_config/dmux/bin/executable_claude
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Opt-in dmux → happy-claude shim. dmux launches the bare `claude` binary (paneBootstrapRunner
+# types `claude …` into the pane shell), and the dmux / dmux-r06 zsh wrappers prepend this
+# shim's directory to PATH (alongside the codex shim), so this file intercepts `claude` in every
+# pane. By default it is a TRANSPARENT passthrough — it execs the first OTHER `claude` on PATH,
+# exactly matching dmux's own PATH resolution, so default dmux behaviour is unchanged.
+#
+# When DMUX_HAPPY is set (run `DMUX_HAPPY=1 dmux`), it instead launches `happy claude` so the
+# pane is phone-controllable. happy spawns the REAL Claude Code TUI locally (unlike `happy
+# codex`, which is headless/remote-only — see docs/agents/codex.md), so the pane stays
+# interactive and dmux's prompt dispatch / pane-state capture keep working.
+#
+# Recursion is structurally impossible: before exec'ing happy we `unset DMUX_HAPPY`, so the
+# nested `claude` that happy spawns re-enters this shim with DMUX_HAPPY cleared and takes the
+# transparent-passthrough branch — never `happy claude` again. (The pane's own shell keeps
+# DMUX_HAPPY; only the happy subprocess tree has it cleared.) The codex shim deliberately
+# ignores DMUX_HAPPY: `happy codex` has no local TUI, so wrapping codex panes would break dmux.
+#
+# Account selection needs no flag here: claude picks its account purely from CLAUDE_CONFIG_DIR
+# (set by dmux-r06's session env), which happy inherits.
+case "$0" in
+  */*) self_dir="${0%/*}" ;;
+  *) self_dir="${HOME}/.config/dmux/bin" ;;
+esac
+self_dir="${self_dir%/}"
+
+if [ -n "${DMUX_HAPPY}" ]; then
+  unset DMUX_HAPPY
+  exec happy claude "$@"
+fi
+
+# Default: transparent passthrough to the first `claude` on PATH that is not this shim.
+real=""
+IFS=:
+for dir in $PATH; do
+  d="${dir%/}"
+  [ "$d" = "$self_dir" ] && continue
+  if [ -x "$d/claude" ]; then
+    real="$d/claude"
+    break
+  fi
+done
+unset IFS
+
+[ -n "$real" ] || {
+  printf '%s\n' "dmux claude shim: no real claude found on PATH" >&2
+  exit 127
+}
+
+exec "$real" "$@"

--- a/home/dot_config/dmux/bin/executable_claude
+++ b/home/dot_config/dmux/bin/executable_claude
@@ -5,7 +5,7 @@
 # pane. By default it is a TRANSPARENT passthrough — it execs the first OTHER `claude` on PATH,
 # exactly matching dmux's own PATH resolution, so default dmux behaviour is unchanged.
 #
-# When DMUX_HAPPY is set (run `DMUX_HAPPY=1 dmux`), it instead launches `happy claude` so the
+# When DMUX_HAPPY=1 (run `DMUX_HAPPY=1 dmux`), it instead launches `happy claude` so the
 # pane is phone-controllable. happy spawns the REAL Claude Code TUI locally (unlike `happy
 # codex`, which is headless/remote-only — see docs/agents/codex.md), so the pane stays
 # interactive and dmux's prompt dispatch / pane-state capture keep working.
@@ -24,9 +24,16 @@ case "$0" in
 esac
 self_dir="${self_dir%/}"
 
-if [ -n "${DMUX_HAPPY}" ]; then
+if [ "${DMUX_HAPPY:-}" = "1" ]; then
   unset DMUX_HAPPY
-  exec happy claude "$@"
+  # Resolve happy to an absolute path (symmetry with the passthrough branch) and fail with a
+  # clear diagnostic if it is missing, rather than relying on the shell's bare-name exec error.
+  happy_bin="$(command -v happy 2>/dev/null)"
+  [ -n "$happy_bin" ] || {
+    printf '%s\n' "dmux claude shim: DMUX_HAPPY=1 but no happy found on PATH" >&2
+    exit 127
+  }
+  exec "$happy_bin" claude "$@"
 fi
 
 # Default: transparent passthrough to the first `claude` on PATH that is not this shim.

--- a/home/dot_config/zsh/dmux.zsh
+++ b/home/dot_config/zsh/dmux.zsh
@@ -21,8 +21,11 @@
 # `sh -c "codex …"`), so it cannot pass `--profile shared`, the chezmoi-managed SSOT static
 # config ($CODEX_HOME/shared.config.toml). Prepending this dir to PATH makes dmux pick up the
 # shim, which re-injects `--profile shared` for every codex pane (both accounts). dmux's PATH
-# sanitiser only strips node_modules/.bin, so the shim dir survives into the panes. claude
-# needs no shim: its account is selected purely by CLAUDE_CONFIG_DIR.
+# sanitiser only strips node_modules/.bin, so the shim dir survives into the panes. The same
+# dir also holds an opt-in `claude` shim: by default it is a transparent passthrough (claude's
+# account is selected purely by CLAUDE_CONFIG_DIR), but `DMUX_HAPPY=1 dmux` makes it launch
+# `happy claude` for phone control. Codex is deliberately not wrapped: `happy codex` is
+# headless/remote-only (no local TUI), so it cannot drive a dmux pane (see docs/agents/codex.md).
 _DMUX_SHIM_DIR="${HOME}/.config/dmux/bin"
 
 dmux() {

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1144,6 +1144,82 @@ STUB
   echo "$output" | grep -qF 'no real codex found on PATH'
 }
 
+@test "dmux claude shim deploys as ~/.config/dmux/bin/claude and is opt-in via DMUX_HAPPY" {
+  local shim="${HOME_DIR}/dot_config/dmux/bin/executable_claude"
+  [ -f "$shim" ]
+  # executable_ prefix → chezmoi deploys 0755 as `claude` (no extension), which dmux invokes.
+  head -1 "$shim" | grep -qE '^#!/bin/sh'
+  # Opt-in branch launches happy claude; default branch is a transparent passthrough.
+  grep -qF 'exec happy claude "$@"' "$shim"
+  grep -qF 'exec "$real" "$@"' "$shim"
+  # Recursion break: DMUX_HAPPY is cleared before exec so the nested claude passes through.
+  grep -qF 'unset DMUX_HAPPY' "$shim"
+}
+
+@test "dmux claude shim passes shellcheck and shfmt as POSIX sh" {
+  local shim="${HOME_DIR}/dot_config/dmux/bin/executable_claude"
+  # make lint only globs *.sh/*.sh.tmpl, so the extension-less shim needs explicit coverage.
+  if command -v shellcheck >/dev/null; then
+    shellcheck --shell=sh --exclude=SC1091,SC2034,SC2086,SC2317,SC2329 "$shim"
+  fi
+  if command -v shfmt >/dev/null; then
+    shfmt -d -i 2 -ci "$shim"
+  fi
+}
+
+@test "dmux claude shim is a transparent passthrough when DMUX_HAPPY is unset" {
+  local shimsrc="${HOME_DIR}/dot_config/dmux/bin/executable_claude"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/shim" "$tmp/real"
+  cp "$shimsrc" "$tmp/shim/claude"
+  chmod +x "$tmp/shim/claude"
+  # Real claude stub (in a separate dir) reports the args it was handed — verbatim, no flags.
+  cat >"$tmp/real/claude" <<'STUB'
+#!/usr/bin/env bash
+printf 'REAL_CLAUDE_ARGS=[%s]\n' "$*"
+STUB
+  chmod +x "$tmp/real/claude"
+  # shim dir first, real dir second: the shim must skip its own dir, then resolve the real claude.
+  run env -u DMUX_HAPPY PATH="$tmp/shim:$tmp/real:/usr/bin:/bin" sh -c 'claude --resume foo'
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF 'REAL_CLAUDE_ARGS=[--resume foo]'
+}
+
+@test "dmux claude shim wraps in happy and clears DMUX_HAPPY to break recursion when opted in" {
+  local shimsrc="${HOME_DIR}/dot_config/dmux/bin/executable_claude"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/shim" "$tmp/bin"
+  cp "$shimsrc" "$tmp/shim/claude"
+  chmod +x "$tmp/shim/claude"
+  # happy stub reports its args and whether DMUX_HAPPY survived into its environment.
+  cat >"$tmp/bin/happy" <<'STUB'
+#!/usr/bin/env bash
+printf 'HAPPY_ARGS=[%s]\n' "$*"
+printf 'HAPPY_DMUX_HAPPY=[%s]\n' "${DMUX_HAPPY-<unset>}"
+STUB
+  chmod +x "$tmp/bin/happy"
+  run env DMUX_HAPPY=1 PATH="$tmp/shim:$tmp/bin:/usr/bin:/bin" sh -c 'claude --permission-mode plan'
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF 'HAPPY_ARGS=[claude --permission-mode plan]'
+  # The nested claude that happy would spawn must NOT see DMUX_HAPPY (else it would re-wrap).
+  echo "$output" | grep -qF 'HAPPY_DMUX_HAPPY=[<unset>]'
+}
+
+@test "dmux claude shim exits non-zero (no fork bomb) when no real claude is on PATH" {
+  local shimsrc="${HOME_DIR}/dot_config/dmux/bin/executable_claude"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/shim"
+  cp "$shimsrc" "$tmp/shim/claude"
+  chmod +x "$tmp/shim/claude"
+  # Only the shim is reachable as `claude`: it must fail cleanly, never recurse into itself.
+  run env -u DMUX_HAPPY PATH="$tmp/shim:/usr/bin:/bin" "$tmp/shim/claude" --resume
+  [ "$status" -eq 127 ]
+  echo "$output" | grep -qF 'no real claude found on PATH'
+}
+
 @test "dmux (default account) prepends the codex shim dir to PATH and passes the MCP keys" {
   local zsh="${HOME_DIR}/dot_config/zsh/dmux.zsh"
   grep -qF '_DMUX_SHIM_DIR="${HOME}/.config/dmux/bin"' "$zsh"

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1149,8 +1149,10 @@ STUB
   [ -f "$shim" ]
   # executable_ prefix → chezmoi deploys 0755 as `claude` (no extension), which dmux invokes.
   head -1 "$shim" | grep -qE '^#!/bin/sh'
-  # Opt-in branch launches happy claude; default branch is a transparent passthrough.
-  grep -qF 'exec happy claude "$@"' "$shim"
+  # Opt-in is strict (=1), not just "non-empty", so DMUX_HAPPY=0 does not enable happy.
+  grep -qF '[ "${DMUX_HAPPY:-}" = "1" ]' "$shim"
+  # Opt-in branch launches happy (resolved to an absolute path); default branch passes through.
+  grep -qF 'exec "$happy_bin" claude "$@"' "$shim"
   grep -qF 'exec "$real" "$@"' "$shim"
   # Recursion break: DMUX_HAPPY is cleared before exec so the nested claude passes through.
   grep -qF 'unset DMUX_HAPPY' "$shim"
@@ -1205,6 +1207,44 @@ STUB
   echo "$output" | grep -qF 'HAPPY_ARGS=[claude --permission-mode plan]'
   # The nested claude that happy would spawn must NOT see DMUX_HAPPY (else it would re-wrap).
   echo "$output" | grep -qF 'HAPPY_DMUX_HAPPY=[<unset>]'
+}
+
+@test "dmux claude shim treats DMUX_HAPPY=0 as off (strict =1 opt-in, not just non-empty)" {
+  local shimsrc="${HOME_DIR}/dot_config/dmux/bin/executable_claude"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/shim" "$tmp/real" "$tmp/bin"
+  cp "$shimsrc" "$tmp/shim/claude"
+  chmod +x "$tmp/shim/claude"
+  # A happy stub that would shout if (wrongly) invoked, plus a real claude for the passthrough.
+  cat >"$tmp/bin/happy" <<'STUB'
+#!/usr/bin/env bash
+printf 'HAPPY_WAS_CALLED=[%s]\n' "$*"
+STUB
+  chmod +x "$tmp/bin/happy"
+  cat >"$tmp/real/claude" <<'STUB'
+#!/usr/bin/env bash
+printf 'REAL_CLAUDE_ARGS=[%s]\n' "$*"
+STUB
+  chmod +x "$tmp/real/claude"
+  # DMUX_HAPPY=0 must NOT enable happy: a non-empty-but-not-1 value falls through to passthrough.
+  run env DMUX_HAPPY=0 PATH="$tmp/shim:$tmp/bin:$tmp/real:/usr/bin:/bin" sh -c 'claude --resume foo'
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF 'REAL_CLAUDE_ARGS=[--resume foo]'
+  ! echo "$output" | grep -qF 'HAPPY_WAS_CALLED'
+}
+
+@test "dmux claude shim fails with a clear diagnostic when DMUX_HAPPY=1 but happy is absent" {
+  local shimsrc="${HOME_DIR}/dot_config/dmux/bin/executable_claude"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/shim"
+  cp "$shimsrc" "$tmp/shim/claude"
+  chmod +x "$tmp/shim/claude"
+  # Opt-in requested but no happy on PATH: must exit non-zero with an explicit message, not recurse.
+  run env DMUX_HAPPY=1 PATH="$tmp/shim:/usr/bin:/bin" sh -c 'claude --permission-mode plan'
+  [ "$status" -eq 127 ]
+  echo "$output" | grep -qF 'DMUX_HAPPY=1 but no happy found on PATH'
 }
 
 @test "dmux claude shim exits non-zero (no fork bomb) when no real claude is on PATH" {


### PR DESCRIPTION
## Summary

Add an **opt-in** way to run dmux Claude panes through the happy wrapper (phone control),
following the same PATH-shim pattern as the existing codex shim.

`home/dot_config/dmux/bin/executable_claude` is deployed alongside `executable_codex`. By
default it is a **transparent passthrough** — it execs the first real `claude` on `PATH`, so
default dmux behavior is unchanged. Running `DMUX_HAPPY=1 dmux` flips it to `happy claude`.

## Why codex is not wrapped

`happy codex` runs Codex **headless** via `codex app-server`; the local terminal is a
read-only viewer with no input (documented in #211). dmux drives panes by typing into an
interactive TUI, so a happy-codex pane would be a dead, non-interactive panel. Codex is
therefore deliberately left as bare `cdx` / `cdx-r06` inside dmux; use `hcdx` standalone for
phone-controlled Codex. `happy claude`, by contrast, spawns the real Claude Code TUI locally,
so it stays interactive under dmux.

## Recursion safety

The shim `unset`s `DMUX_HAPPY` before `exec happy claude`, so the nested `claude` that happy
spawns re-enters the shim with the flag cleared and takes the passthrough branch — recursion
is structurally impossible (same guarantee as the codex shim's self-dir skip).

## Changes

- `home/dot_config/dmux/bin/executable_claude`: new POSIX-sh shim (mode 0755 via `executable_` prefix)
- `home/dot_config/zsh/dmux.zsh`: document the opt-in shim next to the shim-dir definition
- `docs/agents/codex.md` + `codex.ja.md`: add a `DMUX_HAPPY` subsection to the dmux PATH-shim docs
- `tests/files.bats`: 5 new cases mirroring the codex shim coverage

## Test plan

- [x] `make lint` (shellcheck + shfmt + zsh syntax) passes
- [x] `make test-bats` passes in a clean env (105 tests; the 5 new claude-shim cases incl. shellcheck/shfmt of the shim, passthrough, happy opt-in + recursion break, clean exit-127)
- [x] `bats tests/docs_facts.bats` passes (FACT markers, link resolution, EN/JA mirror)
- [ ] **Manual (needs interactive tmux + paired phone):** `DMUX_HAPPY=1 dmux` in a real session, confirm a Claude pane comes up phone-controllable **and** dmux's pane-state detection still works (happy injects its own hooks/`--settings`; if dmux's hook-based state detection degrades, it should fall back to text-capture heuristics). This is the one residual risk flagged during design.

## Notes

Docs-only assertion: codex behavior is unchanged; the codex shim ignores `DMUX_HAPPY`.
