### PR TITLE
feat(pr-workflow): embed intent confirmation into the risk tier

### DIFF
--- a/home/dot_agents/skills/grill-me/SKILL.md
+++ b/home/dot_agents/skills/grill-me/SKILL.md
@@ -20,6 +20,7 @@ If a question can be answered by exploring the codebase, explore the codebase in
 
 - **auto でも security / data migration / contract change 等は強制的に user エスカレート**する。
 - PRD 書き出しは memory 記録に相当するため、`~/AGENTS.md` の memory ポリシー（**承認前に保存しない**）に従い、**file 出力前に必ず user 承認**を得る。
+- **PRD 生成の default 化（#222）**: `pr-workflow` の non-trivial path（standard/large）から呼ばれるときは **PRD 生成を default handoff** とする（intent gate の成果物）。ただし **file 永続化は上記 memory ポリシーどおり user 承認必須**（生成は default、保存は承認）。grill-me を **単体起動**したときの `--output-prd` は従来どおり opt-in（未指定なら対話のみ・ファイル出力なし）を維持する。
 
 ### PRD frontmatter + sections
 
@@ -33,6 +34,8 @@ status: draft | finalized | implemented
 ---
 ```
 
-sections: **Background** / **User Story** / **Acceptance Criteria**（`AC-NNN`、ゼロ埋め 3 桁: `AC-001`） / **Out of Scope** / **Open Questions**。`created_at` は `date -Iseconds`（ローカル TZ）で生成する。
+sections: **Background** / **User Story** / **Acceptance Criteria**（`AC-NNN`、ゼロ埋め 3 桁: `AC-001`） / **Considered Alternatives / Rejection Rationale**（決定ログ: 検討した代替案とその却下理由。**必須**） / **Out of Scope** / **Open Questions**。`created_at` は `date -Iseconds`（ローカル TZ）で生成する。
+
+- **Considered Alternatives / Rejection Rationale（決定ログ, #222）は必須セクション**。intent を将来へ残すため、検討した設計代替案と「なぜ採らなかったか」を最低 1 件記録する（可能なら `AC` と対応づける）。intent 確認の成果を decision log として保全し、後から「なぜこの設計か」を辿れるようにする狙い。
 
 **衝突処理（上書き禁止）**: 出力先 file が既存なら `-v2`、それも在れば `-v3`…と空きが見つかるまで `-vN` を増やす（既存 file は決して上書きしない。user が override path を明示した場合のみ従う）。下流の `/planning --input-prd <path>` がこの file を入力にする。

--- a/home/dot_agents/skills/pr-workflow/SKILL.md
+++ b/home/dot_agents/skills/pr-workflow/SKILL.md
@@ -56,8 +56,10 @@ user-invocable: true
 |------|------|
 | `trivial` | inline Edit。**ただし spec/planning の skip は「既に承認済みの計画があるとき」のみ**（global 指示「実装前は `$planning`」を上書きしない。曖昧なら `/planning` を通す）。→ `/commit` → `/create-pr` |
 | `small` | **general-purpose サブエージェント（`model: sonnet`）**に inline prompt で委任（named worker は使わない）。prompt に **TDD の RED→GREEN 規律**（テスト先行・最小実装。inline protocol、外部 skill ではない）を含める。→ `/commit` → `/create-pr` |
-| `standard` | `/sdd`（完全自律実行）。**`/sdd` は内部で自前に commit + PR 作成まで行う**ため、この path では `/commit`/`/create-pr` を別途呼ばない（二重実行回避）。 |
-| `large` | （任意で）先に `/grill-me` で設計を詰める → `/sdd`（完全自律実行）。**`/grill-me` は対話型のため、pr-workflow から自動 invoke せず user が事前に実行する**前提。 |
+| `standard` | **軽量 intent gate**（`/sdd` 起動前に intent + scope + 主要 AC を `AskUserQuestion` で 1 回確認。承認 1 回で自律性を最大限維持）→ `/sdd`（完全自律実行）。**`/sdd` は内部で自前に commit + PR 作成まで行う**ため、この path では `/commit`/`/create-pr` を別途呼ばない（二重実行回避）。 |
+| `large` | **intent gate（enforced）**: `/sdd` の前に `/grill-me --mode=auto`（自律審議＋最終 PRD を user が 1 回承認）を pr-workflow から auto-invoke する（`--mode=auto` が「対話型だから auto-invoke しない」を解消。auto でも security/data-migration/contract は grill-me が強制 user エスカレート）→ `/sdd`（完全自律実行）。 |
+
+**intent gate（#222・構造化）**: `standard`/`large` は **human intent check なしに実装フェーズ（`/sdd` Phase 4）へ入れない**。large=`/grill-me --mode=auto` の PRD 承認、standard=軽量 intent gate がそれに当たる。**gate を skip する場合は必ず理由を記録**する（decision log / spec / PR の 1 行）。**PRD 生成は non-trivial（standard/large）の default handoff**とする（生成は default、file 永続化は grill-me の memory ポリシーに従い user 承認必須）。
 
 **Plan-PRD pipeline（task #22 / PR10b）連携**: PR10b マージ後は `/grill-me --output-prd` → `/planning --output-plan` → `/sdd --prd --plan` の file handoff を使える。**PR10b 未マージ時はこれらの flag は存在しない**ため、PRD/Plan は手動で渡す。
 


### PR DESCRIPTION
## Summary

Implements design-review issue #222 (embed intent confirmation into the risk tier as structure). Markdown-only changes to the `pr-workflow` orchestrator and the `grill-me` skill.

## Changes

### pr-workflow Phase 1-4
- **`standard`**: add a **lightweight single intent gate** — one `AskUserQuestion` confirming intent + scope + key AC before `/sdd`. Keeps autonomy high (one approval) while ensuring the implementation phase can't start without a human intent check.
- **`large`**: make `/grill-me` **enforced** instead of optional/manual — pr-workflow auto-invokes `/grill-me --mode=auto` (autonomous council + santa-method, with a single final PRD approval by the user). `--mode=auto` resolves the previous "interactive, so not auto-invoked" blocker; grill-me still force-escalates security / data-migration / contract changes to the user. **Skipping the intent gate requires a recorded reason** (decision log / spec / PR one-liner).
- **Structural rule**: `standard`/`large` cannot enter the implementation phase (`/sdd` Phase 4) without a human intent check. PRD generation becomes the **default handoff** for non-trivial tiers (generation is default; file persistence still requires user approval).

### grill-me
- Add a **required** PRD section: **Considered Alternatives / Rejection Rationale** (decision log — considered alternatives and why they were rejected).
- Document the PRD default policy: default handoff when invoked from a non-trivial `pr-workflow` path, but **file persistence still requires user approval** (memory policy preserved); standalone `--output-prd` stays opt-in.

## Acceptance Criteria (#222)
- [x] On the `large`/`standard` paths, the implementation phase (`/sdd` Phase 4) cannot be entered without a human intent check
- [x] If intent confirmation is skipped, a reason is recorded (decision log / spec / PR)
- [x] grill-me's PRD has a required decision-log section (considered alternatives and rejection rationale)

## Verification
Markdown-only edits to skill definitions; no shell/zsh/Makefile/CI changes, so `$code-change-verification` (lint/test) is not applicable.

Closes #222
