### PR TITLE
feat(mise): add gws (Google Workspace CLI) via ubi backend

### DIFF
--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -36,6 +36,9 @@ uv = "0.11.24"
 yazi = "26.5.6"
 zoxide = "0.9.9"
 
+# ubi-backed CLIs (no mise/aqua registry entry)
+"ubi:googleworkspace/cli" = { version = "0.22.5", exe = "gws" }
+
 # npm-backed CLIs (no registry entry). agent-browser ships its specialized skills
 # (electron/slack/dogfood/...) via `agent-browser skills get`, so they are loaded at
 # runtime instead of being vendored; only the discovery stub is chezmoi-managed.


### PR DESCRIPTION
## Summary

Add [gws (Google Workspace CLI)](https://github.com/googleworkspace/cli) to the mise tool inventory using the ubi backend.

- Pin `googleworkspace/cli` v0.22.5 via `ubi:` backend with `exe = "gws"`
- ubi backend chosen because gws has no mise/aqua registry entry, and the npm package (`@googleworkspace/cli`) ships a Node.js wrapper (`run.js`), while GitHub Releases provides native prebuilt binaries
- `exe = "gws"` is required because the archive binary is named `gws`, not `cli`

## Background

gws provides a unified CLI for Google Workspace APIs (Drive, Gmail, Calendar, Sheets, etc.) with structured JSON output and AI agent skills. It is distributed as:

| Channel | Suitability |
|---------|-------------|
| GitHub Releases (prebuilt binaries) | Best — native binary, target-triple naming, SHA256 checksums |
| npm (`@googleworkspace/cli`) | Suboptimal — bin entry is a Node.js wrapper requiring Node runtime |
| mise registry | Not available |
| aqua registry | Not available |

## Test plan

- [ ] `mise install` succeeds with the new entry
- [ ] `gws --version` returns `gws version 0.22.5`
- [ ] `make lint` passes
- [ ] `make test` passes
