### PR TITLE
fix(claude): inline fable orchestrator prompt for happy variants (hcldf/hcldf-r06)

### DIFF
--- a/home/dot_config/zsh/claude.zsh
+++ b/home/dot_config/zsh/claude.zsh
@@ -73,6 +73,12 @@ alias claude-config='ECC_DISABLED_HOOKS_EXTRA=pre:config-protection,pre:edit-wri
 # The prompt is passed via --append-system-prompt-file (path) instead of --append-system-prompt
 # (content) so the prompt body stays out of argv — the CLI reads the file at process start,
 # avoiding argv-length and control-char concerns as the prompt grows.
+# Exception (hcldf/hcldf-r06): the happy (slopus/happy) wrapper always injects its own
+# --append-system-prompt, and Claude Code >= 2.1.185 refuses to mix --append-system-prompt
+# with --append-system-prompt-file ("Cannot use both ... Please use only one."), which aborted
+# the happy variants at launch. So when routing through happy ($1 == happy) the prompt is
+# inlined via --append-system-prompt instead — repeating the same flag is allowed, so ours
+# coexists with happy's. The prompt is small (~6 KB) and static, so the argv cost is moot.
 _claude_fable() {
   local home_dir="$1"
   shift
@@ -81,7 +87,13 @@ _claude_fable() {
   (($#)) || set -- claude
   local prompt_file="$HOME/.claude/fable-orchestrator-prompt.md"
   local -a fable_flags=(--model claude-fable-5)
-  [[ -r "$prompt_file" ]] && fable_flags+=(--append-system-prompt-file "$prompt_file")
+  if [[ -r "$prompt_file" ]]; then
+    if [[ "$1" == happy ]]; then
+      fable_flags+=(--append-system-prompt "$(<"$prompt_file")")
+    else
+      fable_flags+=(--append-system-prompt-file "$prompt_file")
+    fi
+  fi
   _claude_with_home "$home_dir" "$@" "${fable_flags[@]}"
 }
 alias cldf='_claude_fable "$HOME/.claude" claude'

--- a/home/dot_config/zsh/claude.zsh
+++ b/home/dot_config/zsh/claude.zsh
@@ -77,8 +77,11 @@ alias claude-config='ECC_DISABLED_HOOKS_EXTRA=pre:config-protection,pre:edit-wri
 # --append-system-prompt, and Claude Code >= 2.1.185 refuses to mix --append-system-prompt
 # with --append-system-prompt-file ("Cannot use both ... Please use only one."), which aborted
 # the happy variants at launch. So when routing through happy ($1 == happy) the prompt is
-# inlined via --append-system-prompt instead — repeating the same flag is allowed, so ours
-# coexists with happy's. The prompt is small (~6 KB) and static, so the argv cost is moot.
+# inlined via --append-system-prompt instead — repeating the same flag is allowed (observed on
+# claude 2.1.205), so ours coexists with happy's. The prompt is small (~6 KB) and static, so the
+# argv cost is moot; note that inlining exposes the body in argv (readable by same-user
+# processes), so keep fable-orchestrator-prompt.md secret-free — revert to the file form if
+# happy ever honors --append-system-prompt-file.
 _claude_fable() {
   local home_dir="$1"
   shift

--- a/tests/zsh_aliases.bats
+++ b/tests/zsh_aliases.bats
@@ -95,6 +95,27 @@ load helpers/setup
   [ "$output" = "happy|claude --resume --model claude-fable-5" ]
 }
 
+@test "claude.zsh: _claude_fable inlines the orchestrator prompt via --append-system-prompt through happy" {
+  # Regression guard for hcldf/hcldf-r06: the happy (slopus/happy) wrapper always injects its
+  # own --append-system-prompt, and Claude Code >= 2.1.185 rejects mixing --append-system-prompt
+  # with --append-system-prompt-file ("Cannot use both ... Please use only one."). So when
+  # routing through happy, the orchestrator prompt must be inlined via --append-system-prompt
+  # (repeating the same flag is allowed) instead of --append-system-prompt-file, which would
+  # otherwise collide with happy's own flag and abort the launch. Direct (non-happy) launches
+  # keep --append-system-prompt-file (covered by the readable-prompt-file test above).
+  mkdir -p "$BATS_TEST_TMPDIR/.claude"
+  printf 'ORCHESTRATOR-BODY\n' >"$BATS_TEST_TMPDIR/.claude/fable-orchestrator-prompt.md"
+  run zsh -fc "
+    export HOME='$BATS_TEST_TMPDIR'
+    source '${HOME_DIR}/dot_config/zsh/claude.zsh'
+    happy() { print -r -- \"happy|\$*\"; }
+    _claude_fable \"\$HOME/.claude\" happy claude
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "happy|claude --model claude-fable-5 --append-system-prompt ORCHESTRATOR-BODY" ]
+  [[ "$output" != *"--append-system-prompt-file"* ]]
+}
+
 @test "claude.zsh: _claude_fable defaults to claude when no command is given" {
   # Symmetry with _claude_with_home's own default-command fallback: bare invocation
   # (e.g. `_claude_fable "$HOME/.claude"`) must launch `claude` rather than exec'ing

--- a/tests/zsh_aliases.bats
+++ b/tests/zsh_aliases.bats
@@ -103,17 +103,27 @@ load helpers/setup
   # (repeating the same flag is allowed) instead of --append-system-prompt-file, which would
   # otherwise collide with happy's own flag and abort the launch. Direct (non-happy) launches
   # keep --append-system-prompt-file (covered by the readable-prompt-file test above).
+  #
+  # The fixture is intentionally multi-line with internal whitespace: the core guarantee is that
+  # the whole prompt body reaches happy as a SINGLE argv element (not split on whitespace or
+  # newlines). The happy mock asserts the arg count and the exact prompt arg. zsh's $(<file)
+  # strips the trailing newline, so the expected value ($'line one\nline two with spaces') has
+  # none. Asserting $4 == --append-system-prompt also rejects a stray --append-system-prompt-file.
   mkdir -p "$BATS_TEST_TMPDIR/.claude"
-  printf 'ORCHESTRATOR-BODY\n' >"$BATS_TEST_TMPDIR/.claude/fable-orchestrator-prompt.md"
+  printf 'line one\nline two with spaces\n' >"$BATS_TEST_TMPDIR/.claude/fable-orchestrator-prompt.md"
   run zsh -fc "
     export HOME='$BATS_TEST_TMPDIR'
     source '${HOME_DIR}/dot_config/zsh/claude.zsh'
-    happy() { print -r -- \"happy|\$*\"; }
+    happy() {
+      [[ \$# -eq 5 ]] || { print -r -- \"argc=\$#\"; return 1; }
+      [[ \$4 == --append-system-prompt ]] || { print -r -- \"flag=\$4\"; return 1; }
+      [[ \$5 == \$'line one\nline two with spaces' ]] || { print -r -- \"body=[\$5]\"; return 1; }
+      print -r -- ok
+    }
     _claude_fable \"\$HOME/.claude\" happy claude
   "
   [ "$status" -eq 0 ]
-  [ "$output" = "happy|claude --model claude-fable-5 --append-system-prompt ORCHESTRATOR-BODY" ]
-  [[ "$output" != *"--append-system-prompt-file"* ]]
+  [ "$output" = "ok" ]
 }
 
 @test "claude.zsh: _claude_fable defaults to claude when no command is given" {


### PR DESCRIPTION
## Summary

`hcldf` / `hcldf-r06` (the Fable 5 orchestrator variants routed through the `happy` wrapper) abort at launch on Claude Code v2.1.185+ with:

```
Error: Cannot use both --append-system-prompt and --append-system-prompt-file. Please use only one.
```

**Root cause:** the `happy` (slopus/happy) wrapper always injects its own `--append-system-prompt` before appending the caller's args ([`happy` dist source](https://github.com/slopus/happy): `args.push("--append-system-prompt", systemPrompt)`). `_claude_fable` additionally passed the orchestrator prompt via `--append-system-prompt-file`. Claude Code >= 2.1.185 newly rejects mixing the two flag forms, so every happy-routed Fable launch failed. The direct `cldf` / `cldf-r06` variants were unaffected (no happy = no injected `--append-system-prompt`), and the non-Fable `hcld` / `hcld-r06` variants were unaffected too (they never add the prompt-file flag).

## Fix

In `_claude_fable`, when routing through `happy` (`$1 == happy`), inline the orchestrator prompt via `--append-system-prompt` (content) instead of `--append-system-prompt-file`. Repeating the same flag is allowed, so ours coexists with happy's injected one. The direct variants keep `--append-system-prompt-file` to stay out of argv. The prompt is small (~6 KB) and static, so the argv cost of inlining is negligible.

## Verification

Confirmed empirically against `claude` 2.1.205:

- `--append-system-prompt` + `--append-system-prompt-file` → rejected at parse time (reproduces the reported error).
- `--append-system-prompt` specified twice → accepted, both prompts applied.

Test and lint:

- Added a regression test in `tests/zsh_aliases.bats` for the `happy` + readable-prompt-file path, asserting `--append-system-prompt` (not `--append-system-prompt-file`) is used.
- `make lint` and `make test-bats` (156 tests) all pass.

## Deploy note

Run `chezmoi apply` after merge to restore `hcldf` / `hcldf-r06`.
