### PR TITLE
fix(claude): restore AI-attribution suppression (happy reads includeCoAuthoredBy)

### DIFF
--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "includeCoAuthoredBy": false,
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "env": {
     "CLAUDE_CODE_AUTO_CONNECT_IDE": "false",
     "CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL": "1",

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -255,6 +255,19 @@ load helpers/setup
   [ -f "${HOME_DIR}/dot_claude/executable_ecc-hook.sh" ]
 }
 
+@test "settings.json suppresses AI attribution (Claude Code + happy) so no signatures leak" {
+  local s="${HOME_DIR}/dot_claude/settings.json"
+  [ -f "$s" ]
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  # `attribution.commit`/`.pr` empty → Claude Code's own "Generated with…" + Co-Authored-By
+  # trailer is suppressed. `includeCoAuthoredBy: false` is ALSO required: happy-cli reads only
+  # this key from $CLAUDE_CONFIG_DIR/settings.json (not attribution, not project settings.local)
+  # and defaults to true when absent — dropping it re-enables happy's "via [Happy]" commit
+  # signature injection. Both keys must stay present; this guards against that regression.
+  jq -e '.includeCoAuthoredBy == false' "$s" >/dev/null
+  jq -e '.attribution.commit == "" and .attribution.pr == ""' "$s" >/dev/null
+}
+
 @test "settings.json wires the CLV2 observer as direct observe.sh hooks (pre + post)" {
   local s="${HOME_DIR}/dot_claude/settings.json"
   [ -f "$s" ]


### PR DESCRIPTION
## Summary

The `via [Happy]` / `Co-Authored-By` signature reappeared in commits made through the happy
wrapper, even though the settings intended to suppress AI attribution.

## Root cause

happy-cli injects the "give credit to Happy" instruction into commit messages via
`--append-system-prompt`, gated on its own `shouldIncludeCoAuthoredBy()`
(`src/claude/utils/systemPrompt.ts` → `claudeSettings.ts`). That helper:

- reads **only** `$CLAUDE_CONFIG_DIR/settings.json` → the `includeCoAuthoredBy` key,
- does **not** read `attribution`, nor a project-level `.claude/settings.local.json`,
- **defaults to `true`** when the key is absent.

The settings had migrated to `attribution: {commit:"", pr:""}` (Claude Code's official
successor to the deprecated `includeCoAuthoredBy`). Claude Code honours `attribution`, but
**happy ignores it** — so with `includeCoAuthoredBy` gone, happy fell back to its default and
re-injected the signature. Setting it in the acsim repo's `settings.local.json` also had no
effect, because happy never reads project-level settings.

## Fix

- `dot_claude/settings.json`: add back `"includeCoAuthoredBy": false` (read by happy and
  legacy Claude Code) **and** keep `attribution` empty (Claude Code's own trailer). Both are
  required — they cover different layers.
- `tests/files.bats`: assert both keys stay present, guarding against the regression that
  silently re-enabled the signature.

Note: happy reads settings at process start and only from the global config dir, so the
suppression applies to new happy sessions and cannot be scoped per-repo with current happy.

## Test plan

- [x] `jq` confirms `includeCoAuthoredBy=false` and empty `attribution` in the source
- [x] new bats test passes; `make test-bats` (full) and `make lint` green
- [x] applied live to `~/.claude/settings.json` (preserving `cleanupPeriodDays`); r06 symlink
      reflects `includeCoAuthoredBy=false`
