### PR TITLE
feat(ci): guard ruby install against the no-baseruby source-build deadlock

### DIFF
--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -186,6 +186,50 @@ jobs:
           echo "OK: zsh starts cleanly"
         timeout-minutes: 2
 
+  guard-ruby-no-baseruby:
+    name: Guard ruby install without baseruby
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Remove every ruby from PATH (reproduce the fresh-install condition)
+        run: |
+          # The ruby source-build deadlock (#122) only manifests with no baseruby
+          # on PATH: ruby-build's configure probe re-enters the mise shim for the
+          # in-progress version and blocks on the install lock. Standard runners
+          # ship a system ruby, so strip every ruby off PATH to reproduce it.
+          while p=$(command -v ruby 2>/dev/null); do sudo rm -f "$p"; done
+          if command -v ruby >/dev/null 2>&1; then
+            echo "ERROR: ruby is still on PATH: $(command -v ruby)"
+            exit 1
+          fi
+          echo "OK: no ruby on PATH"
+
+      - name: Install mise
+        run: |
+          curl -fsSL https://mise.run | sh
+          echo "$HOME/.local/bin" >>"$GITHUB_PATH"
+
+      - name: Deploy the repo mise config
+        run: |
+          # Exercise the actual pinned ruby version and [settings] (ruby.compile = false).
+          mkdir -p ~/.config/mise
+          cp home/dot_config/mise/config.toml ~/.config/mise/config.toml
+
+      - name: Install ruby with a hard timeout (fails fast if not precompiled)
+        run: |
+          # With ruby.compile = false the precompiled binary installs in a few
+          # minutes. If that setting is ever removed or overridden, a source build
+          # deadlocks here without a baseruby; the timeout turns that indefinite
+          # hang into a fast, deterministic failure instead of a 6-hour job.
+          timeout 600 mise install ruby
+          mise exec ruby -- ruby --version
+
   setup-validation-ubuntu:
     name: Validate dotfiles setup (Ubuntu)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add a CI job that reproduces the fresh-install condition behind #122 — an environment with **no baseruby on PATH** — so the ruby source-build deadlock is structurally guarded against regression.

`#122` was fixed by setting `ruby.compile = false` (precompiled ruby) in the mise config. But the deadlock only manifests when there is no usable ruby on PATH: ruby-build's `configure` probe re-enters the mise `ruby` shim for the in-progress version and blocks on the install lock. Standard runners (macOS, Ubuntu) ship a system ruby, so the existing `setup-validation` jobs can never reproduce it — the fix is currently **unguarded** in CI.

## Changes

- `.github/workflows/setup-validation.yml` — new `guard-ruby-no-baseruby` job (ubuntu-latest, `timeout-minutes: 15`):
  1. Strips every `ruby` off PATH to reproduce the no-baseruby condition.
  2. Installs mise and deploys the repo's `home/dot_config/mise/config.toml` (so the pinned ruby version and `[settings] ruby.compile = false` are exercised as-is).
  3. Runs `timeout 600 mise install ruby`, then `mise exec ruby -- ruby --version`.

With `ruby.compile = false`, the precompiled binary installs in a few minutes and the job passes. If that setting is ever removed or overridden, a source build deadlocks without a baseruby and the `timeout` turns the indefinite hang into a fast, deterministic failure (instead of a 6-hour job).

## Verification

- `actionlint` — passes (includes shellcheck on the embedded `run` scripts).
- `make lint` — passes.
- **The job passing on this PR's CI is the real confirmation** that precompiled ruby installs cleanly with no baseruby on PATH under the current config.

## Notes

- The job runs whenever `setup-validation.yml` runs (triggered by `home/**`, which includes `dot_config/mise/config.toml`), so a change that drops `ruby.compile = false` is caught on that PR.

Closes #126.
