### PR TITLE
fix(install): install Rosetta 2 on Apple Silicon before brew bundle

### DIFF
--- a/docs/architecture/lifecycle-scripts.ja.md
+++ b/docs/architecture/lifecycle-scripts.ja.md
@@ -24,7 +24,7 @@ flowchart TD
     A([chezmoi apply 開始]) --> B
 
     subgraph BEFORE ["BEFORE フェーズ (ファイル未書き込み)"]
-        B["00 install-prerequisites\nrun_once\n(macOS: Xcode CLI + Homebrew)\n(Linux: apt build-deps + Linuxbrew)"]
+        B["00 install-prerequisites\nrun_once\n(macOS: Xcode CLI + Homebrew + Rosetta 2)\n(Linux: apt build-deps + Linuxbrew)"]
         B --> C["10 brew-bundle\nrun_onchange\n(brew bundle --no-upgrade)\n(Linux: .brewfile-linux-exclude でフィルタ)"]
     end
 
@@ -107,7 +107,7 @@ flowchart TD
 
 ### 00 — install-prerequisites (`run_once`、before)
 
-Xcode CLI ツール（macOS、`xcode-select -p` が成功するまでポーリング）と Homebrew（arch 対応 shellenv: arm64 → `/opt/homebrew`、intel → `/usr/local`）をインストールします。Linux では `apt-get` で `build-essential curl file git` をインストールした後 Linuxbrew をインストールします。レンダリング済みコンテンツが同じなら1回のみ実行されるため、`chezmoi apply` を再実行しても Homebrew インストールは繰り返されません。
+Xcode CLI ツール（macOS、`xcode-select -p` が成功するまでポーリング）と Homebrew（arch 対応 shellenv: arm64 → `/opt/homebrew`、intel → `/usr/local`）をインストールします。Apple Silicon では Rosetta 2 も（冪等な `arch -x86_64` ガード付きで）インストールし、`sony-ps-remote-play` のような Intel 専用 cask が `brew bundle` 中に正しくインストールされるようにします。Linux では `apt-get` で `build-essential curl file git` をインストールした後 Linuxbrew をインストールします。レンダリング済みコンテンツが同じなら1回のみ実行されるため、`chezmoi apply` を再実行しても Homebrew インストールは繰り返されません。
 
 ### 10 — brew-bundle (`run_onchange`、before)
 

--- a/docs/architecture/lifecycle-scripts.md
+++ b/docs/architecture/lifecycle-scripts.md
@@ -24,7 +24,7 @@ flowchart TD
     A([chezmoi apply starts]) --> B
 
     subgraph BEFORE ["BEFORE phase (files not yet written)"]
-        B["00 install-prerequisites\nrun_once\n(macOS: Xcode CLI + Homebrew)\n(Linux: apt build-deps + Linuxbrew)"]
+        B["00 install-prerequisites\nrun_once\n(macOS: Xcode CLI + Homebrew + Rosetta 2)\n(Linux: apt build-deps + Linuxbrew)"]
         B --> C["10 brew-bundle\nrun_onchange\n(brew bundle --no-upgrade)\n(Linux: filters .brewfile-linux-exclude)"]
     end
 
@@ -107,7 +107,7 @@ Scripts use chezmoi template guards to select the appropriate behavior per OS.
 
 ### 00 — install-prerequisites (`run_once`, before)
 
-Installs Xcode CLI tools (macOS, polling until `xcode-select -p` succeeds) and Homebrew (arch-aware shellenv: `/opt/homebrew` on arm64, `/usr/local` on intel). On Linux installs `build-essential curl file git` via `apt-get` then Linuxbrew. Runs once per rendered content so a re-run of `chezmoi apply` never repeats the Homebrew install.
+Installs Xcode CLI tools (macOS, polling until `xcode-select -p` succeeds) and Homebrew (arch-aware shellenv: `/opt/homebrew` on arm64, `/usr/local` on intel). On Apple Silicon it also installs Rosetta 2 (idempotent `arch -x86_64` guard) so Intel-only casks like `sony-ps-remote-play` install cleanly during `brew bundle`. On Linux installs `build-essential curl file git` via `apt-get` then Linuxbrew. Runs once per rendered content so a re-run of `chezmoi apply` never repeats the Homebrew install.
 
 ### 10 — brew-bundle (`run_onchange`, before)
 

--- a/home/run_once_before_00-install-prerequisites.sh.tmpl
+++ b/home/run_once_before_00-install-prerequisites.sh.tmpl
@@ -24,8 +24,9 @@ if ! command -v brew &>/dev/null; then
   {{ end -}}
 fi
 
-# Rosetta 2 (Apple Silicon only; required by Intel-only casks e.g. sony-ps-remote-play)
 {{ if eq .chezmoi.arch "arm64" -}}
+# Rosetta 2 (Apple Silicon only; required by Intel-only casks e.g. sony-ps-remote-play).
+# Idempotent: `arch -x86_64` succeeds only once Rosetta can run x86_64 binaries.
 if ! arch -x86_64 /usr/bin/true 2>/dev/null; then
   echo "Installing Rosetta 2..."
   sudo softwareupdate --install-rosetta --agree-to-license

--- a/home/run_once_before_00-install-prerequisites.sh.tmpl
+++ b/home/run_once_before_00-install-prerequisites.sh.tmpl
@@ -24,6 +24,13 @@ if ! command -v brew &>/dev/null; then
   {{ end -}}
 fi
 
+# Rosetta 2 (Apple Silicon only; required by Intel-only casks e.g. sony-ps-remote-play)
+{{ if eq .chezmoi.arch "arm64" -}}
+if ! arch -x86_64 /usr/bin/true 2>/dev/null; then
+  echo "Installing Rosetta 2..."
+  sudo softwareupdate --install-rosetta --agree-to-license
+fi
+{{ end -}}
 echo "Prerequisites installed."
 {{ else if eq .chezmoi.os "linux" -}}
 #!/bin/bash

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -81,6 +81,16 @@ load helpers/setup
   [ -f "${HOME_DIR}/run_once_after_90-other-apps.sh.tmpl" ]
 }
 
+@test "prerequisites installs Rosetta 2 on arm64 darwin" {
+  local tmpl="${HOME_DIR}/run_once_before_00-install-prerequisites.sh.tmpl"
+  # arm64 でのみ実行されるようガードされていること
+  grep -q '{{ if eq .chezmoi.arch "arm64" -}}' "$tmpl"
+  # Rosetta 2 を非対話で導入すること
+  grep -q 'softwareupdate --install-rosetta --agree-to-license' "$tmpl"
+  # 冪等性: 既に Rosetta が使えるなら再実行しないガードがあること
+  grep -q 'arch -x86_64' "$tmpl"
+}
+
 @test "claude agents exist" {
   [ -d "${HOME_DIR}/dot_claude/agents" ]
   local count

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -81,14 +81,21 @@ load helpers/setup
   [ -f "${HOME_DIR}/run_once_after_90-other-apps.sh.tmpl" ]
 }
 
-@test "prerequisites installs Rosetta 2 on arm64 darwin" {
+@test "prerequisites installs Rosetta 2 behind an arm64 guard" {
   local tmpl="${HOME_DIR}/run_once_before_00-install-prerequisites.sh.tmpl"
-  # arm64 でのみ実行されるようガードされていること
-  grep -q '{{ if eq .chezmoi.arch "arm64" -}}' "$tmpl"
-  # Rosetta 2 を非対話で導入すること
-  grep -q 'softwareupdate --install-rosetta --agree-to-license' "$tmpl"
-  # 冪等性: 既に Rosetta が使えるなら再実行しないガードがあること
-  grep -q 'arch -x86_64' "$tmpl"
+  # Installs Rosetta 2 non-interactively (Intel-only casks need it).
+  grep -Fq 'softwareupdate --install-rosetta --agree-to-license' "$tmpl"
+  # Idempotent: skips when x86_64 binaries already run (Rosetta present).
+  grep -Fq 'arch -x86_64' "$tmpl"
+  # The install must sit inside an arm64 template guard, not just anywhere: the
+  # Homebrew shellenv block also opens an arm64 guard, so a bare grep for the
+  # guard string would pass even if the Rosetta block lost its own guard.
+  awk '
+    /\{\{ if eq \.chezmoi\.arch "arm64" -\}\}/ { guard = 1; next }
+    /\{\{ (else|end)/ { guard = 0 }
+    /softwareupdate --install-rosetta/ && guard { inside = 1 }
+    END { exit !inside }
+  ' "$tmpl"
 }
 
 @test "claude agents exist" {


### PR DESCRIPTION
## Summary

Intel-only Homebrew casks (e.g. `sony-ps-remote-play`) fail to install on Apple Silicon Macs when Rosetta 2 is missing. The `00 install-prerequisites` lifecycle script set up Xcode CLI tools and Homebrew but never installed Rosetta 2, so `brew bundle` (step 10) failed on M-series machines during a fresh setup.

## Changes

- **`run_once_before_00-install-prerequisites.sh.tmpl`**: add an idempotent Rosetta 2 install to the arm64 darwin branch. Guarded by `arch -x86_64 /usr/bin/true`, so it is skipped when Rosetta 2 is already usable; runs `sudo softwareupdate --install-rosetta --agree-to-license` otherwise.
- **`tests/files.bats`**: regression test asserting the arm64-guarded Rosetta 2 install exists in the template.
- **`docs/architecture/lifecycle-scripts.md` / `.ja.md`**: document the new Rosetta 2 step (prose + flow diagram label), EN/JA mirrors in sync.

## Verification

- `bats tests/files.bats -f "Rosetta"` -> PASS (RED before implementation, GREEN after)
- `make lint` -> PASS (shellcheck + shfmt + zsh syntax)
- Full `bats tests/files.bats` -> no regressions from this change (one pre-existing, environment-dependent failure in the unrelated `claude.zsh injects MCP keys` test)

## Notes

`softwareupdate --install-rosetta` requires root; `sudo` is consistent with the existing Homebrew install step in the same script, which is already interactive on first-time setup.