### PR TITLE
chore(git): globally ignore dmux per-repo dirs (.dmux/, .dmux-hooks/)

### DIFF
--- a/home/dot_gitignore_global
+++ b/home/dot_gitignore_global
@@ -207,6 +207,11 @@ dogfood-output/
 # Playwright MCP
 .playwright-mcp/
 
+# dmux (tmux agent pane manager): per-repo runtime state + worktrees, and the
+# auto-generated hook scaffolding (AGENTS.md/CLAUDE.md/examples/) it writes into every project.
+.dmux/
+.dmux-hooks/
+
 # Personal files
 .kryota-dev
 *.local.*


### PR DESCRIPTION
## Summary

dmux (the tmux agent pane manager) writes two per-repo directories into every project root:

- `.dmux/` — runtime state, worktrees, prompts, bootstrap configs
- `.dmux-hooks/` — auto-generated hook scaffolding (`AGENTS.md`, `CLAUDE.md`, `examples/`, `README.md`)

Both show up as untracked noise in the working tree of every repo where dmux runs. This adds
them to the global excludesfile (`~/.gitignore_global`, deployed from `home/dot_gitignore_global`)
so they are ignored everywhere, not per-repo.

## Verification

- [x] `chezmoi apply ~/.gitignore_global` deploys the entries
- [x] `git check-ignore .dmux-hooks/` → matched by `~/.gitignore_global`
- [x] `git status` no longer lists the dmux dirs as untracked