### PR TITLE
feat(skills): add parallel-dev triad (repo-radar / renovate-sweep / issue-fleet)

### DIFF
--- a/home/dot_agents/skills/issue-fleet/SKILL.md
+++ b/home/dot_agents/skills/issue-fleet/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: issue-fleet
+description: |
+  複数の GitHub Issue を並列 worktree + サブエージェントで同時に実装し、それぞれ draft PR まで進める並列開発の司令塔。
+  wtp で worktree を作成し、各サブエージェントへ実装 → 検証 → commit → push → draft PR 作成を委任する。
+  トリガー: "issue-fleet", "並列で実装して", "issue をまとめて片付けて", "フリートで進めて"
+  使用場面: trivial〜small 級の独立した Issue が複数溜まっているとき（コンテンツ修正・小規模バグ修正・文言変更など）。
+argument-hint: "<issue 番号列 or 検索条件> [--max-parallel=N] [--repo=owner/name] [--dry-run]"
+user-invocable: true
+---
+
+# issue-fleet
+
+複数 Issue を **1 Issue = 1 worktree = 1 branch = 1 draft PR** の原則で並列処理する orchestrator。
+自分（メインループ）は司令塔に徹し、実装はサブエージェントへ委任する。単一タスクの深い orchestration は `pr-workflow` の領分であり、本 skill は「浅く広く並列に」が領分。
+
+## 引数
+
+| 引数 | 既定 | 意味 |
+|------|------|------|
+| `<issue 番号列 or 検索条件>` | - | `123 124 125` / `#123,#124` / `label:content` / 自然文（例:「写真差し替え系を全部」） |
+| `--max-parallel` | 4 | 同時に走らせるサブエージェント数の上限 |
+| `--repo` | カレントリポジトリ | 対象リポジトリ（`owner/name`） |
+| `--dry-run` | off | Phase 2 の dispatch 計画表を出して終了（worktree 作成・実装をしない） |
+
+## 安全原則（絶対遵守）
+
+- **自動マージ禁止**。作るのは draft PR まで。merge は user の明示操作。
+- **main / master への直接 push 禁止**。必ず worktree 上の feature branch で作業する。
+- **GATE（dispatch 承認）を通過するまで書き込み系操作をしない**。承認は「各 worktree 内での commit / push / draft PR 作成」を包括的に許可するものとし、以降 Issue ごとの個別確認はしない。
+- standard 以上の tier と判定した Issue は fleet に入れず、`pr-workflow` での単独処理を推奨として報告する。
+
+## Phase 0: 対象 Issue の収集
+
+```bash
+# 番号指定の場合
+gh issue view <番号> --repo <owner/name> --json number,title,body,labels,assignees
+
+# 検索条件の場合
+gh issue list --repo <owner/name> --state open --label <label> \
+  --json number,title,body,labels --limit 30
+```
+
+自然文で指定された場合は `gh issue list` の結果からタイトル・本文でフィルタし、**解釈した対象一覧を Phase 2 の計画表に含めて user に見せる**（勝手に対象を確定しない）。
+
+## Phase 1: 事前分析（並列可否と tier）
+
+各 Issue について軽量に判定する（ここで実装調査に深入りしない。1 Issue あたり数分以内）:
+
+1. **tier 判定**: `pr-workflow` の基準を再利用。
+   - `trivial`: 1〜数行、単一ファイル、振る舞い不変
+   - `small`: 数ファイル、所有境界内、契約変更なし
+   - `standard` 以上: **fleet 対象外**。計画表に「pr-workflow 単独処理推奨」として記載
+2. **想定変更ファイルの推定**: Issue 本文・ラベル・過去の類似 PR から、触りそうなファイル/ディレクトリを推定
+3. **競合検出**: 想定変更ファイルが重なる Issue ペアは**同一レーンに直列化**する（並列レーンを分けると conflict 地獄になる）
+
+## Phase 2: dispatch 計画と GATE
+
+以下の計画表を提示し、**user の承認を 1 回だけ**得る:
+
+| Issue | tier | branch 名 | worktree | レーン | 備考 |
+|-------|------|-----------|----------|--------|------|
+| #491 | trivial | fix/491-photo-swap | (wtp が導出) | A（並列） | |
+| #499 | small | feat/499-... | 〃 | B（並列） | |
+| #503 | small | feat/503-... | 〃 | B の後（直列） | #499 と同一ファイル競合 |
+
+- branch 名はリポジトリの既存規約（`git log` の直近ブランチ命名）に合わせる。
+- `--dry-run` ならここで終了。
+- **承認が得られなければ何も作らない**。
+
+## Phase 3: worktree 作成
+
+承認後、レーンごとに wtp で worktree を作成する:
+
+```bash
+wtp add -b <branch名>   # ベースは各リポジトリの default branch
+wtp list                # 作成結果とパスの確認
+```
+
+`wtp` が使えないリポジトリでは `git worktree add` に fallback してよいが、パス規約は `wtp` の導出に揃える。
+
+## Phase 4: サブエージェントへの並列委任
+
+**1 メッセージ内で複数の Agent tool 呼び出しを同時に発行**し（`--max-parallel` を上限）、各サブエージェント（general-purpose）に以下のテンプレートで委任する:
+
+```
+あなたは worktree <絶対パス> で Issue #<番号> を実装する担当エージェントです。
+
+## コンテキスト
+- リポジトリ: <owner/name>（default branch: <name>）
+- Issue 全文: <title / body / ラベルをここに展開>
+- 作業ブランチ: <branch名>（作成済み。この worktree 内でのみ作業すること）
+
+## 実行手順
+1. cd <worktree絶対パス> し、以降すべての操作をこの worktree 内で行う
+2. Issue の要求を実装する。既存コードの流儀（命名・構成・テスト規範）に合わせる
+3. プロジェクトの lint / test があれば実行して通す
+4. commit する（メッセージは英語・Conventional Commits。1Password 署名エラーが出たら
+   commit を中断し、エラー内容をそのまま報告して終了する）
+5. push し、draft PR を作成する:
+   gh pr create --draft --title "<英語タイトル>" --body "<英語本文。Closes #<番号> を含める>"
+6. **絶対にマージしない。main に push しない。**
+
+## 返答形式（最終メッセージ）
+- status: success / failed
+- pr_url: <URL or なし>
+- summary: 変更内容 1〜2 行
+- blockers: 詰まった点（なければ「なし」）
+```
+
+- 直列レーンは前のエージェントの完了（成功）を確認してから次を発行する。
+- サブエージェントが failed を返した場合、**自動リトライは 1 回まで**。それでも失敗したら worktree を残したまま報告に回す（人間が引き継げるように）。
+- 1Password 署名エラーの報告を受けたら、`osascript` の通知（AGENTS.md 規定）で user に知らせる。
+
+## Phase 5: 集約と報告
+
+全エージェント完了後、以下を報告する:
+
+| Issue | 結果 | PR | CI | 備考 |
+|-------|------|----|----|------|
+
+- CI 状態は `gh pr checks <PR番号>` で確認（watch までは不要。赤なら失敗ログの要点を添える）
+- 成功した PR の一覧と、失敗分の引き継ぎ情報（worktree パス・詰まった理由）
+- 後片付けの案内: マージ後は `wtp-cleanup` / `delete-merged-branches` を使う
+
+## 他 skill との連携
+
+- **入口**: `repo-radar` が「assign 済み Issue が N 件滞留」を検出したとき、本 skill へのハンドオフを提案する
+- **単独処理**: standard 以上の Issue は `pr-workflow` へ
+- **後始末**: `wtp-cleanup` / `delete-merged-branches`

--- a/home/dot_agents/skills/renovate-sweep/SKILL.md
+++ b/home/dot_agents/skills/renovate-sweep/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: renovate-sweep
+description: |
+  open な Renovate PR を一括トリアージする skill。CI 状態と更新種別でリスク分類し、
+  要注意 PR は renovate-analyzer サブエージェントで並列深掘りし、user 承認後に安全な PR を一括マージする。
+  トリガー: "renovate-sweep", "Renovate まとめて処理", "依存更新 PR を片付けて", "renovate 一括"
+  使用場面: Renovate PR が複数溜まっているとき。単一 PR の深掘りだけなら `renovate-analyzer` を直接使う。
+argument-hint: "[--repo=owner/name] [--all] [--limit=N]"
+user-invocable: true
+---
+
+# renovate-sweep
+
+Renovate（bot: `app/renovate`）の open PR を「**収集 → 機械的分類 → 深掘り（必要分のみ）→ 承認 → 一括マージ**」の流れで処理する。1 PR ずつ人間が開いて確認する作業を、承認 1 回のバッチ処理に置き換える。
+
+## 引数
+
+| 引数 | 既定 | 意味 |
+|------|------|------|
+| `--repo` | カレントリポジトリ | 対象リポジトリ（`owner/name`） |
+| `--all` | off | 自分の owner 配下（kryota-dev / kryota-devs）を横断して収集 |
+| `--limit` | 30 | 収集する PR 数の上限 |
+
+## 安全原則（絶対遵守）
+
+- **承認なしのマージは絶対にしない**。トリアージ表を提示し、user がマージ対象を明示承認した PR のみマージする。
+- security advisory 付き・conflict 状態・CI 赤の PR は「マージ候補」に**決して入れない**（分析 or 人間対応へ回す）。
+- マージ方式はリポジトリの慣習に従う（直近のマージ済み PR の方式を確認。不明なら squash）。
+
+## Phase 1: 収集
+
+```bash
+# カレント or --repo 指定
+gh pr list --repo <owner/name> --author app/renovate --state open --limit <N> \
+  --json number,title,url,labels,mergeable,statusCheckRollup,createdAt
+
+# --all の場合
+gh search prs --author app/renovate --state open --owner kryota-dev --owner kryota-devs \
+  --limit <N> --json number,title,url,repository
+# → repo ごとに上の gh pr list で詳細を取り直す
+```
+
+## Phase 2: 機械的分類
+
+各 PR を以下のルールで 3 分類する。判定材料は **タイトルの semver 種別**（Renovate のタイトル規約 `update dependency X to vY`）、**CI 状態**（statusCheckRollup）、**mergeable**、**ラベル**:
+
+| 分類 | 条件 | 扱い |
+|------|------|------|
+| A: マージ候補 | patch / minor 更新、CI 全緑、mergeable、security advisory なし | 承認後そのままマージ |
+| B: 要分析 | major 更新、または CI 赤、または grouped/monorepo 更新、または digest 以外で semver 判定不能 | renovate-analyzer へ委譲 |
+| C: 要人間 | conflict、security advisory 付き、Renovate の rebase 停止など | 理由を添えて報告のみ |
+
+- semver 種別はタイトルから `vX.Y.Z` の変化を抽出して判定する。抽出できなければ B に倒す（**安全側に倒す**）。
+- CI が pending の PR は数分待って再取得し、それでも pending なら B に倒す。
+- `mergeable` は GitHub が遅延計算するため **`UNKNOWN` が頻出する**。`UNKNOWN` は conflict 扱いにせず、一度再取得（`gh pr view <番号> --json mergeable`）してから判定する。再取得後も `UNKNOWN` なら他条件で分類を続行し、Phase 5 のマージ実行時のエラーで検知する（`CONFLICTING` のときだけ C に落とす）。
+
+## Phase 3: 深掘り（B 分類のみ）
+
+B 分類の各 PR について、`renovate-analyzer` サブエージェントを**並列で**起動する（1 メッセージ内で複数 Agent 呼び出し）。各エージェントには repo と PR 番号を渡し、以下を返させる:
+
+- Breaking Changes の有無と影響範囲
+- アップデート可否の判定（マージ可 / 修正必要 / 保留推奨）
+- 修正が必要な場合の方針
+
+分析結果「マージ可」の PR は A 相当に格上げしてよい（ただしトリアージ表にその旨を明記する）。
+
+## Phase 4: トリアージ表と GATE
+
+全分類・分析が終わったら、以下の表を提示して **user の承認を得る**:
+
+| # | repo | PR | 更新内容 | semver | CI | 分類 | 判定 | 提案 |
+|---|------|----|---------|--------|----|------|------|------|
+
+- 「A + 格上げ分をすべてマージ」「番号指定でマージ」「マージしない」を選べる形で提示する。
+- **承認された PR 以外には一切の書き込み操作をしない**。
+
+## Phase 5: 一括マージと報告
+
+承認された PR を順次マージする:
+
+```bash
+# base が古い場合は先に更新（update-branch 後は CI 完了を待ってからマージ）
+gh pr update-branch <番号> --repo <owner/name>
+gh pr checks <番号> --repo <owner/name> --watch
+
+gh pr merge <番号> --repo <owner/name> --squash   # 方式はリポジトリ慣習に従う
+```
+
+- 同一 repo 内では 1 件マージするたびに残りの mergeable を再確認する（conflict の連鎖を避ける）。
+- 失敗した PR は理由（rebase 必要 / CI 赤化など）を添えて報告する。
+
+最終報告:
+
+| 結果 | 件数 | 詳細 |
+|------|------|------|
+| マージ済み | | PR リンク |
+| 修正必要（B） | | 分析サマリと修正方針 |
+| 人間対応（C） | | 理由 |
+
+## 他 skill との連携
+
+- **入口**: `repo-radar` が Renovate 滞留を検出したとき、本 skill へのハンドオフを提案する
+- **単一 PR の深掘り**: `renovate-analyzer`（Phase 3 が委譲するのと同じサブエージェント）
+- **修正が必要な B 分類**: 修正タスク化して `pr-workflow` へ

--- a/home/dot_agents/skills/repo-radar/SKILL.md
+++ b/home/dot_agents/skills/repo-radar/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: repo-radar
+description: |
+  自分が関わる全リポジトリを横断スイープし、要対応事項（レビュー依頼・自分の PR の CI 失敗 /
+  未解決コメント・Renovate 滞留・assign 済み Issue）を優先度付きの単一レポートにまとめる skill。
+  トリガー: "repo-radar", "レーダー", "今日やることある？", "状況スイープ", "横断チェック"
+  使用場面: 作業開始時の状況把握、離席後のキャッチアップ、issue-fleet / renovate-sweep の起点。
+argument-hint: "[--owners=a,b] [--days=N] [--post]"
+user-invocable: true
+---
+
+# repo-radar
+
+「今、自分の対応を待っているものは何か」を GitHub 横断で 1 コマンドで可視化する。
+読み取り専用が既定であり、`--post` を付けたときだけ（承認後に）Discussion へ投稿する。
+
+## 引数
+
+| 引数 | 既定 | 意味 |
+|------|------|------|
+| `--owners` | kryota-dev,kryota-devs | スイープ対象の owner / org（involves 検索は owner 外もヒットする） |
+| `--days` | 14 | 「滞留」と見なす経過日数の閾値 |
+| `--post` | off | レポートを daily-planning の Discussion にコメント投稿する（投稿前に承認必須） |
+
+## 安全原則
+
+- 既定では **GitHub への書き込みを一切しない**（すべて read-only の `gh` 検索・参照）。
+- `--post` 時も、投稿本文を提示して user 承認を得てからコメントする。
+
+## Phase 1: 収集（並列実行）
+
+以下の検索を**並列の Bash 呼び出し**で一気に取得する（`@me` は gh が解決する）:
+
+```bash
+# 1. 自分にレビュー依頼が来ている open PR
+gh search prs --review-requested=@me --state=open --limit 30 \
+  --json number,title,url,repository,updatedAt,author
+
+# 2. 自分が author の open PR（CI・レビュー状態は後段で詳細取得）
+gh search prs --author=@me --state=open --limit 30 \
+  --json number,title,url,repository,updatedAt,isDraft
+
+# 3. 自分に assign された open Issue
+gh search issues --assignee=@me --state=open --limit 30 \
+  --json number,title,url,repository,updatedAt,labels
+
+# 4. Renovate 滞留（owner 横断）
+gh search prs --author=app/renovate --state=open --owner kryota-dev --owner kryota-devs \
+  --limit 50 --json number,title,url,repository,createdAt
+
+# 5. 自分が involves の直近更新（メンション・コメント返信待ちの取りこぼし防止）
+gh search prs --involves=@me --state=open --limit 30 --json number,title,url,repository,updatedAt
+```
+
+自分が author の PR（2 の結果）については、repo ごとに詳細を取り直す:
+
+```bash
+gh pr view <番号> --repo <owner/name> \
+  --json number,title,url,statusCheckRollup,reviewDecision,mergeable,isDraft
+# 未解決レビュースレッド数（GraphQL）
+gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){
+  repository(owner:$o,name:$r){pullRequest(number:$n){
+    reviewThreads(first:50){nodes{isResolved}}}}}' \
+  -f o=<owner> -f r=<repo> -F n=<番号> \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved|not)]|length'
+```
+
+## Phase 2: 優先度付け
+
+収集結果を以下のルールで格付けする:
+
+| 優先度 | 条件 | 理由 |
+|--------|------|------|
+| P1 | 自分の PR の CI 赤 / changes_requested、自分へのレビュー依頼 | 他人 or パイプラインをブロックしている |
+| P2 | 自分の PR の未解決レビュースレッド、mergeable=CONFLICTING | マージへの直接障害 |
+| P3 | Renovate 滞留（`--days` 超過分を強調） | 溜まるほど conflict 率が上がる |
+| P4 | assign 済み Issue（更新が古い順） | 着手待ちのバックログ |
+
+## Phase 3: レポート出力
+
+以下の形式で出力する（空のセクションは「なし ✅」と明記して省略しない）:
+
+```markdown
+# Repo Radar — <日付 JST>
+
+## P1: 今すぐ（ブロッカー）
+| 種別 | repo | 対象 | 状態 | リンク |
+
+## P2: 今日中（自分の PR の障害）
+...
+
+## P3: Renovate 滞留 <N> 件
+（repo ごとの件数サマリ + 最古の滞留日数）
+
+## P4: バックログ（assign 済み Issue <N> 件）
+...
+
+## 推奨ネクストアクション
+1. <最もレバレッジの高い 1 手>
+```
+
+**推奨ネクストアクション**では、該当があれば他 skill へのハンドオフを具体的に提案する:
+
+- Renovate が 3 件以上 → 「`renovate-sweep --all` で一括処理できます」
+- trivial/small 級の assign Issue が 2 件以上 → 「`issue-fleet <番号列>` で並列処理できます」
+- レビュー指摘が溜まった自分の PR → 「`review-resolve-loop` で対応できます」
+- レビュー依頼された他人の PR → 「`multi-review` / `cc-code-review` でレビューできます」
+
+## Phase 4: 投稿（`--post` 時のみ）
+
+`daily-planning` skill の手順で今月分の Daily planning Discussion を特定し、レポートをコメントとして投稿する。**投稿本文を提示して user 承認を得てから実行する**。
+
+## 運用メモ
+
+- 毎朝の定例にする場合は、このレポート生成だけなら read-only なので、Claude Code のスケジュール実行（cron / routine）に載せられる。その設定は本 skill の範囲外とし、user の明示依頼で行う。
+- 検索 limit（30/50）を超えて溢れた場合は、溢れた旨をレポート末尾に必ず明記する（silent truncation 禁止）。


### PR DESCRIPTION
## Summary

Add three interlocking curated skills that turn recurring maintenance chores into single-approval batch operations, built around one goal: maximizing parallel development throughput. A live sweep during design found 50 open Renovate PRs across owners and 30+ pending review requests / assigned issues — all currently handled one at a time by hand.

- **`repo-radar`** — cross-repo triage: sweeps review requests, own-PR CI failures / unresolved review threads, stale Renovate PRs, and assigned issues into one prioritized report. Read-only by default; `--post` (with explicit approval) comments on the daily-planning Discussion.
- **`renovate-sweep`** — batch Renovate triage: mechanical classification by semver kind / CI / mergeability, parallel deep-dives via the existing `renovate-analyzer` subagent for risky updates, then a single-approval batch merge.
- **`issue-fleet`** — parallel issue dispatch: implements multiple trivial/small issues concurrently with one worktree / branch / draft PR per issue, subagents doing the work, and conflicting issues serialized into the same lane.

The three hand off to each other (radar detects → sweep/fleet execute) and delegate to existing skills (`renovate-analyzer`, `pr-workflow`, `wtp`, `review-resolve-loop`, `daily-planning`) instead of duplicating them.

## Changes

- `home/dot_agents/skills/repo-radar/SKILL.md` — new curated skill
- `home/dot_agents/skills/renovate-sweep/SKILL.md` — new curated skill
- `home/dot_agents/skills/issue-fleet/SKILL.md` — new curated skill

## Safety design (shared)

- No write operation before an explicit user-approval gate; **never auto-merges** (consistent with pr-workflow's merge-is-user-only decision).
- `issue-fleet` forbids pushing to the default branch and stops at draft PRs; failed lanes keep their worktrees for human handover.
- `renovate-sweep` never puts security-advisory / conflicting / red-CI PRs in the merge bucket, and handles GitHub's lazily computed `mergeable=UNKNOWN` by re-fetching before classification (found during live QA).
- `repo-radar` is read-only by default; search-limit overflow must be reported (no silent truncation).

## Verification

- `bats tests/skill_provenance.bats` — 9/9 pass (all three classified as curated).
- Deployed via `chezmoi apply` and confirmed discoverable through the `~/.claude/skills` → `~/.agents/skills` symlink.
- Every `gh` query in the skills executed live against real data: `gh search prs/issues` field sets, `gh pr list --json statusCheckRollup`, and the review-thread GraphQL query all verified working.
- Documentation-only change (`SKILL.md` files); no shell/CI surface touched.
