### PR TITLE
fix(ci): unbreak the Ubuntu validation job (stale chezmoi.toml copy + untrusted taps)

### DIFF
--- a/.brewfile-linux-exclude
+++ b/.brewfile-linux-exclude
@@ -1,3 +1,6 @@
 ^brew "rename"$
 smudge/smudge
 gh-asset
+k1low/tap
+minacle/chntpw
+satococoa/tap

--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -259,8 +259,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          mkdir -p ~/.config/chezmoi
-          cp home/.chezmoi.toml ~/.config/chezmoi/chezmoi.toml
           for attempt in 1 2 3; do
             if installer=$(curl -fsLS get.chezmoi.io) && [ -n "$installer" ]; then
               break


### PR DESCRIPTION
## Summary

The "Validate dotfiles setup (Ubuntu)" job has been red on `main` and every PR. This PR makes it green again by fixing the actual current blocker and hardening a separate, intermittent failure mode.

Investigation (via the job's step-level logs) showed the Ubuntu job currently fails at **step 9 "Apply dotfiles with chezmoi"**, not at the Homebrew step named in #148:

```
cp: cannot stat 'home/.chezmoi.toml': No such file or directory
##[error]Process completed with exit code 1.
```

`home/.chezmoi.toml` was deleted in #167, which centralized template data into `.chezmoidata.toml` (auto-loaded from the source dir) and moved the `[diff]` behavior config into `dot_config/chezmoi/private_chezmoi.toml` (auto-deployed). #167 removed the `cp` from the macOS job but left the identical block in the Ubuntu job — a stale reference that has failed on every run since.

## Changes

Two commits, both aimed at unbreaking the Ubuntu validation job:

1. **`fix(ci): drop obsolete chezmoi.toml copy from the Ubuntu apply step`** — the actual current blocker. Removes `mkdir -p ~/.config/chezmoi` + `cp home/.chezmoi.toml ...` from the Ubuntu "Apply dotfiles with chezmoi" step so it matches the working macOS job. Template data is auto-loaded from `.chezmoidata.toml`; the config auto-deploys from `private_chezmoi.toml`.
2. **`fix(ci): exclude untrusted third-party taps from Linux brew bundle`** — a defensive fix. `.brewfile-linux-exclude` gains `k1low/tap`, `minacle/chntpw`, and `satococoa/tap`. The `Refusing to load formula … from untrusted tap` error from #148 is currently intermittent (the Homebrew step passes on the latest `main`/PR runs), but excluding these unused-on-Linux taps prevents recurrence. These taps have no `brew` formula lines needed on Linux, so they are tapped only on macOS.

## Verification

- **Step-level CI evidence**: on both the latest `main` run and PR #232's first run, step 6 "Install Homebrew formulas only" = success (43 deps installed, no untrusted-tap error), step 9 = failure on the `cp`. So the tap exclusion is defensive and the `chezmoi.toml` removal targets the active red.
- `actionlint` — passes on `setup-validation.yml`.
- Local Linux-filter simulation (`grep -E '^(tap |brew )' home/dot_Brewfile | grep -v -E -f .brewfile-linux-exclude`): only the three target taps plus the already-excluded `rename` / `smudge/smudge` / `gh-asset` are removed; the four tolerated taps (grishka, heroku, manaflow-ai/cmux, supabase) are untouched.
- `make lint` — passes (shellcheck, shfmt, zsh syntax).
- `make test` — all bats pass except the pre-existing, environment-dependent `claude.zsh injects MCP keys into the subprocess but not the parent shell` (fails identically on untouched `main`; the local dev shell exports `EXA_API_KEY`/`FIRECRAWL_API_KEY` which leak into the test's `zsh -fc`; CI has no real keys so it passes there — same failure documented in #229).
- **Final confirmation is the Ubuntu job on this PR** going green after the push.

## Notes

- macOS validation behavior is unchanged — the macOS job neither applies the `.brewfile-linux-exclude` filter nor copied a chezmoi config.
- Acceptance criteria (#148): Ubuntu job passes / macOS unchanged.

Fixes #148.
