### PR TITLE
fix(vscode): replace dead MesloLGS NF with installed Symbols Nerd Font Mono

### DIFF
--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -10,7 +10,7 @@
   "editor.cursorSmoothCaretAnimation": "on",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.detectIndentation": false,
-  "editor.fontFamily": "Moralerspace Neon, "Ricty Diminished", Menlo, MesloLGS NF, 'Courier New', monospace",
+  "editor.fontFamily": "Moralerspace Neon, "Ricty Diminished", Menlo, Symbols Nerd Font Mono, 'Courier New', monospace",
   "editor.fontLigatures": true,
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,


### PR DESCRIPTION
## Summary

`editor.fontFamily` in the VS Code user settings listed `MesloLGS NF` in its fallback chain, but that font is not installed on the machine — only `font-symbols-only-nerd-font` ("Symbols Nerd Font Mono") is. A dead font reference provides no real fallback and is misleading.

## Changes

- `home/Library/Application Support/Code/User/settings.json` — replace `MesloLGS NF` with `Symbols Nerd Font Mono` in `editor.fontFamily`. This keeps a real symbol-glyph fallback and aligns the editor chain with `terminal.integrated.fontFamily`, which already uses `Symbols Nerd Font Mono`.

## Verification

- `make lint` — passes (shellcheck, shfmt, zsh syntax).
- `make test-bats` — all pass except the pre-existing, environment-dependent `claude.zsh injects MCP keys into the subprocess but not the parent shell` (unrelated to this change; documented in #229 / #232).
- No bats test asserts the VS Code font chain; the `settings.json` tests target `dot_claude/settings.json`, not this VS Code file.

## Notes

- `MesloLGS NF` was the only uninstalled font in the chain: `Moralerspace Neon` and `Menlo` are installed, and `Ricty Diminished` / `Courier New` / `monospace` are generic fallbacks.

Fixes #147.
