### PR TITLE
refactor(skills): migrate github/discussion skills to native gh 2.94 commands

### DIFF
--- a/home/dot_agents/skills/create-issue/SKILL.md
+++ b/home/dot_agents/skills/create-issue/SKILL.md
@@ -133,14 +133,17 @@ if [ -f "$TEMPLATE_FILE" ]; then
 fi
 ```
 
-### 5. Organization Issue Typesの取得
+### 5. Issue Type名の確定（任意の事前検証）
+
+native の `gh issue create --type <name>` / `gh issue edit --type <name>` は Issue Type を
+**名前**で設定するため、従来の Node ID / Issue Type ID 解決（GraphQL）は不要になった。
+テンプレートから抽出した `ISSUE_TYPE_NAME` をそのまま後続の `--type` に渡す。
 
 ```bash
-# OrganizationのIssue Typesを取得（GraphQL API）
-ISSUE_TYPE_ID=""
+# 任意: 事前に type 名が Organization に存在するか検証したい場合のみ実行する。
+# Issue Type 名の列挙に相当する native コマンドは存在しないため、この確認のみ GraphQL を使用する。
+# （Issue Type 機能は GitHub.com / GHES 3.17+ が必要。未対応環境ではこの検証はスキップしてよい）
 if [ -n "$ISSUE_TYPE_NAME" ]; then
-    echo "Organization Issue Typesを取得中..."
-
     ORG_NAME="${REPO%/*}"
     ISSUE_TYPES_JSON=$(gh api graphql \
       -H "GraphQL-Features: issue_types" \
@@ -149,10 +152,8 @@ if [ -n "$ISSUE_TYPE_NAME" ]; then
         organization(login: \"$ORG_NAME\") {
           issueTypes(first: 25) {
             nodes {
-              id
               name
               description
-              color
               isEnabled
             }
           }
@@ -160,18 +161,15 @@ if [ -n "$ISSUE_TYPE_NAME" ]; then
       }" 2>/dev/null)
 
     if [ $? -eq 0 ] && [ -n "$ISSUE_TYPES_JSON" ]; then
-        # テンプレートのtype名と一致するIssue Type IDを検索
-        ISSUE_TYPE_ID=$(echo "$ISSUE_TYPES_JSON" | jq -r --arg name "$ISSUE_TYPE_NAME" '.data.organization.issueTypes.nodes[] | select(.name == $name and .isEnabled == true) | .id')
-
-        if [ -n "$ISSUE_TYPE_ID" ]; then
-            echo "✓ Issue Type IDを取得: $ISSUE_TYPE_NAME ($ISSUE_TYPE_ID)"
+        if echo "$ISSUE_TYPES_JSON" | jq -e --arg name "$ISSUE_TYPE_NAME" '.data.organization.issueTypes.nodes[] | select(.name == $name and .isEnabled == true)' >/dev/null; then
+            echo "✓ Issue Type '$ISSUE_TYPE_NAME' を確認しました"
         else
             echo "⚠️ テンプレートのtype '$ISSUE_TYPE_NAME' に対応するIssue Typeが見つかりません"
             echo "   利用可能なIssue Types:"
-            echo "$ISSUE_TYPES_JSON" | jq -r '.data.organization.issueTypes.nodes[] | "   - \(.name): \(.description // "")"'
+            echo "$ISSUE_TYPES_JSON" | jq -r '.data.organization.issueTypes.nodes[] | select(.isEnabled == true) | "   - \(.name): \(.description // "")"'
         fi
     else
-        echo "⚠️ Organization Issue Typesの取得に失敗しました（Issue Type機能が有効でない可能性があります）"
+        echo "ℹ️ Issue Typeの事前検証をスキップします（Issue Type機能が無効、または権限がない可能性があります）。--type はそのまま試行します。"
     fi
 fi
 ```
@@ -297,6 +295,13 @@ CREATE_CMD="gh issue create --repo $REPO"
 CREATE_CMD="$CREATE_CMD --title \"$TITLE\""
 CREATE_CMD="$CREATE_CMD --body \"$ISSUE_BODY\""
 
+# Issue Typeが確定している場合は native の --type で作成時に設定する
+# 注意: Issue Type未対応の環境（GHES 3.17未満等）では --type を付けると作成が失敗するため、
+#       その場合は --type を外して作成し、Step 9 の `gh issue edit --type` フォールバックで後付けする。
+if [ -n "$ISSUE_TYPE_NAME" ]; then
+    CREATE_CMD="$CREATE_CMD --type \"$ISSUE_TYPE_NAME\""
+fi
+
 # ラベルが選択されている場合は追加
 if [ -n "$SELECTED_LABELS" ]; then
     # カンマ区切りのラベルをスペース区切りの--labelオプションに変換
@@ -318,7 +323,7 @@ if [ $? -eq 0 ]; then
     if [ "$ISSUE_TYPE" = "epic" ]; then
         echo ""
         echo "💡 ヒント: EpicにSub-issueを追加する場合は、以下のコマンドを使用してください："
-        echo "gh issue edit $ISSUE_URL --add-project <project-name>"
+        echo "gh issue edit $ISSUE_URL --add-sub-issue <child-issue-number>"
     fi
 else
     echo "❌ エラー: Issueの作成に失敗しました"
@@ -334,54 +339,18 @@ echo ""
 echo "=== 作成されたIssueの詳細 ==="
 gh issue view $ISSUE_URL --repo $REPO
 
-# Issue Typeの設定
-if [ -n "$ISSUE_TYPE_ID" ] && [ -n "$ISSUE_URL" ]; then
+# Issue Typeの設定（フォールバック / 明示確認）
+# Step 8 の `gh issue create --type` が使えなかった環境向けに、作成後に native の
+# `gh issue edit --type`（名前指定・Node ID 解決不要）で後付けする。
+# 失敗しても Issue 作成自体は成功しているため、警告のみ出して続行する（graceful fallback）。
+if [ -n "$ISSUE_TYPE_NAME" ] && [ -n "$ISSUE_URL" ]; then
     echo ""
-    echo "Issue Typeを設定中..."
+    echo "Issue Typeを確認・設定中..."
 
-    # IssueのNode IDを取得
-    ISSUE_NUMBER="${ISSUE_URL##*/}"
-    ISSUE_NODE_ID=$(gh api graphql -f query="
-    query {
-      repository(owner: \"${REPO%/*}\", name: \"${REPO#*/}\") {
-        issue(number: $ISSUE_NUMBER) {
-          id
-        }
-      }
-    }" --jq '.data.repository.issue.id')
-
-    if [ -n "$ISSUE_NODE_ID" ]; then
-        # Issue Typeを設定（GraphQL mutation）
-        RESULT=$(gh api graphql \
-          -H "GraphQL-Features: issue_types" \
-          -f query="
-          mutation {
-            updateIssueIssueType(input: {
-              issueId: \"$ISSUE_NODE_ID\"
-              issueTypeId: \"$ISSUE_TYPE_ID\"
-            }) {
-              issue {
-                title
-                number
-                url
-                issueType {
-                  name
-                  description
-                  color
-                }
-              }
-            }
-          }" 2>&1)
-
-        if [ $? -eq 0 ]; then
-            ISSUE_TYPE_SET=$(echo "$RESULT" | jq -r '.data.updateIssueIssueType.issue.issueType.name')
-            echo "✅ Issue Type '$ISSUE_TYPE_SET' を設定しました"
-        else
-            echo "⚠️ Issue Typeの設定に失敗しました"
-            echo "$RESULT"
-        fi
+    if gh issue edit "$ISSUE_URL" --repo "$REPO" --type "$ISSUE_TYPE_NAME" >/dev/null 2>&1; then
+        echo "✅ Issue Type '$ISSUE_TYPE_NAME' を設定しました"
     else
-        echo "⚠️ Issue Node IDの取得に失敗しました"
+        echo "⚠️ Issue Typeの設定に失敗しました（Issue Type機能が無効、または type名が不一致の可能性があります）"
     fi
 fi
 
@@ -407,52 +376,13 @@ if [ "$ADD_AS_SUBISSUE" = "y" ]; then
     # ※ユーザーは「Other」からIssue番号を自由入力する想定
     PARENT_ISSUE_NUMBER=""  # AskUserQuestionの結果を設定
 
-    # 作成したIssueのNode IDを取得
-    SUBISSUE_NODE_ID=$(gh api graphql -f query="
-    query {
-      repository(owner: \"${REPO%/*}\", name: \"${REPO#*/}\") {
-        issue(number: ${ISSUE_URL##*/}) {
-          id
-        }
-      }
-    }" --jq '.data.repository.issue.id')
-
-    # Parent IssueのNode IDを取得
-    PARENT_NODE_ID=$(gh api graphql -f query="
-    query {
-      repository(owner: \"${REPO%/*}\", name: \"${REPO#*/}\") {
-        issue(number: $PARENT_ISSUE_NUMBER) {
-          id
-        }
-      }
-    }" --jq '.data.repository.issue.id')
-
-    # Sub-issueとして追加（GraphQL-Features: sub_issuesヘッダーが必須）
+    # 作成した Issue を Parent の sub-issue として native に追加する（Node ID 解決は不要）。
+    # child 側から --parent を設定する（`gh issue edit PARENT --add-sub-issue CHILD` と等価）。
     echo "Sub-issueとして追加中..."
-    RESULT=$(gh api graphql \
-      -H "GraphQL-Features: sub_issues" \
-      -f query="
-      mutation {
-        addSubIssue(input: {
-          issueId: \"$PARENT_NODE_ID\"
-          subIssueId: \"$SUBISSUE_NODE_ID\"
-        }) {
-          issue {
-            number
-            title
-          }
-          subIssue {
-            number
-            title
-          }
-        }
-      }")
-
-    if [ $? -eq 0 ]; then
+    if gh issue edit "$ISSUE_URL" --repo "$REPO" --parent "$PARENT_ISSUE_NUMBER" >/dev/null 2>&1; then
         echo "✅ Issue #${ISSUE_URL##*/} を Issue #$PARENT_ISSUE_NUMBER のsub-issueとして追加しました"
     else
-        echo "❌ エラー: Sub-issueの追加に失敗しました"
-        echo "$RESULT"
+        echo "❌ エラー: Sub-issueの追加に失敗しました（Sub-issue機能が無効、または番号が不正な可能性があります）"
     fi
 fi
 
@@ -540,35 +470,14 @@ fi
 ### Sub-issue操作の独立したコマンド例
 
 ```bash
-# 既存のIssueをSub-issueとして追加
-# Step 1: Node IDを取得
-PARENT_ID=$(gh api graphql -f query='
-query {
-  repository(owner: "owner", name: "repo") {
-    issue(number: 100) { id }
-  }
-}' --jq '.data.repository.issue.id')
+# 既存のIssue #101 を Issue #100 の Sub-issue として追加（native、Node ID 解決は不要）
+gh issue edit 100 --repo owner/repo --add-sub-issue 101
 
-CHILD_ID=$(gh api graphql -f query='
-query {
-  repository(owner: "owner", name: "repo") {
-    issue(number: 101) { id }
-  }
-}' --jq '.data.repository.issue.id')
+# 複数まとめて追加
+gh issue edit 100 --repo owner/repo --add-sub-issue 101,102
 
-# Step 2: Sub-issueとして追加
-gh api graphql \
-  -H "GraphQL-Features: sub_issues" \
-  -f query="
-mutation {
-  addSubIssue(input: {
-    issueId: \"$PARENT_ID\"
-    subIssueId: \"$CHILD_ID\"
-  }) {
-    issue { number title }
-    subIssue { number title }
-  }
-}"
+# child 側から親を設定しても等価
+gh issue edit 101 --repo owner/repo --parent 100
 ```
 
 ## Sub-issue機能の詳細
@@ -577,130 +486,59 @@ mutation {
 
 GitHubのSub-issue機能は、親子関係を持つIssueの階層構造を作成できる機能です。Epic配下にタスクを整理したり、大きな機能を小さな実装タスクに分割する際に便利です。
 
-### GraphQL APIを使用したSub-issue管理
+### native gh コマンドを使用したSub-issue管理
 
-**重要**: Sub-issue機能を使用するには、GraphQL APIリクエストに `GraphQL-Features: sub_issues` ヘッダーが必須です。
+gh 2.94.0+ では Sub-issue 操作が `gh issue edit` / `gh issue view` に first-class 化され、
+Node ID 解決も `GraphQL-Features: sub_issues` ヘッダーも不要になった。番号（または URL）で直接操作する。
 
-#### 1. Issue番号からNode IDを取得
-
-```bash
-# Issue番号からNode IDを取得
-gh api graphql -f query='
-query {
-  repository(owner: "owner", name: "repo") {
-    issue(number: 123) {
-      id
-    }
-  }
-}' --jq '.data.repository.issue.id'
-```
-
-#### 2. Sub-issueを追加
+#### 1. Sub-issueを追加
 
 ```bash
-# Parent IssueにSub-issueを追加
-gh api graphql \
-  -H "GraphQL-Features: sub_issues" \
-  -f query='
-mutation {
-  addSubIssue(input: {
-    issueId: "I_kwDOxxxxxx"      # Parent IssueのNode ID
-    subIssueId: "I_kwDOyyyyyy"   # Sub-issueのNode ID
-  }) {
-    issue {
-      number
-      title
-    }
-    subIssue {
-      number
-      title
-    }
-  }
-}'
+# Parent #100 に Sub-issue #123 を追加（カンマ区切りで複数同時可）
+gh issue edit 100 --repo owner/repo --add-sub-issue 123
+gh issue edit 100 --repo owner/repo --add-sub-issue 123,124
+
+# child 側から親を設定しても等価
+gh issue edit 123 --repo owner/repo --parent 100
 ```
 
-#### 3. Sub-issueを削除
+#### 2. Sub-issueを削除
 
 ```bash
-# Sub-issueを親から削除
-gh api graphql \
-  -H "GraphQL-Features: sub_issues" \
-  -f query='
-mutation {
-  removeSubIssue(input: {
-    issueId: "I_kwDOxxxxxx"
-    subIssueId: "I_kwDOyyyyyy"
-  }) {
-    issue {
-      number
-      title
-    }
-  }
-}'
+gh issue edit 100 --repo owner/repo --remove-sub-issue 123
+
+# child 側から親を外しても等価
+gh issue edit 123 --repo owner/repo --remove-parent
 ```
 
-#### 4. Sub-issuesの一覧を取得
+#### 3. Sub-issuesの一覧を取得
 
 ```bash
-# Parent IssueのSub-issuesを取得
-gh api graphql \
-  -H "GraphQL-Features: sub_issues" \
-  -f query='
-query {
-  node(id: "I_kwDOxxxxxx") {
-    ... on Issue {
-      number
-      title
-      subIssues(first: 20) {
-        nodes {
-          number
-          title
-          state
-        }
-      }
-      subIssuesSummary {
-        total
-        completed
-        percentCompleted
-      }
-    }
-  }
-}'
+gh issue view 100 --repo owner/repo \
+  --json number,title,subIssues,subIssuesSummary \
+  --jq '{number, title, summary: .subIssuesSummary, subIssues: [.subIssues.nodes[] | {number, title, state}]}'
 ```
 
-#### 5. Parent Issueを取得
+#### 4. Parent Issueを取得
 
 ```bash
-# IssueのParent Issueを取得
-gh api graphql \
-  -H "GraphQL-Features: sub_issues" \
-  -f query='
-query {
-  node(id: "I_kwDOyyyyyy") {
-    ... on Issue {
-      number
-      title
-      parent {
-        number
-        title
-      }
-    }
-  }
-}'
+gh issue view 123 --repo owner/repo --json number,title,parent --jq '{number, title, parent}'
 ```
 
-### GitHub CLI拡張機能
+### 拡張機能・Fallback（native が使えない環境向け）
 
-GitHub CLI本体にはSub-issue機能のサポートがないため、以下のサードパーティ拡張機能が利用可能です：
+gh 2.94.0 未満や GHES 3.17 未満では native フラグが使えない。その場合は以下を利用する：
 
-- **gh-sub-issue** (by agbiotech): https://github.com/agbiotech/gh-sub-issue
-- **gh-sub-issue** (by yahsan2): https://github.com/yahsan2/gh-sub-issue
+- Fallback: `gh api graphql`（`GraphQL-Features: sub_issues` ヘッダー付き、`addSubIssue` / `removeSubIssue`、Node ID は `repository(...).issue(number:).id` で取得）
+- サードパーティ拡張機能:
+  - **gh-sub-issue** (by agbiotech): https://github.com/agbiotech/gh-sub-issue
+  - **gh-sub-issue** (by yahsan2): https://github.com/yahsan2/gh-sub-issue
 
 ### 制限事項
 
 - 1つのParent Issueに最大100個のSub-issueを追加可能
 - 最大8レベルまでネスト可能
-- Sub-issue機能はGraphQL APIでのみ利用可能（REST APIでは一部のみ対応）
+- native コマンドは gh 2.94.0+ かつ GitHub.com / GHES 3.17+ が必要（それ未満は GraphQL fallback）
 
 ### 参考リンク
 
@@ -729,11 +567,13 @@ assignees: ""
 ---
 ```
 
-### GraphQL APIを使用したIssue Type管理
+### Issue Type管理
 
-**重要**: Issue Type機能を使用するには、GraphQL APIリクエストに `GraphQL-Features: issue_types` ヘッダーが必須です。
+gh 2.94.0+ では Issue Type の取得・設定が `gh issue view` / `gh issue edit` に first-class 化され、
+Node ID / Issue Type ID の解決は不要になった（`--type` は名前で指定する）。ただし Organization の
+Issue Type 名を**列挙**する native コマンドは無いため、その確認のみ GraphQL を使用する。
 
-#### 1. Organization Issue Typesの取得
+#### 1. Organization Issue Typesの取得（native 未対応のため GraphQL を使用）
 
 ```bash
 gh api graphql \
@@ -743,59 +583,30 @@ query {
   organization(login: "ORG_NAME") {
     issueTypes(first: 25) {
       nodes {
-        id
         name
         description
-        color
         isEnabled
       }
     }
   }
-}'
+}' --jq '.data.organization.issueTypes.nodes[] | select(.isEnabled == true) | "\(.name): \(.description // "")"'
 ```
 
 #### 2. IssueのTypeを取得
 
 ```bash
-gh api graphql \
-  -H "GraphQL-Features: issue_types" \
-  -f query='
-query {
-  repository(owner: "OWNER", name: "REPO") {
-    issue(number: 123) {
-      title
-      number
-      issueType {
-        name
-        description
-        color
-      }
-    }
-  }
-}'
+gh issue view 123 --repo owner/repo --json number,title,issueType \
+  --jq '{number, title, issueType: .issueType.name}'
 ```
 
 #### 3. IssueのTypeを設定/変更
 
 ```bash
-gh api graphql \
-  -H "GraphQL-Features: issue_types" \
-  -f query='
-mutation($issueId: ID!, $issueTypeId: ID!) {
-  updateIssueIssueType(input: {
-    issueId: $issueId
-    issueTypeId: $issueTypeId
-  }) {
-    issue {
-      title
-      issueType {
-        name
-      }
-    }
-  }
-}' \
-  -f issueId="ISSUE_NODE_ID" \
-  -f issueTypeId="ISSUE_TYPE_ID"
+# 名前で直接指定（Node ID / Issue Type ID の解決は不要）
+gh issue edit 123 --repo owner/repo --type "Enhancement"
+
+# Issue Type を外す
+gh issue edit 123 --repo owner/repo --remove-type
 ```
 
 #### 4. Organization Issue Typesの作成（REST API）
@@ -845,7 +656,7 @@ Issue Templateの`type`フィールドは、Organizationで定義されたIssue 
 - GitHub CLIの認証が必須
 - 適切な権限（Issue作成権限）が必要
 - テンプレートファイルはMarkdown形式で作成
-- Sub-issue機能を使用する場合は `GraphQL-Features: sub_issues` ヘッダーが必須
-- Issue Type機能を使用する場合は `GraphQL-Features: issue_types` ヘッダーが必須
+- Sub-issue / Issue Type の設定は native の `gh issue create/edit`（gh 2.94.0+、GitHub.com / GHES 3.17+）を使用する。列挙用の GraphQL fallback を除き `GraphQL-Features` ヘッダーは不要
+- native が使えない環境（gh 2.94.0 未満 / GHES 3.17 未満）では `gh api graphql`（`GraphQL-Features: sub_issues` / `issue_types` ヘッダー付き）へフォールバックする
 - Issue TypesはOrganizationでのみ利用可能（個人リポジトリでは自動設定されません）
 - テンプレートの`type`フィールドは、Organizationで定義されたIssue Type名と完全一致する必要があります

--- a/home/dot_agents/skills/daily-planning/SKILL.md
+++ b/home/dot_agents/skills/daily-planning/SKILL.md
@@ -219,12 +219,23 @@ gh search issues --repo "${REPO_FULLNAME}" --author "${GH_USER}" --created "${SE
   - Step 7 の投稿本文を**ミューテーション直書きから `BODY` 変数バインディング**へ変更（複数行・絵文字・記号でクエリが壊れる問題を解消）
   - `YEAR_MONTH` を Step 1 へ集約し `TZ=Asia/Tokyo` を付与（月境界の取り違え解消）
   - Step 7 投稿直前に**日跨ぎ検証**（`TODAY_JST` と現在 JST 日付の不一致確認）を追加
+- 2026-07 の見直し:
+  - Step 4（前日の投稿取得）・Step 7（投稿）を native の `gh discussion view --comments` / `gh discussion comment`（gh 2.94.0+）へ移行し、Discussion Node ID 解決を不要化。`gh discussion` は preview のため、破壊的変更に備え GraphQL 版を各ステップの Fallback として残置（Step 2 の Discussion 検索は `gh discussion list` と非等価のため GraphQL Search のまま）
 
 ### 4. 前日の投稿を取得
 
-Discussionの既存コメントから直前の投稿を取得し、「やったこと」と「レビュー」を「前日の振り返り」に使用する。
+Discussionの既存コメントから直前の投稿を取得し、「やったこと」と「レビュー」を「前日の振り返り」に使用する。native の `gh discussion view --comments` で取得する（Discussion Node ID の解決は不要）。`DISCUSSION_NUMBER` は Step 2 で特定した番号を入れる。
 
-**重要: GraphQL は変数バインディング（`-f`/`-F`）で渡す。** シングルクォート内に `${REPO_OWNER}` 等のシェル変数を直書きすると展開されず、文字列リテラル `${REPO_OWNER}` が GraphQL に送られて `Could not resolve to a Repository` で失敗する。`-f` は文字列、`-F` は数値（`number: Int!`）に使う。`DISCUSSION_NUMBER` は Step 2 で特定した番号を入れる。
+**注意: `gh discussion` は preview 機能であり、フラグや出力構造が予告なく変わりうる。** 破壊的変更で動作しなくなった場合は、末尾の Fallback に記載した `gh api graphql`（`discussion(number:).comments`）へ切り替える。
+
+```bash
+# native: 最新コメント（newest 順の先頭 1 件）の本文を取得
+gh discussion view "${DISCUSSION_NUMBER}" --repo "${REPO_FULLNAME}" \
+  --comments --order newest --limit 1 \
+  --json comments --jq '.comments.nodes[0].body'
+```
+
+**Fallback（`gh discussion` が preview 変更等で使えない場合）:** GraphQL は変数バインディング（`-f`/`-F`）で渡す。シングルクォート内に `${REPO_OWNER}` 等のシェル変数を直書きすると展開されず、文字列リテラル `${REPO_OWNER}` が GraphQL に送られて `Could not resolve to a Repository` で失敗する。`-f` は文字列、`-F` は数値（`number: Int!`）に使う。
 
 ```bash
 gh api graphql \
@@ -327,11 +338,27 @@ fi
 ```
 
 **重要（D3・D4）:**
-- GraphQL は**変数バインディング（`-f`/`-F`）で渡す**。シングルクォート内のシェル変数（`${REPO_OWNER}` 等）は展開されないため、クエリ文字列へ直書きしない。
-- **投稿本文は必ず `BODY` 変数に格納して `-f body="${BODY}"` で渡す**。ミューテーション文字列へ本文を直接埋め込まない（複数行・絵文字 🤿📣⏰・`##`・改行・引用符でクエリが壊れる）。
+- 投稿には native の `gh discussion comment`（Discussion Node ID の解決は不要）を使う。
+- **投稿本文は必ず `BODY` 変数に格納して `--body "${BODY}"` で渡す**（複数行・絵文字 🤿📣⏰・`##`・改行・引用符をそのまま安全に渡すため。ミューテーション文字列への埋め込みは不要になった）。
+- **注意: `gh discussion` は preview 機能で、フラグや挙動が予告なく変わりうる。** 破壊的変更で使えない場合は、Fallback の `gh api graphql`（`addDiscussionComment`）へ切り替える。
 
 ```bash
-# Discussion Node ID を取得（DISCUSSION_NUMBER は Step 2 で特定した番号）
+# 本文を heredoc で組み立てる（クォートなし EOF で変数展開を避け、Step 6 の下書きをそのまま流し込む）
+BODY=$(cat <<'EOF'
+## 2026/06/25
+
+✅ やったこと
+- ...（Step 6 で承認された下書きをそのまま貼る）
+EOF
+)
+
+# native: コメントを投稿する（実行後に出力されるコメント URL をユーザーへ表示する）
+gh discussion comment "${DISCUSSION_NUMBER}" --repo "${REPO_FULLNAME}" --body "${BODY}"
+```
+
+**Fallback（`gh discussion` が preview 変更等で使えない場合）:** GraphQL は変数バインディング（`-f`/`-F`）で渡す。シングルクォート内のシェル変数（`${REPO_OWNER}` 等）は展開されないためクエリ文字列へ直書きしない。本文は `-f body="${BODY}"` で渡し、Discussion Node ID を先に取得する。
+
+```bash
 DISCUSSION_ID=$(gh api graphql \
   -f owner="${REPO_OWNER}" \
   -f name="${REPO_NAME}" \
@@ -343,16 +370,6 @@ query($owner: String!, $name: String!, $number: Int!) {
   }
 }' --jq '.data.repository.discussion.id')
 
-# 本文を heredoc で組み立てる（クォートなし EOF で変数展開を避け、Step 6 の下書きをそのまま流し込む）
-BODY=$(cat <<'EOF'
-## 2026/06/25
-
-✅ やったこと
-- ...（Step 6 で承認された下書きをそのまま貼る）
-EOF
-)
-
-# コメントを投稿（body は変数バインディング）
 gh api graphql \
   -f discussionId="${DISCUSSION_ID}" \
   -f body="${BODY}" \

--- a/home/dot_agents/skills/github-sub-issues/README.md
+++ b/home/dot_agents/skills/github-sub-issues/README.md
@@ -1,6 +1,7 @@
 # GitHub Sub-issues & Issue Types Management Skill
 
-GitHub の Sub-issue 機能および Issue Types 機能を GraphQL API で操作するエージェントスキルです。
+GitHub の Sub-issue 機能および Issue Types 機能を、gh CLI 2.94.0+ の native コマンド
+（`gh issue create/edit/view`）で操作するエージェントスキルです。
 
 ## 概要
 
@@ -13,35 +14,27 @@ GitHub の Sub-issue 機能および Issue Types 機能を GraphQL API で操作
 ## 提供する機能
 
 ### Sub-issue 操作
-- Parent Issue の Sub-issues 一覧取得
-- 既存 Issue を Sub-issue として追加
-- Sub-issue を親から削除
-- Issue の Parent Issue 取得
+- Parent Issue の Sub-issues 一覧取得（`gh issue view --json subIssues,subIssuesSummary`）
+- 既存 Issue を Sub-issue として追加（`gh issue edit --add-sub-issue` / `--parent`）
+- Sub-issue を親から削除（`gh issue edit --remove-sub-issue` / `--remove-parent`）
+- Issue の Parent Issue 取得（`gh issue view --json parent`）
 
 ### Issue Types 操作
-- Organization の Issue Types 一覧取得
-- Issue の現在の Issue Type 取得
-- Issue の Issue Type 設定・変更
+- Issue の現在の Issue Type 取得（`gh issue view --json issueType`）
+- Issue の Issue Type 設定・変更（`gh issue edit --type <name>` / `--remove-type`）
+- Organization の Issue Types 一覧取得（native 未対応のため GraphQL を併用）
 
 ## 重要な注意点
 
-GraphQL API で Sub-issues / Issue Types 機能を使用するには、特別なヘッダーが必須です：
-
-```bash
-# Sub-issues 操作時
--H "GraphQL-Features: sub_issues"
-
-# Issue Types 操作時
--H "GraphQL-Features: issue_types"
-```
-
-このヘッダーがないと API は正しく動作しません。
+native フラグは gh 2.94.0+ かつ GitHub.com / GHES 3.17+（relationships は 3.19+）で利用可能です。
+それ未満の環境では、SKILL.md 末尾の「Fallback: GraphQL API」に記載した `gh api graphql`
+（`GraphQL-Features: sub_issues` / `issue_types` ヘッダー付き）へフォールバックします。
 
 ## ファイル構成
 
 ```
 github-sub-issues/
-├── SKILL.md   # スキル定義（GraphQL API の使用方法）
+├── SKILL.md   # スキル定義（native gh コマンド + GraphQL fallback）
 └── README.md  # このファイル
 ```
 

--- a/home/dot_agents/skills/github-sub-issues/SKILL.md
+++ b/home/dot_agents/skills/github-sub-issues/SKILL.md
@@ -1,133 +1,75 @@
 ---
 name: github-sub-issues
-description: This skill should be used when the user asks about "sub-issues", "sub-issue", "サブイシュー", "子イシュー", "issue type", "Issue Type", mentions "parent issue", "親issue", or discusses managing hierarchical GitHub issues using GraphQL API. Provides operations for listing, adding, removing sub-issues, and setting Issue Types.
-version: 1.0.0
+description: This skill should be used when the user asks about "sub-issues", "sub-issue", "サブイシュー", "子イシュー", "issue type", "Issue Type", mentions "parent issue", "親issue", or discusses managing hierarchical GitHub issues. Provides operations for listing, adding, removing sub-issues, and setting Issue Types.
+version: 2.0.0
 ---
 
 # GitHub Sub-issues & Issue Types Management Skill
 
-GitHub の Sub-issue 機能および Issue Types 機能を GraphQL API で操作するスキルです。
+GitHub の Sub-issue 機能および Issue Types 機能を、gh CLI 2.94.0+ で first-class 化された
+native コマンド（`gh issue create/edit/view`）で操作するスキルです。従来の `gh api graphql`
+ワークアラウンド（`GraphQL-Features` ヘッダー・Node ID 解決）は不要になりました。
 
-## 重要: 必須HTTPヘッダー
+## 前提と graceful fallback
 
-Sub-issue と Issue Types の機能を使用するには、GraphQL API リクエストに特別なヘッダーが必要です：
+| 機能 | 必要な gh バージョン | 必要な GitHub 環境 |
+|------|---------------------|--------------------|
+| Sub-issues（`--parent` / `--add-sub-issue` / `--remove-sub-issue`） | gh 2.94.0+ | GitHub.com / GHES 3.17+ |
+| Issue Types（`--type`） | gh 2.94.0+ | GitHub.com / GHES 3.17+ |
+| Relationships（`--blocked-by` / `--blocking`） | gh 2.94.0+ | GitHub.com / GHES 3.19+ |
 
-| 機能 | 必須ヘッダー |
-|------|-------------|
-| Sub-issues | `-H "GraphQL-Features: sub_issues"` |
-| Issue Types | `-H "GraphQL-Features: issue_types"` |
+上記を満たさない環境（古い gh、または GHES 3.17 未満）では native フラグが使えないため、
+末尾の「Fallback: GraphQL API」に記載した `gh api graphql`（`GraphQL-Features` ヘッダー付き）
+へフォールバックする。
 
 ## Sub-issue 操作
 
 ### 1. Parent Issue の Sub-issues 一覧を取得
 
 ```bash
-# Step 1: Parent Issue の Node ID を取得
-PARENT_ID=$(gh api graphql -f query='
-query {
-  repository(owner: "OWNER", name: "REPO") {
-    issue(number: ISSUE_NUMBER) { id }
-  }
-}' --jq '.data.repository.issue.id')
-
-# Step 2: Sub-issues を取得
-gh api graphql \
-  -H "GraphQL-Features: sub_issues" \
-  -f query="
-query {
-  node(id: \"$PARENT_ID\") {
-    ... on Issue {
-      number
-      title
-      subIssues(first: 50) {
-        nodes {
-          number
-          title
-          state
-        }
-      }
-      subIssuesSummary {
-        total
-        completed
-        percentCompleted
-      }
-    }
-  }
-}"
+# subIssues と subIssuesSummary を native に取得（Node ID 解決は不要）
+gh issue view ISSUE_NUMBER --repo OWNER/REPO \
+  --json number,title,subIssues,subIssuesSummary \
+  --jq '{number, title, summary: .subIssuesSummary, subIssues: [.subIssues.nodes[] | {number, title, state}]}'
 ```
 
 ### 2. 既存の Issue を Sub-issue として追加
 
 ```bash
-# Parent と Sub-issue の Node ID を取得
-PARENT_ID=$(gh api graphql -f query='
-query {
-  repository(owner: "OWNER", name: "REPO") {
-    issue(number: PARENT_NUMBER) { id }
-  }
-}' --jq '.data.repository.issue.id')
+# Parent（PARENT_NUMBER）に Child（CHILD_NUMBER）を sub-issue として追加
+# カンマ区切りで複数同時に追加可能（番号でも URL でも可）
+gh issue edit PARENT_NUMBER --repo OWNER/REPO --add-sub-issue CHILD_NUMBER
 
-CHILD_ID=$(gh api graphql -f query='
-query {
-  repository(owner: "OWNER", name: "REPO") {
-    issue(number: CHILD_NUMBER) { id }
-  }
-}' --jq '.data.repository.issue.id')
+# 例: 複数追加
+gh issue edit 100 --repo OWNER/REPO --add-sub-issue 123,124
 
-# Sub-issue として追加
-gh api graphql \
-  -H "GraphQL-Features: sub_issues" \
-  -f query="
-mutation {
-  addSubIssue(input: {
-    issueId: \"$PARENT_ID\"
-    subIssueId: \"$CHILD_ID\"
-  }) {
-    issue { number title }
-    subIssue { number title }
-  }
-}"
+# Child 側から親を設定しても等価（--parent は sub-issue 関係の裏返し）
+gh issue edit CHILD_NUMBER --repo OWNER/REPO --parent PARENT_NUMBER
 ```
 
 ### 3. Sub-issue を親から削除
 
 ```bash
-gh api graphql \
-  -H "GraphQL-Features: sub_issues" \
-  -f query="
-mutation {
-  removeSubIssue(input: {
-    issueId: \"$PARENT_ID\"
-    subIssueId: \"$CHILD_ID\"
-  }) {
-    issue { number title }
-  }
-}"
+gh issue edit PARENT_NUMBER --repo OWNER/REPO --remove-sub-issue CHILD_NUMBER
+
+# Child 側から親を外しても等価
+gh issue edit CHILD_NUMBER --repo OWNER/REPO --remove-parent
 ```
 
 ### 4. Issue の Parent Issue を取得
 
 ```bash
-gh api graphql \
-  -H "GraphQL-Features: sub_issues" \
-  -f query="
-query {
-  node(id: \"$ISSUE_NODE_ID\") {
-    ... on Issue {
-      number
-      title
-      parent {
-        number
-        title
-      }
-    }
-  }
-}"
+gh issue view ISSUE_NUMBER --repo OWNER/REPO --json number,title,parent \
+  --jq '{number, title, parent}'
 ```
 
 ## Issue Types 操作
 
 ### 1. Organization の Issue Types 一覧を取得
+
+Issue Type 名の列挙に相当する native コマンドは存在しないため、この確認のみ GraphQL を使用する。
+`gh issue edit --type <name>` は名前で設定するため、通常この一覧取得は「利用可能な type 名の確認」
+にのみ必要。
 
 ```bash
 gh api graphql \
@@ -137,83 +79,30 @@ query {
   organization(login: "ORG_NAME") {
     issueTypes(first: 25) {
       nodes {
-        id
         name
         description
-        color
         isEnabled
       }
     }
   }
-}'
-```
-
-**出力例:**
-```json
-{
-  "data": {
-    "organization": {
-      "issueTypes": {
-        "nodes": [
-          {"id": "IT_kwDOxxxxxx", "name": "Task", "description": "A specific piece of work", "isEnabled": true},
-          {"id": "IT_kwDOyyyyyy", "name": "Bug", "description": "An unexpected problem", "isEnabled": true},
-          {"id": "IT_kwDOzzzzzz", "name": "Enhancement", "description": "A request or new functionality", "isEnabled": true},
-          {"id": "IT_kwDOwwwwww", "name": "Epic", "description": "A larger requirement", "isEnabled": true}
-        ]
-      }
-    }
-  }
-}
+}' --jq '.data.organization.issueTypes.nodes[] | select(.isEnabled == true) | "\(.name): \(.description // "")"'
 ```
 
 ### 2. Issue の現在の Issue Type を取得
 
 ```bash
-gh api graphql \
-  -H "GraphQL-Features: issue_types" \
-  -f query='
-query {
-  repository(owner: "OWNER", name: "REPO") {
-    issue(number: ISSUE_NUMBER) {
-      number
-      title
-      issueType {
-        id
-        name
-        description
-      }
-    }
-  }
-}'
+gh issue view ISSUE_NUMBER --repo OWNER/REPO --json number,title,issueType \
+  --jq '{number, title, issueType: .issueType.name}'
 ```
 
 ### 3. Issue の Issue Type を設定・変更
 
 ```bash
-# Step 1: Issue の Node ID を取得
-ISSUE_NODE_ID=$(gh api graphql -f query='
-query {
-  repository(owner: "OWNER", name: "REPO") {
-    issue(number: ISSUE_NUMBER) { id }
-  }
-}' --jq '.data.repository.issue.id')
+# 名前で直接指定（Node ID / Issue Type ID の解決は不要）
+gh issue edit ISSUE_NUMBER --repo OWNER/REPO --type "Enhancement"
 
-# Step 2: Issue Type を設定
-gh api graphql \
-  -H "GraphQL-Features: issue_types" \
-  -f query="
-mutation {
-  updateIssueIssueType(input: {
-    issueId: \"$ISSUE_NODE_ID\"
-    issueTypeId: \"IT_kwDOxxxxxx\"
-  }) {
-    issue {
-      number
-      title
-      issueType { name }
-    }
-  }
-}"
+# Issue Type を外す
+gh issue edit ISSUE_NUMBER --repo OWNER/REPO --remove-type
 ```
 
 ## 実践例: Epic の全 Sub-issues に Issue Type を一括設定
@@ -222,80 +111,43 @@ mutation {
 #!/bin/bash
 # Epic #123 の全 sub-issues を Enhancement に設定する例
 
-OWNER="<OWNER>"
-REPO="<REPO>"
+REPO="<OWNER>/<REPO>"
 EPIC_NUMBER=123
 ISSUE_TYPE_NAME="Enhancement"
 
-# 1. Epic の Node ID を取得
-EPIC_ID=$(gh api graphql -f query="
-query {
-  repository(owner: \"$OWNER\", name: \"$REPO\") {
-    issue(number: $EPIC_NUMBER) { id }
-  }
-}" --jq '.data.repository.issue.id')
+# 1. Sub-issues の番号を native に取得（Node ID 解決は不要）
+SUB_ISSUE_NUMBERS=$(gh issue view "$EPIC_NUMBER" --repo "$REPO" \
+  --json subIssues --jq '.subIssues.nodes[].number')
 
-# 2. Sub-issues の番号を取得
-SUB_ISSUE_NUMBERS=$(gh api graphql \
-  -H "GraphQL-Features: sub_issues" \
-  -f query="
-query {
-  node(id: \"$EPIC_ID\") {
-    ... on Issue {
-      subIssues(first: 50) {
-        nodes { number }
-      }
-    }
-  }
-}" --jq '.data.node.subIssues.nodes[].number')
-
-# 3. Organization から Issue Type ID を取得
-ORG="${OWNER}"
-ISSUE_TYPE_ID=$(gh api graphql \
-  -H "GraphQL-Features: issue_types" \
-  -f query="
-query {
-  organization(login: \"$ORG\") {
-    issueTypes(first: 25) {
-      nodes { id name isEnabled }
-    }
-  }
-}" --jq ".data.organization.issueTypes.nodes[] | select(.name == \"$ISSUE_TYPE_NAME\" and .isEnabled == true) | .id")
-
-echo "Epic ID: $EPIC_ID"
-echo "Issue Type ID for $ISSUE_TYPE_NAME: $ISSUE_TYPE_ID"
-echo ""
-
-# 4. 各 sub-issue に Issue Type を設定
+# 2. 各 sub-issue に Issue Type を名前で設定
 for issue_num in $SUB_ISSUE_NUMBERS; do
-  echo "Setting Issue Type for #$issue_num..."
-
-  # Issue の Node ID を取得
-  NODE_ID=$(gh api graphql -f query="
-  query {
-    repository(owner: \"$OWNER\", name: \"$REPO\") {
-      issue(number: $issue_num) { id }
-    }
-  }" --jq '.data.repository.issue.id')
-
-  # Issue Type を設定
-  RESULT=$(gh api graphql \
-    -H "GraphQL-Features: issue_types" \
-    -f query="
-  mutation {
-    updateIssueIssueType(input: {
-      issueId: \"$NODE_ID\"
-      issueTypeId: \"$ISSUE_TYPE_ID\"
-    }) {
-      issue {
-        number
-        issueType { name }
-      }
-    }
-  }")
-
-  echo "$RESULT" | jq -c '.data.updateIssueIssueType.issue'
+  echo "Setting Issue Type '$ISSUE_TYPE_NAME' for #$issue_num..."
+  gh issue edit "$issue_num" --repo "$REPO" --type "$ISSUE_TYPE_NAME"
 done
+```
+
+## Fallback: GraphQL API（native が使えない環境向け）
+
+古い gh（2.94.0 未満）や GHES 3.17 未満では native フラグが使えないため、従来どおり
+`gh api graphql` に `GraphQL-Features: sub_issues` / `issue_types` ヘッダーを付けて操作する。
+Node ID は `gh api graphql` の `repository(...).issue(number:).id` で取得する。
+
+```bash
+# Sub-issue 追加（fallback）
+PARENT_ID=$(gh api graphql -f query='
+query { repository(owner: "OWNER", name: "REPO") { issue(number: PARENT_NUMBER) { id } } }' \
+  --jq '.data.repository.issue.id')
+CHILD_ID=$(gh api graphql -f query='
+query { repository(owner: "OWNER", name: "REPO") { issue(number: CHILD_NUMBER) { id } } }' \
+  --jq '.data.repository.issue.id')
+gh api graphql -H "GraphQL-Features: sub_issues" -f query="
+mutation {
+  addSubIssue(input: { issueId: \"$PARENT_ID\", subIssueId: \"$CHILD_ID\" }) {
+    issue { number title }
+  }
+}"
+
+# Sub-issue 削除は removeSubIssue、Issue Type 設定は updateIssueIssueType（要 issue_types ヘッダー）を使う。
 ```
 
 ## 制限事項
@@ -303,12 +155,13 @@ done
 ### Sub-issues
 - 1つの Parent Issue に最大 100 個の Sub-issue を追加可能
 - 最大 8 レベルまでネスト可能
-- GraphQL API でのみ利用可能（REST API では一部のみ対応）
+- native コマンドは gh 2.94.0+ かつ GitHub.com / GHES 3.17+ が必要（それ未満は GraphQL fallback）
 
 ### Issue Types
 - Organization でのみ利用可能（個人リポジトリでは使用不可）
 - 1つの Organization に最大 25 個の Issue Types を作成可能
 - Pull Request は非対応（Issue のみ）
+- 利用可能な type 名の列挙は native 未対応のため GraphQL を使用する
 
 ## 参考リンク
 

--- a/home/dot_agents/skills/self-evaluate/SKILL.md
+++ b/home/dot_agents/skills/self-evaluate/SKILL.md
@@ -53,7 +53,28 @@ gh api "repos/<repo>/stats/contributors" --jq ".[] | select(.author.login == \"$
 git log --author="$USERNAME" --grep="Co-Authored-By" --oneline --since="$SINCE_DATE" | wc -l
 git log --author="$USERNAME" --oneline --since="$SINCE_DATE" | wc -l
 
-# GitHub Discussions データ（GraphQL API）
+# GitHub Discussions データ
+# 列挙は native の `gh discussion list`（gh 2.94.0+）。Discussion 単位のメタ
+# （作成者・カテゴリ・作成日・回答採択・ラベル）を取得する。--json 出力は `.discussions[]` 配下。
+# 注意: `gh discussion` は preview 機能で、フラグ・出力構造が予告なく変わりうる。破壊的変更で
+#       動作しなくなった場合は、末尾の Fallback（`gh api graphql` の discussions クエリ）へ切り替える。
+gh discussion list --repo <repo> --limit 500 \
+  --json number,title,author,category,createdAt,answered,answerChosenBy,labels \
+  --jq '.discussions[]'
+
+# コメント本文・コメント著者・回答フラグ（isAnswer）が必要な場合は、各 discussion に対して
+# `gh discussion view --comments` を併用する（`gh discussion list` は per-comment データを返さないため）。
+# 例: 他者の Discussion への自分のコメント数、Accepted Answer 数の集計に使う。
+for num in $(gh discussion list --repo <repo> --limit 500 --json number --jq '.discussions[].number'); do
+  gh discussion view "$num" --repo <repo> --comments --limit 100 \
+    --json number,comments \
+    --jq '{number, comments: [.comments.nodes[] | {author: .author.login, createdAt, isAnswer}]}'
+done
+```
+
+**Fallback（`gh discussion` が preview 変更等で使えない場合）:** 従来の GraphQL で discussions を列挙する。
+
+```bash
 gh api graphql -f query='
   query($owner: String!, $repo: String!, $cursor: String) {
     repository(owner: $owner, name: $repo) {
@@ -85,7 +106,7 @@ gh api graphql -f query='
 - `gh auth status` でログイン状態を事前確認すること
 - APIレートリミットに注意し、必要に応じてsleepを挟むこと
 - データが取得できなかったリポジトリはスキップし、レポートにその旨を記載すること
-- Discussions機能が無効なリポジトリではGraphQLクエリがエラーになるため、エラー時はスキップすること
+- Discussions機能が無効なリポジトリでは `gh discussion list`（および Fallback の GraphQL クエリ）がエラーになるため、エラー時はスキップすること
 
 ### Step 2: 定量分析
 

--- a/home/dot_agents/skills/sync-daily-planning-calendar/SKILL.md
+++ b/home/dot_agents/skills/sync-daily-planning-calendar/SKILL.md
@@ -144,6 +144,19 @@ GraphQLの変数バインディング（`-f q=`）を使用することで、検
 
 3. Discussionのコメントを全取得:
 
+native の `gh discussion view --comments` で取得する（Discussion Node ID の解決は不要）。`DISCUSSION_NUMBER` は手順 2 で特定した番号を入れる。
+
+**注意: `gh discussion` は preview 機能であり、フラグや出力構造が予告なく変わりうる。** 破壊的変更で動作しなくなった場合は、下の Fallback（`gh api graphql`）へ切り替える。
+
+```bash
+# native: 全コメントを古い順で取得（--limit はコメント件数に応じて調整）
+gh discussion view DISCUSSION_NUMBER --repo "${REPO_FULLNAME}" \
+  --comments --order oldest --limit 100 \
+  --json comments --jq '.comments.nodes[] | {createdAt, body}'
+```
+
+**Fallback（`gh discussion` が preview 変更等で使えない場合）:**
+
 ```bash
 gh api graphql -f query="
 {


### PR DESCRIPTION
## Summary

gh CLI [v2.94.0](https://github.com/cli/cli/releases/tag/v2.94.0) promoted Issues 2.0 (issue types, sub-issues, relationships) and the `gh discussion` command set to first-class commands. Five agent skills under `home/dot_agents/skills/` implemented these via `gh api graphql` workarounds (custom queries + `GraphQL-Features` headers + Node ID lookups). This PR migrates them to the native commands, simplifying the skills and removing the header/Node-ID plumbing where a native equivalent exists.

The repo's pinned gh is **2.95.0**; every native flag and `--json` field used below was verified against its `--help` output before writing.

## Changes

**Issues 2.0 → native `gh issue`**
- `github-sub-issues/SKILL.md` (v1.0.0 → 2.0.0) + `README.md` — sub-issue list → `gh issue view --json subIssues,subIssuesSummary`; add → `gh issue edit --add-sub-issue` / `--parent`; remove → `--remove-sub-issue` / `--remove-parent`; issue-type get → `gh issue view --json issueType`; set → `gh issue edit --type` / `--remove-type`. All `addSubIssue` / `removeSubIssue` / `updateIssueIssueType` mutations, Node ID lookups, and the required-headers section removed.
- `create-issue/SKILL.md` — issue-type assignment via `gh issue create --type` / `gh issue edit --type`; sub-issue attach via `gh issue edit --parent`. Fixed an Epic hint that wrongly showed `--add-project` instead of `--add-sub-issue`.

**Discussions → `gh discussion` (preview)**
- `daily-planning/SKILL.md` — prior-comment read → `gh discussion view --comments --order newest --limit 1`; post → `gh discussion comment --body`.
- `sync-daily-planning-calendar/SKILL.md` — comment retrieval → `gh discussion view --comments --order oldest`.
- `self-evaluate/SKILL.md` — enumeration → `gh discussion list --json`, plus a per-discussion `gh discussion view --comments` loop (list does not return per-comment data).

## Kept on GraphQL (no native equivalent / preview safety)

- **Org issue-type listing** — no native command enumerates an org's issue types, so this stays GraphQL (kept for validating available `--type` names).
- **Discussion search** — verified that `gh discussion list --category` + `--search` do not compose equivalently, so the discussion-search steps remain GraphQL.
- **Graceful fallback** — each migrated skill keeps a documented `gh api graphql` fallback for gh <2.94 / GHES <3.17 (relationships: 3.19+). `gh discussion` is still **preview**, so each discussion skill notes this and retains the GraphQL fallback.

## Verification

- Every native flag / `--json` field verified against gh 2.95.0 `--help` (`gh issue edit`: `--add-sub-issue`/`--remove-sub-issue`/`--parent`/`--remove-parent`/`--type`/`--remove-type`; `gh issue view --json`: `subIssues`/`subIssuesSummary`/`issueType`/`parent`; `gh discussion view --comments --order --limit`; `gh discussion comment --body`; `gh discussion list --search`/`--category`/`--json`).
- `bats tests/skill_provenance.bats` — all pass.
- Documentation-only change (`SKILL.md` / `README.md`); no shell/CI surface touched.

Closes #154.
