### PR TITLE
chore(zsh): disable GateGuard edit-write gate to remove first-touch friction and unblock CLV2 instincts

### DIFF
--- a/home/dot_config/zsh/claude.zsh
+++ b/home/dot_config/zsh/claude.zsh
@@ -19,11 +19,18 @@ _claude_with_home() {
   # EXA_API_KEY/FIRECRAWL_API_KEY are exported here (scoped to "$@") so Claude Code can expand
   # the "${EXA_API_KEY}" / "${FIRECRAWL_API_KEY}" placeholders in its MCP env at spawn. The :-
   # default keeps this safe when the secrets file is absent.
+  # ECC_DISABLED_HOOKS defaults to skipping the edit-write gateguard-fact-force gate: it removes
+  # the deny-then-retry friction on first-touch file Edits and unblocks the CLV2 observer's
+  # instinct writes (each observer run is a fresh `claude --print` session, so the gate's
+  # "checked" cache resets and every instinct Write hits an initial deny that Haiku transcribes
+  # instead of retrying); destructive-Bash and routine-Bash gates stay active. The :- default
+  # lets claude-config's own ECC_DISABLED_HOOKS override still win.
   CLAUDE_CONFIG_DIR="$home_dir" \
     ECC_AGENT_DATA_HOME="$home_dir" \
     CLV2_HOMUNCULUS_DIR="$home_dir/ecc-homunculus" \
     ECC_MCP_HEALTH_STATE_PATH="$home_dir/mcp-health-cache.json" \
     GATEGUARD_STATE_DIR="$home_dir/.gateguard" \
+    ECC_DISABLED_HOOKS="${ECC_DISABLED_HOOKS:-pre:edit-write:gateguard-fact-force}" \
     EXA_API_KEY="${EXA_API_KEY:-}" \
     FIRECRAWL_API_KEY="${FIRECRAWL_API_KEY:-}" \
     "$@"


### PR DESCRIPTION
## Summary
- Add `ECC_DISABLED_HOOKS="${ECC_DISABLED_HOOKS:-pre:edit-write:gateguard-fact-force}"` to the shared env bundle in `_claude_with_home()` so the edit-write GateGuard fact-force gate is skipped by default for both `cld` and `cld-r06`.
- This removes the deny-then-retry friction on first-touch file Edits, and is expected to unblock the CLV2 observer's instinct writes: each observer run is a fresh `claude --print` session, so the gate's "checked" cache resets every time and every instinct Write hits an initial deny that Haiku transcribes instead of retrying. The destructive-Bash and routine-Bash gates remain active. The `:-` default preserves `claude-config`'s own `ECC_DISABLED_HOOKS` override.

Closes #243

The CLV2 instinct 0-count problem is expected to resolve as an observed side effect of this change (evidence: the r06 account already accumulates instincts normally — 195 instincts — under the same permission model).

## Test plan
- [x] `zsh -n home/dot_config/zsh/claude.zsh` — no syntax error
- [x] `make lint` — shellcheck / shfmt / zsh syntax check all pass
- [x] Manual runtime check: `_claude_with_home` exports `ECC_DISABLED_HOOKS=pre:edit-write:gateguard-fact-force` by default, and honors an existing `ECC_DISABLED_HOOKS` (e.g. from `claude-config`) when already set