### PR TITLE
fix(brew): source brew shellenv before brew bundle on macOS

### DIFF
--- a/home/run_onchange_before_10-brew-bundle.sh.tmpl
+++ b/home/run_onchange_before_10-brew-bundle.sh.tmpl
@@ -12,6 +12,11 @@ trap 'rm -f "$TMPFILE"' EXIT
 grep -E '^(tap |brew )' "$BREWFILE" | grep -v -E -f "$EXCLUDE" >"$TMPFILE"
 brew bundle --no-upgrade --file="$TMPFILE"
 {{ else -}}
+{{ if eq .chezmoi.arch "arm64" -}}
+eval "$(/opt/homebrew/bin/brew shellenv)"
+{{ else -}}
+eval "$(/usr/local/bin/brew shellenv)"
+{{ end -}}
 echo "Running brew bundle..."
 brew bundle --no-upgrade --file="{{ .chezmoi.sourceDir }}/dot_Brewfile"
 {{ end -}}


### PR DESCRIPTION
## Summary

- On a fresh macOS bootstrap (`install.sh` → `chezmoi init --apply`), the `brew bundle` step failed with `brew: command not found` (`chezmoi: 10-brew-bundle.sh: exit status 127`).
- Root cause: chezmoi runs each `run_` script as an **independent subprocess**. `run_once_before_00-install-prerequisites.sh.tmpl` installs Homebrew and sources it via `eval "$(... brew shellenv)"`, but that PATH change only lives in script 00's process. The next script, `run_onchange_before_10-brew-bundle.sh.tmpl`, runs in a new subprocess where `/opt/homebrew/bin` is not yet on `PATH` (the user's `.zprofile` has not been updated and the terminal has not been restarted). The **Linux** branch already guarded against this with `eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"`, but the **macOS** branch called `brew bundle` directly.
- Fix: add an arch-conditional `eval "$(... brew shellenv)"` at the top of the macOS branch (`/opt/homebrew` for arm64, `/usr/local` for intel), mirroring the Linux branch and the existing idiom in `run_once_before_00-install-prerequisites.sh.tmpl`. Re-sourcing when brew is already on `PATH` is idempotent, so re-runs are unaffected.

## Test plan

- [x] `make lint` — shellcheck / shfmt / zsh syntax checks all pass
- [x] `make test` — bats suite (141 tests) passes
- [ ] Fresh macOS bootstrap completes through `brew bundle` without `command not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)