### PR TITLE
feat(claude): manage Claude Code plugins declaratively from settings.json

### DIFF
--- a/docs/agents/claude-code.ja.md
+++ b/docs/agents/claude-code.ja.md
@@ -70,11 +70,31 @@
 
 `statusLine` フィールドは `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/statusline.sh` を指し、同じ settings.json を両アカウントで共用できます。
 
-Codex プラグインは `enabledPlugins` で有効化されています：
+2つのプラグインを宣言しています：
 
-```json
-"enabledPlugins": { "codex@openai-codex": true }
-```
+| プラグイン | 提供内容 |
+|---|---|
+| `codex@openai-codex` | Claude Code 内から Codex CLI（OpenAI）へ相談する機能 |
+| `claude-code-setup@claude-plugins-official` | Anthropic 公式の read-only コードベース分析ツール。hooks・skills・MCP サーバー・サブエージェントを推奨する |
+
+`enabledPlugins` がプラグインを、`extraKnownMarketplaces` がその入手元となる非公式 marketplace を宣言します
+（`openai-codex` → `openai/codex-plugin-cc`）。ただしどちらのキーも、それ自体はインストールを行いません。
+CLI は `enabledPlugins` を「*すでにインストール済みの*プラグイン」の有効/無効スイッチとして扱い、
+settings.json に宣言があるだけでは marketplace を登録しません
+（[anthropics/claude-code#23737](https://github.com/anthropics/claude-code/issues/23737)（duplicate でクローズ）、
+[#45323](https://github.com/anthropics/claude-code/issues/45323)（not planned でクローズ）を参照）。
+各アカウントのプラグイン実体は `$CLAUDE_CONFIG_DIR/plugins/` にあり、chezmoiignore 対象なので新しいマシンでは空です。
+
+このギャップを埋めるのが `run_onchange_after_17-setup-claude-plugins.sh.tmpl` です。両方のリストを
+settings.json からレンダリングして導出する（＝宣言の単一ソースを保つ）うえで、不足している marketplace の
+登録とプラグインのインストールをアカウントごとに実行します。
+
+**settings.json は chezmoi のものであり、CLI のものではありません。** `claude plugin install`・
+`claude plugin marketplace add`・対話的な `/plugin` マネージャは、いずれもこのファイルを自前のシリアライザで
+書き戻します。その結果トップレベルのキーが並べ替えられ、各 hook の `id`・`description` 注釈が失われます。
+機能は壊れません（hook は JSON のキーではなく `command` 内の引数で識別されるため）が、書き戻された
+ファイルを `chezmoi add` してはいけません。注釈付きの版に戻すには `chezmoi apply` を実行します。
+スクリプト 17 も同じことを自前で行い、終了時にスナップショットを書き戻します。
 
 ---
 

--- a/docs/agents/claude-code.ja.md
+++ b/docs/agents/claude-code.ja.md
@@ -78,16 +78,23 @@
 | `claude-code-setup@claude-plugins-official` | Anthropic 公式の read-only コードベース分析ツール。hooks・skills・MCP サーバー・サブエージェントを推奨する |
 
 `enabledPlugins` がプラグインを、`extraKnownMarketplaces` がその入手元となる非公式 marketplace を宣言します
-（`openai-codex` → `openai/codex-plugin-cc`）。ただしどちらのキーも、それ自体はインストールを行いません。
-CLI は `enabledPlugins` を「*すでにインストール済みの*プラグイン」の有効/無効スイッチとして扱い、
-settings.json に宣言があるだけでは marketplace を登録しません
+（`openai-codex` → `openai/codex-plugin-cc`、タグ `v1.0.6` に pin）。ただしどちらのキーも、それ自体は
+インストールを行いません。CLI は `enabledPlugins` を「*すでにインストール済みの*プラグイン」の有効/無効
+スイッチとして扱い、settings.json に宣言があるだけでは marketplace を登録しません
 （[anthropics/claude-code#23737](https://github.com/anthropics/claude-code/issues/23737)（duplicate でクローズ）、
 [#45323](https://github.com/anthropics/claude-code/issues/45323)（not planned でクローズ）を参照）。
 各アカウントのプラグイン実体は `$CLAUDE_CONFIG_DIR/plugins/` にあり、chezmoiignore 対象なので新しいマシンでは空です。
 
-このギャップを埋めるのが `run_onchange_after_17-setup-claude-plugins.sh.tmpl` です。両方のリストを
-settings.json からレンダリングして導出する（＝宣言の単一ソースを保つ）うえで、不足している marketplace の
+このギャップを埋めるのが `run_onchange_after_17-setup-claude-plugins.sh.tmpl` です。settings.json から
+レンダリングした宣言を JSON として埋め込み（＝宣言の単一ソースを保つ）、不足している marketplace の
 登録とプラグインのインストールをアカウントごとに実行します。
+
+marketplace は `chezmoi apply` が無人でインストールする実行コードなので、可変な既定ブランチを追ってはいけません。
+この pin には落とし穴が 2 つあります。宣言した `ref` は **CLI 引数に含めない限り無視される**ため、スクリプトは
+`<repo>#<ref>` を渡します。また ref は `git clone --branch` に届くので、**コミット SHA は使えません** —
+ブランチかタグのみです。したがって `openai-codex` はタグで pin しており、このリポジトリが chezmoi external に
+用いているコミット pin より弱い保証になります（タグは上流で移動しうる）。現状タグの更新は手動編集で、
+Renovate の `github-tags` datasource への接続は別途追跡します。
 
 **settings.json は chezmoi のものであり、CLI のものではありません。** `claude plugin install`・
 `claude plugin marketplace add`・対話的な `/plugin` マネージャは、いずれもこのファイルを自前のシリアライザで

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -70,11 +70,32 @@ This document covers the Claude Code harness configuration deployed by this dotf
 
 The `statusLine` field points to `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/statusline.sh` so the same settings file works for both accounts.
 
-The Codex plugin is enabled via `enabledPlugins`:
+Two plugins are declared:
 
-```json
-"enabledPlugins": { "codex@openai-codex": true }
-```
+| Plugin | Provides |
+|---|---|
+| `codex@openai-codex` | Codex CLI (OpenAI) consultation from within Claude Code |
+| `claude-code-setup@claude-plugins-official` | Anthropic-official read-only codebase analyzer that recommends hooks, skills, MCP servers, and subagents |
+
+`enabledPlugins` names the plugins, and `extraKnownMarketplaces` names the non-official marketplaces
+they come from (`openai-codex` → `openai/codex-plugin-cc`). Neither key installs anything by itself:
+the CLI treats `enabledPlugins` as a switch for plugins that are *already* installed, and it does not
+register a marketplace merely because settings.json declares one — see
+[anthropics/claude-code#23737](https://github.com/anthropics/claude-code/issues/23737) (closed as
+duplicate) and [#45323](https://github.com/anthropics/claude-code/issues/45323) (closed as not
+planned). Each account's plugin runtime lives in `$CLAUDE_CONFIG_DIR/plugins/`, which is
+chezmoiignored and therefore empty on a new machine.
+
+`run_onchange_after_17-setup-claude-plugins.sh.tmpl` closes that gap. It renders both lists out of
+settings.json — so the declaration keeps a single source of truth — then registers the marketplaces
+and installs the plugins that are missing, once per account.
+
+**settings.json belongs to chezmoi, not to the CLI.** `claude plugin install`, `claude plugin
+marketplace add`, and the interactive `/plugin` manager each rewrite the file with their own
+serializer: top-level keys are reordered and every hook's `id` and `description` annotation is
+dropped. Nothing breaks — hooks are identified by the argument inside their `command`, not by those
+keys — but never `chezmoi add` the rewritten file. Run `chezmoi apply` to restore the annotated
+version; script 17 does the same for itself by writing back a snapshot when it exits.
 
 ---
 

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -78,17 +78,25 @@ Two plugins are declared:
 | `claude-code-setup@claude-plugins-official` | Anthropic-official read-only codebase analyzer that recommends hooks, skills, MCP servers, and subagents |
 
 `enabledPlugins` names the plugins, and `extraKnownMarketplaces` names the non-official marketplaces
-they come from (`openai-codex` → `openai/codex-plugin-cc`). Neither key installs anything by itself:
-the CLI treats `enabledPlugins` as a switch for plugins that are *already* installed, and it does not
-register a marketplace merely because settings.json declares one — see
-[anthropics/claude-code#23737](https://github.com/anthropics/claude-code/issues/23737) (closed as
-duplicate) and [#45323](https://github.com/anthropics/claude-code/issues/45323) (closed as not
+they come from (`openai-codex` → `openai/codex-plugin-cc`, pinned to tag `v1.0.6`). Neither key
+installs anything by itself: the CLI treats `enabledPlugins` as a switch for plugins that are
+*already* installed, and it does not register a marketplace merely because settings.json declares one
+— see [anthropics/claude-code#23737](https://github.com/anthropics/claude-code/issues/23737) (closed
+as duplicate) and [#45323](https://github.com/anthropics/claude-code/issues/45323) (closed as not
 planned). Each account's plugin runtime lives in `$CLAUDE_CONFIG_DIR/plugins/`, which is
 chezmoiignored and therefore empty on a new machine.
 
-`run_onchange_after_17-setup-claude-plugins.sh.tmpl` closes that gap. It renders both lists out of
-settings.json — so the declaration keeps a single source of truth — then registers the marketplaces
-and installs the plugins that are missing, once per account.
+`run_onchange_after_17-setup-claude-plugins.sh.tmpl` closes that gap. It embeds the declaration as
+JSON rendered out of settings.json — so the declaration keeps a single source of truth — then
+registers the marketplaces and installs the plugins that are missing, once per account.
+
+A marketplace is executable code that `chezmoi apply` installs unattended, so it must not track a
+moving default branch. The pin has two sharp edges. A declared `ref` is **ignored** unless it is also
+part of the CLI argument, so the script passes `<repo>#<ref>`; and the ref reaches `git clone
+--branch`, so a **commit SHA cannot be used** — only a branch or a tag. `openai-codex` is therefore
+pinned to a tag, which is weaker than the commit pins this repo uses for chezmoi externals: a tag can
+be moved upstream. Bumping it is a manual edit today; wiring Renovate's `github-tags` datasource to
+it is tracked separately.
 
 **settings.json belongs to chezmoi, not to the CLI.** `claude plugin install`, `claude plugin
 marketplace add`, and the interactive `/plugin` manager each rewrite the file with their own

--- a/docs/architecture/lifecycle-scripts.ja.md
+++ b/docs/architecture/lifecycle-scripts.ja.md
@@ -38,7 +38,8 @@ flowchart TD
         E --> F["13 setup-mcp\nrun_onchange\n(mise exec -- claude 経由で\n4つの user-scope MCP サーバーを登録)"]
         F --> G["14 enable-clv2-observer\nrun_onchange\n(per-account homunculus config.json に\nobserver.enabled=true を書き込む)"]
         G --> H["16 migrate-claude-binary\nrun_once\n(~/.local/bin/claude を\nmise installs/claude/latest へ symlink)"]
-        H --> I["18 setup-agent-browser\nrun_onchange\n(mise exec 経由で agent-browser install)"]
+        H --> H2["17 setup-claude-plugins\nrun_onchange\n(dot_claude/settings.json が宣言する\nmarketplace 登録 + plugin インストール)"]
+        H2 --> I["18 setup-agent-browser\nrun_onchange\n(mise exec 経由で agent-browser install)"]
         I --> J["20 macos-defaults\nrun_onchange · macOS のみ\n(defaults write + killall Dock/Finder)"]
         J --> J2["30 register-launchd-agents\nrun_onchange · macOS のみ\n(repo 管理 LaunchAgent の launchctl bootstrap\nCI ではスキップ)"]
         J2 --> K["40 setup-sheldon\nrun_onchange\n(sheldon lock)"]
@@ -75,12 +76,18 @@ flowchart TD
 |-----------|----------------------|
 | `10-brew-bundle` | `dot_Brewfile` |
 | `12-setup-mise` | `dot_config/mise/config.toml` |
+| `17-setup-claude-plugins` | `dot_claude/settings.json` |
 | `18-setup-agent-browser` | `dot_config/mise/config.toml` |
 | `30-register-launchd-agents` | `Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl` |
 | `40-setup-sheldon` | `dot_config/sheldon/plugins.toml` |
 | `20-macos-defaults` | 自分自身のソースファイル（任意の編集で再トリガー） |
 
 `20-macos-defaults` は `joinPath` による自己ハッシュを使用しており、スクリプト自体を編集するだけで全 `defaults write` が再適用されます。
+
+`17-setup-claude-plugins` はハッシュを使わずに同じ結果を得ています。`include | fromJson` で
+`dot_claude/settings.json` から plugin と marketplace のリストを直接レンダリングするため、宣言そのものが
+スクリプト本文に埋め込まれます。これにより単一ソースを保ちつつ、宣言が変わったときにだけ再実行されます
+（settings.json の無関係な箇所を編集しても、レンダリング後の本文は変わりません）。
 
 ---
 
@@ -97,6 +104,7 @@ flowchart TD
 | `13-setup-mcp` | 両対応 | OS ガードなし。両アカウントを処理 |
 | `14-enable-clv2-observer` | 両対応 | OS ガードなし |
 | `16-migrate-claude-binary` | 両対応 | OS ガードなし。バイナリ存在をランタイムで確認 |
+| `17-setup-claude-plugins` | 両対応 | OS ガードなし。両アカウントを処理 |
 | `18-setup-agent-browser` | 両対応 | `{{ if linux }}` で `--with-deps` を追加 |
 | `20-macos-defaults` | **macOS のみ** | 本文全体が `{{ if darwin }}` 内。Linux ではほぼ空にレンダリング |
 | `30-register-launchd-agents` | **macOS のみ** | 本文全体が `{{ if darwin }}` 内。Linux ではほぼ空にレンダリング |

--- a/docs/architecture/lifecycle-scripts.ja.md
+++ b/docs/architecture/lifecycle-scripts.ja.md
@@ -85,9 +85,11 @@ flowchart TD
 `20-macos-defaults` は `joinPath` による自己ハッシュを使用しており、スクリプト自体を編集するだけで全 `defaults write` が再適用されます。
 
 `17-setup-claude-plugins` はハッシュを使わずに同じ結果を得ています。`include | fromJson` で
-`dot_claude/settings.json` から plugin と marketplace のリストを直接レンダリングするため、宣言そのものが
-スクリプト本文に埋め込まれます。これにより単一ソースを保ちつつ、宣言が変わったときにだけ再実行されます
-（settings.json の無関係な箇所を編集しても、レンダリング後の本文は変わりません）。
+`dot_claude/settings.json` を読み、`enabledPlugins` と `extraKnownMarketplaces` だけを JSON として
+quoted heredoc の中に埋め込みます。これにより単一ソースを保ちつつ、宣言が変わったときにだけ再実行されます
+（settings.json の無関係な箇所を編集しても、レンダリング後の本文は変わりません）。quoted heredoc であることが
+重要で、値を bash の配列リテラルとしてレンダリングすると、クォートや `$(...)` を含む値がレンダリング時に
+スクリプト本文として評価されてしまいます。
 
 ---
 

--- a/docs/architecture/lifecycle-scripts.md
+++ b/docs/architecture/lifecycle-scripts.md
@@ -84,11 +84,13 @@ When `dot_Brewfile` changes, the rendered comment line changes, the script body 
 
 `20-macos-defaults` uses a `joinPath` self-hash — editing the script itself is enough to re-apply all macOS `defaults write` calls.
 
-`17-setup-claude-plugins` reaches the same result without a hash: it renders the plugin and
-marketplace lists straight out of `dot_claude/settings.json` with `include | fromJson`, so the
-declaration is embedded in the script body. That keeps one source of truth *and* re-triggers the
-script precisely when the declaration changes — an unrelated edit elsewhere in settings.json leaves
-the rendered body untouched.
+`17-setup-claude-plugins` reaches the same result without a hash: it reads
+`dot_claude/settings.json` with `include | fromJson` and embeds just the `enabledPlugins` and
+`extraKnownMarketplaces` objects into the script body as JSON, inside a quoted heredoc. That keeps
+one source of truth *and* re-triggers the script precisely when the declaration changes — an
+unrelated edit elsewhere in settings.json leaves the rendered body untouched. The quoted heredoc
+matters: rendering the values into bash array literals would let a value containing a quote or
+`$(...)` execute as script source at render time.
 
 ---
 

--- a/docs/architecture/lifecycle-scripts.md
+++ b/docs/architecture/lifecycle-scripts.md
@@ -38,7 +38,8 @@ flowchart TD
         E --> F["13 setup-mcp\nrun_onchange\n(registers 4 user-scope MCP servers\nvia mise exec -- claude)"]
         F --> G["14 enable-clv2-observer\nrun_onchange\n(sets observer.enabled=true\nin per-account homunculus config.json)"]
         G --> H["16 migrate-claude-binary\nrun_once\n(symlink ~/.local/bin/claude\n-> mise installs/claude/latest)"]
-        H --> I["18 setup-agent-browser\nrun_onchange\n(agent-browser install via mise exec)"]
+        H --> H2["17 setup-claude-plugins\nrun_onchange\n(registers marketplaces + installs plugins\ndeclared in dot_claude/settings.json)"]
+        H2 --> I["18 setup-agent-browser\nrun_onchange\n(agent-browser install via mise exec)"]
         I --> J["20 macos-defaults\nrun_onchange · macOS only\n(defaults write + killall Dock/Finder)"]
         J --> J2["30 register-launchd-agents\nrun_onchange · macOS only\n(launchctl bootstrap of repo-managed\nLaunchAgents; skipped in CI)"]
         J2 --> K["40 setup-sheldon\nrun_onchange\n(sheldon lock)"]
@@ -75,12 +76,19 @@ When `dot_Brewfile` changes, the rendered comment line changes, the script body 
 |--------|-----------------|
 | `10-brew-bundle` | `dot_Brewfile` |
 | `12-setup-mise` | `dot_config/mise/config.toml` |
+| `17-setup-claude-plugins` | `dot_claude/settings.json` |
 | `18-setup-agent-browser` | `dot_config/mise/config.toml` |
 | `30-register-launchd-agents` | `Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl` |
 | `40-setup-sheldon` | `dot_config/sheldon/plugins.toml` |
 | `20-macos-defaults` | its own source file (any edit re-triggers) |
 
 `20-macos-defaults` uses a `joinPath` self-hash — editing the script itself is enough to re-apply all macOS `defaults write` calls.
+
+`17-setup-claude-plugins` reaches the same result without a hash: it renders the plugin and
+marketplace lists straight out of `dot_claude/settings.json` with `include | fromJson`, so the
+declaration is embedded in the script body. That keeps one source of truth *and* re-triggers the
+script precisely when the declaration changes — an unrelated edit elsewhere in settings.json leaves
+the rendered body untouched.
 
 ---
 
@@ -97,6 +105,7 @@ Scripts use chezmoi template guards to select the appropriate behavior per OS.
 | `13-setup-mcp` | both | No OS guard; both accounts processed |
 | `14-enable-clv2-observer` | both | No OS guard |
 | `16-migrate-claude-binary` | both | No OS guard; guards on binary existance at runtime |
+| `17-setup-claude-plugins` | both | No OS guard; both accounts processed |
 | `18-setup-agent-browser` | dual | `{{ if linux }}` adds `--with-deps` |
 | `20-macos-defaults` | **macOS only** | Entire body inside `{{ if darwin }}`; renders near-empty on Linux |
 | `30-register-launchd-agents` | **macOS only** | Entire body inside `{{ if darwin }}`; renders near-empty on Linux |

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -473,8 +473,16 @@
   },
   "model": "claude-opus-4-8[1m]",
   "enabledPlugins": {
-    "codex@openai-codex": true
+    "codex@openai-codex": true,
+    "claude-code-setup@claude-plugins-official": true
   },
-  "extraKnownMarketplaces": {},
+  "extraKnownMarketplaces": {
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      }
+    }
+  },
   "agentPushNotifEnabled": true
 }

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -480,7 +480,8 @@
     "openai-codex": {
       "source": {
         "source": "github",
-        "repo": "openai/codex-plugin-cc"
+        "repo": "openai/codex-plugin-cc",
+        "ref": "v1.0.6"
       }
     }
   },

--- a/home/run_onchange_after_17-setup-claude-plugins.sh.tmpl
+++ b/home/run_onchange_after_17-setup-claude-plugins.sh.tmpl
@@ -1,0 +1,148 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reconcile each Claude Code account's plugin runtime with the declaration in dot_claude/settings.json.
+#
+# Plugin state is split in two places:
+#   - Declaration: settings.json `extraKnownMarketplaces` + `enabledPlugins` (chezmoi-owned, versioned).
+#   - Runtime: "$CLAUDE_CONFIG_DIR/plugins/" (marketplace clones, install cache, installed_plugins.json).
+#     Volatile and chezmoiignored, so it starts empty on a fresh machine.
+#
+# The CLI does not bridge the two on its own: `enabledPlugins` only toggles an already-installed
+# plugin, and `extraKnownMarketplaces` does not register the marketplace. Both gaps are upstream
+# wontfix (anthropics/claude-code#23737 closed as duplicate, #45323 closed as not planned: "Plugins
+# configured in org managed settings do not auto-install in the CLI"). Without this script, a new
+# machine gets settings.json's declaration but no plugins. Verified against claude 2.1.185: the
+# `autoInstallEnabledPlugins` and `forcedPlugins` keys those issues ask for do not exist in the binary.
+#
+# The plugin and marketplace lists below are rendered from settings.json, so the declaration has a
+# single source of truth and the run_onchange key changes only when the declaration itself changes.
+#
+# `claude plugin marketplace add` and `claude plugin install` rewrite "$CLAUDE_CONFIG_DIR/settings.json"
+# with their own serializer, which reorders the top-level keys and drops the per-hook `id`/`description`
+# annotations chezmoi ships. We snapshot the file up front and write it back on exit, so the CLI's
+# normalization never outlives this script.
+#
+# claude is mise-managed (dot_config/mise/config.toml) and installed by run_onchange_after_12, so it is
+# invoked through `mise exec` rather than PATH, for the same reason as run_onchange_after_13-setup-mcp.
+
+{{ $settings := include "dot_claude/settings.json" | fromJson }}
+if ! command -v mise &>/dev/null; then
+  echo "WARNING: mise is not installed; skipping Claude Code plugin setup."
+  exit 0
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "WARNING: jq is not installed; skipping Claude Code plugin setup."
+  exit 0
+fi
+
+# Rendered from settings.json .enabledPlugins — only the entries switched on. Each id is
+# "<plugin>@<marketplace>", which is also how the CLI addresses them.
+plugins=(
+{{- range $id, $enabled := $settings.enabledPlugins }}
+{{- if $enabled }}
+  "{{ $id }}"
+{{- end }}
+{{- end }}
+)
+
+# Rendered from settings.json .extraKnownMarketplaces as "<name>=<source>", where <source> is the
+# argument `claude plugin marketplace add` accepts (an owner/repo shorthand, or a git URL).
+declared_marketplaces=(
+{{- range $name, $marketplace := $settings.extraKnownMarketplaces }}
+  "{{ $name }}={{ if eq $marketplace.source.source "github" }}{{ $marketplace.source.repo }}{{ else }}{{ $marketplace.source.url }}{{ end }}"
+{{- end }}
+)
+
+# claude-plugins-official ships with Claude Code, so it is not an "extra" marketplace and must not be
+# declared in settings.json. It still has to be registered before any of its plugins can be installed.
+OFFICIAL_MARKETPLACE="claude-plugins-official"
+OFFICIAL_MARKETPLACE_SOURCE="anthropics/claude-plugins-official"
+
+# Each account is isolated by CLAUDE_CONFIG_DIR (see dot_config/zsh/claude.zsh: cld -> ~/.claude,
+# cld-r06 -> ~/.claude-r06). The two share one settings.json via a symlink, but each keeps its own
+# plugins/ runtime, so every account has to be reconciled separately.
+config_dirs=("$HOME/.claude" "$HOME/.claude-r06")
+
+if [ "${#plugins[@]}" -eq 0 ]; then
+  echo "==> No plugins declared in settings.json; nothing to reconcile."
+  exit 0
+fi
+
+settings_file="$HOME/.claude/settings.json"
+settings_snapshot="$(mktemp)"
+cp "$settings_file" "$settings_snapshot"
+
+restore_settings() {
+  # Undo the CLI's rewrite. Written through the existing path so the file keeps its inode.
+  cat "$settings_snapshot" >"$settings_file"
+  rm -f "$settings_snapshot"
+  # `--scope user` targets "$CLAUDE_CONFIG_DIR/settings.json", which for the work account is the
+  # symlink deployed from dot_claude-r06/symlink_settings.json.tmpl. A CLI that rewrites the file
+  # atomically (temp file + rename) would leave a regular file in the symlink's place.
+  local work_settings="$HOME/.claude-r06/settings.json"
+  if [ -e "$work_settings" ] && [ ! -L "$work_settings" ]; then
+    ln -sfn "$settings_file" "$work_settings"
+  fi
+}
+trap restore_settings EXIT
+
+# Map a marketplace name to the source argument for `claude plugin marketplace add`.
+marketplace_source() {
+  local name="$1" entry
+  for entry in ${declared_marketplaces[@]+"${declared_marketplaces[@]}"}; do
+    if [ "${entry%%=*}" = "$name" ]; then
+      printf '%s' "${entry#*=}"
+      return 0
+    fi
+  done
+  if [ "$name" = "$OFFICIAL_MARKETPLACE" ]; then
+    printf '%s' "$OFFICIAL_MARKETPLACE_SOURCE"
+    return 0
+  fi
+  return 1
+}
+
+failed=0
+for config_dir in "${config_dirs[@]}"; do
+  echo "==> Reconciling Claude Code plugins in ${config_dir}..."
+  known_marketplaces="${config_dir}/plugins/known_marketplaces.json"
+  # `plugin list --json` prints each installed plugin's "<plugin>@<marketplace>" id. It is empty (and
+  # exits non-zero) before the plugin runtime exists, which is the expected state on a first apply.
+  installed="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin list --json 2>/dev/null | jq -r '.[].id' || true)"
+
+  for plugin in "${plugins[@]}"; do
+    marketplace="${plugin##*@}"
+
+    if [ ! -f "$known_marketplaces" ] || ! jq -e --arg m "$marketplace" 'has($m)' "$known_marketplaces" >/dev/null 2>&1; then
+      if ! source_spec="$(marketplace_source "$marketplace")"; then
+        printf 'ERROR: plugin %s needs marketplace %s, which is neither %s nor declared in settings.json extraKnownMarketplaces\n' "$plugin" "$marketplace" "$OFFICIAL_MARKETPLACE" >&2
+        failed=1
+        continue
+      fi
+      if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin marketplace add "$source_spec" 2>&1)"; then
+        printf 'ERROR: failed to add marketplace %s (%s) in %s\n%s\n' "$marketplace" "$source_spec" "$config_dir" "$out" >&2
+        failed=1
+        continue
+      fi
+    fi
+
+    if printf '%s\n' "$installed" | grep -qxF "$plugin"; then
+      continue
+    fi
+    if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin install "$plugin" --scope user 2>&1)"; then
+      printf 'ERROR: failed to install plugin %s in %s\n%s\n' "$plugin" "$config_dir" "$out" >&2
+      failed=1
+    fi
+  done
+done
+
+if [ "$failed" -ne 0 ]; then
+  # Exit non-zero so chezmoi does not record this run as successful and retries on the next apply,
+  # instead of freezing a partially-reconciled state (same contract as run_onchange_after_13-setup-mcp).
+  echo "ERROR: one or more Claude Code plugins failed to install; chezmoi will retry on the next apply." >&2
+  exit 1
+fi
+
+echo "==> Claude Code plugins reconciled."

--- a/home/run_onchange_after_17-setup-claude-plugins.sh.tmpl
+++ b/home/run_onchange_after_17-setup-claude-plugins.sh.tmpl
@@ -9,14 +9,18 @@ set -euo pipefail
 #     Volatile and chezmoiignored, so it starts empty on a fresh machine.
 #
 # The CLI does not bridge the two on its own: `enabledPlugins` only toggles an already-installed
-# plugin, and `extraKnownMarketplaces` does not register the marketplace. Both gaps are upstream
-# wontfix (anthropics/claude-code#23737 closed as duplicate, #45323 closed as not planned: "Plugins
-# configured in org managed settings do not auto-install in the CLI"). Without this script, a new
-# machine gets settings.json's declaration but no plugins. Verified against claude 2.1.185: the
-# `autoInstallEnabledPlugins` and `forcedPlugins` keys those issues ask for do not exist in the binary.
+# plugin, and `extraKnownMarketplaces` does not register the marketplace -- nor is its `ref` honoured
+# unless the ref is passed on the command line. Both gaps are upstream wontfix
+# (anthropics/claude-code#23737 closed as duplicate, #45323 closed as not planned: "Plugins configured
+# in org managed settings do not auto-install in the CLI"). Without this script, a new machine gets
+# settings.json's declaration but no plugins. Verified against claude 2.1.205 (the mise-pinned version
+# in dot_config/mise/config.toml): the `autoInstallEnabledPlugins` and `forcedPlugins` keys those
+# issues ask for do not exist in the binary.
 #
-# The plugin and marketplace lists below are rendered from settings.json, so the declaration has a
-# single source of truth and the run_onchange key changes only when the declaration itself changes.
+# The declaration below is rendered from settings.json, so it has a single source of truth and the
+# run_onchange key changes only when the declaration itself changes. It is emitted as JSON inside a
+# quoted heredoc rather than as bash array literals: a value containing a quote or `$(...)` would
+# otherwise be evaluated as script source at render time, which no amount of runtime quoting fixes.
 #
 # `claude plugin marketplace add` and `claude plugin install` rewrite "$CLAUDE_CONFIG_DIR/settings.json"
 # with their own serializer, which reorders the top-level keys and drops the per-hook `id`/`description`
@@ -32,28 +36,27 @@ if ! command -v mise &>/dev/null; then
   exit 0
 fi
 
-if ! command -v jq &>/dev/null; then
-  echo "WARNING: jq is not installed; skipping Claude Code plugin setup."
-  exit 0
+# Prefer a PATH jq (brew installs it in run_onchange_before_10), else the mise-managed jq. Never a
+# silent `exit 0`: that would mark this run_onchange "done" and never retry once jq lands (the same
+# reasoning as run_onchange_after_14-enable-clv2-observer).
+if command -v jq &>/dev/null; then
+  jq_cmd=(jq)
+else
+  jq_cmd=(mise exec -- jq)
+fi
+if ! "${jq_cmd[@]}" --version >/dev/null 2>&1; then
+  echo "ERROR: neither a PATH jq nor a mise-managed jq is usable; cannot reconcile Claude Code plugins." >&2
+  exit 1
 fi
 
-# Rendered from settings.json .enabledPlugins — only the entries switched on. Each id is
-# "<plugin>@<marketplace>", which is also how the CLI addresses them.
-plugins=(
-{{- range $id, $enabled := $settings.enabledPlugins }}
-{{- if $enabled }}
-  "{{ $id }}"
-{{- end }}
-{{- end }}
-)
-
-# Rendered from settings.json .extraKnownMarketplaces as "<name>=<source>", where <source> is the
-# argument `claude plugin marketplace add` accepts (an owner/repo shorthand, or a git URL).
-declared_marketplaces=(
-{{- range $name, $marketplace := $settings.extraKnownMarketplaces }}
-  "{{ $name }}={{ if eq $marketplace.source.source "github" }}{{ $marketplace.source.repo }}{{ else }}{{ $marketplace.source.url }}{{ end }}"
-{{- end }}
-)
+# Rendered from settings.json: only `enabledPlugins` and `extraKnownMarketplaces`, so an unrelated
+# edit elsewhere in settings.json leaves this script body -- and thus the run_onchange key -- untouched.
+# The heredoc is quoted, so the JSON is never expanded by the shell.
+declaration_json="$(
+  cat <<'CLAUDE_PLUGIN_DECLARATION'
+{{ dict "enabledPlugins" $settings.enabledPlugins "extraKnownMarketplaces" $settings.extraKnownMarketplaces | toJson }}
+CLAUDE_PLUGIN_DECLARATION
+)"
 
 # claude-plugins-official ships with Claude Code, so it is not an "extra" marketplace and must not be
 # declared in settings.json. It still has to be registered before any of its plugins can be installed.
@@ -64,64 +67,94 @@ OFFICIAL_MARKETPLACE_SOURCE="anthropics/claude-plugins-official"
 # cld-r06 -> ~/.claude-r06). The two share one settings.json via a symlink, but each keeps its own
 # plugins/ runtime, so every account has to be reconciled separately.
 config_dirs=("$HOME/.claude" "$HOME/.claude-r06")
+settings_file="${config_dirs[0]}/settings.json"
+
+plugins=()
+plugin_list="$(printf '%s' "$declaration_json" | "${jq_cmd[@]}" -r '.enabledPlugins // {} | to_entries[] | select(.value == true) | .key')"
+while IFS= read -r plugin; do
+  if [ -n "$plugin" ]; then
+    plugins+=("$plugin")
+  fi
+done <<<"$plugin_list"
 
 if [ "${#plugins[@]}" -eq 0 ]; then
   echo "==> No plugins declared in settings.json; nothing to reconcile."
   exit 0
 fi
 
-settings_file="$HOME/.claude/settings.json"
 settings_snapshot="$(mktemp)"
-cp "$settings_file" "$settings_snapshot"
 
 restore_settings() {
-  # Undo the CLI's rewrite. Written through the existing path so the file keeps its inode.
-  cat "$settings_snapshot" >"$settings_file"
+  # Undo the CLI's rewrite. Written through the existing path so the file keeps its inode. Guarded on
+  # a non-empty snapshot: the trap is armed before `cp` runs, and restoring an empty snapshot would
+  # truncate settings.json.
+  if [ -s "$settings_snapshot" ]; then
+    cat "$settings_snapshot" >"$settings_file"
+  fi
   rm -f "$settings_snapshot"
   # `--scope user` targets "$CLAUDE_CONFIG_DIR/settings.json", which for the work account is the
   # symlink deployed from dot_claude-r06/symlink_settings.json.tmpl. A CLI that rewrites the file
   # atomically (temp file + rename) would leave a regular file in the symlink's place.
-  local work_settings="$HOME/.claude-r06/settings.json"
+  local work_settings="${config_dirs[1]}/settings.json"
   if [ -e "$work_settings" ] && [ ! -L "$work_settings" ]; then
     ln -sfn "$settings_file" "$work_settings"
   fi
 }
 trap restore_settings EXIT
 
-# Map a marketplace name to the source argument for `claude plugin marketplace add`.
+cp "$settings_file" "$settings_snapshot"
+
+# Map a marketplace name to the source argument for `claude plugin marketplace add`. Only the `github`
+# and `git` source types are supported; the other five the settings schema allows (url, hostPattern,
+# npm, file, directory) would need a different argument shape, so they fail loudly rather than
+# rendering an empty argument.
+#
+# A declared `ref` is appended as "<source>#<ref>". Declaring it in settings.json alone is not enough:
+# the CLI ignores the declared ref and checks out the default branch unless the ref is part of the
+# argument. Only branches and tags work -- `#<commit-sha>` fails, because the ref reaches `git clone
+# --branch`.
 marketplace_source() {
-  local name="$1" entry
-  for entry in ${declared_marketplaces[@]+"${declared_marketplaces[@]}"}; do
-    if [ "${entry%%=*}" = "$name" ]; then
-      printf '%s' "${entry#*=}"
-      return 0
-    fi
-  done
+  local name="$1"
   if [ "$name" = "$OFFICIAL_MARKETPLACE" ]; then
     printf '%s' "$OFFICIAL_MARKETPLACE_SOURCE"
     return 0
   fi
-  return 1
+  # shellcheck disable=SC2016  # $m is a jq variable bound by --arg, not a shell expansion.
+  printf '%s' "$declaration_json" | "${jq_cmd[@]}" -er --arg m "$name" '
+    .extraKnownMarketplaces[$m].source
+    | (if .source == "github" then .repo
+       elif .source == "git" then .url
+       else error("unsupported marketplace source type \"\(.source)\" for \($m)")
+       end) as $base
+    | if (.ref // "") == "" then $base else "\($base)#\(.ref)" end
+  '
 }
 
 failed=0
 for config_dir in "${config_dirs[@]}"; do
   echo "==> Reconciling Claude Code plugins in ${config_dir}..."
+  mkdir -p "$config_dir"
   known_marketplaces="${config_dir}/plugins/known_marketplaces.json"
-  # `plugin list --json` prints each installed plugin's "<plugin>@<marketplace>" id. It is empty (and
-  # exits non-zero) before the plugin runtime exists, which is the expected state on a first apply.
-  installed="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin list --json 2>/dev/null | jq -r '.[].id' || true)"
+  # `plugin list --json` prints one object per installed plugin. Filter to user scope, the scope this
+  # script installs into: a project- or local-scoped plugin of the same name must not mask a missing
+  # user-scoped one. The command is empty (and exits non-zero) before the plugin runtime exists, which
+  # is the expected state on a first apply.
+  installed="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin list --json 2>/dev/null | "${jq_cmd[@]}" -r '.[] | select(.scope == "user") | .id' || true)"
 
   for plugin in "${plugins[@]}"; do
     marketplace="${plugin##*@}"
 
-    if [ ! -f "$known_marketplaces" ] || ! jq -e --arg m "$marketplace" 'has($m)' "$known_marketplaces" >/dev/null 2>&1; then
+    # Presence is keyed on the marketplace name only: an entry already registered under a different
+    # source is trusted as-is. Rewriting it would need local write access to known_marketplaces.json,
+    # which already implies control of this machine.
+    # shellcheck disable=SC2016  # $m is a jq variable bound by --arg, not a shell expansion.
+    if [ ! -f "$known_marketplaces" ] || ! "${jq_cmd[@]}" -e --arg m "$marketplace" 'has($m)' "$known_marketplaces" >/dev/null 2>&1; then
       if ! source_spec="$(marketplace_source "$marketplace")"; then
-        printf 'ERROR: plugin %s needs marketplace %s, which is neither %s nor declared in settings.json extraKnownMarketplaces\n' "$plugin" "$marketplace" "$OFFICIAL_MARKETPLACE" >&2
+        printf 'ERROR: cannot resolve a source for marketplace %s (needed by %s); declare it in settings.json extraKnownMarketplaces\n' "$marketplace" "$plugin" >&2
         failed=1
         continue
       fi
-      if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin marketplace add "$source_spec" 2>&1)"; then
+      if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin marketplace add "$source_spec" --scope user 2>&1)"; then
         printf 'ERROR: failed to add marketplace %s (%s) in %s\n%s\n' "$marketplace" "$source_spec" "$config_dir" "$out" >&2
         failed=1
         continue

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -446,10 +446,14 @@ load helpers/setup
   # `claude plugin marketplace add`. It knows exactly two origins: the built-in
   # claude-plugins-official, and whatever extraKnownMarketplaces declares. A plugin whose
   # marketplace is neither would fail at apply time on a fresh machine, so catch it here instead.
+  # The `as $known` binding must be parenthesized: jq binds `as` tighter than `+`, so
+  # `a + b as $x | c` means `a + (b as $x | c)` and would try to add an array to a boolean.
   jq -e '
-    (.extraKnownMarketplaces | keys) + ["claude-plugins-official"] as $known
-    | [.enabledPlugins | keys[] | sub("^.*@"; "")]
-    | all(. as $m | $known | index($m) != null)
+    (((.extraKnownMarketplaces | keys) + ["claude-plugins-official"]) as $known
+      | .enabledPlugins
+      | keys
+      | map(sub("^.*@"; ""))
+      | all(IN($known[])))
   ' "$s" >/dev/null
 }
 

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -461,16 +461,154 @@ load helpers/setup
   local s="${HOME_DIR}/dot_claude/settings.json"
   [ -f "$s" ]
   command -v jq >/dev/null 2>&1 || skip "jq unavailable"
-  # The template renders `repo` for github sources and `url` for everything else. An entry with
-  # neither would render an empty `marketplace add` argument.
+  # The reconciler resolves only the `github` (repo) and `git` (url) source types of the seven the
+  # settings schema allows; the rest (url, hostPattern, npm, file, directory) carry a different
+  # identifying field and would make `marketplace add` fail at apply time.
   jq -e '
     .extraKnownMarketplaces
-    | all(.[]; if .source.source == "github" then (.source.repo | length) > 0 else (.source.url | length) > 0 end)
+    | all(.[]; .source
+      | if .source == "github" then (.repo | length) > 0
+        elif .source == "git" then (.url | length) > 0
+        else false end)
   ' "$s" >/dev/null
+}
+
+@test "settings.json: every extraKnownMarketplaces entry is pinned to a ref" {
+  local s="${HOME_DIR}/dot_claude/settings.json"
+  [ -f "$s" ]
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  # A marketplace is executable code installed unattended by `chezmoi apply`, so it must not track a
+  # moving default branch. Only branches and tags work: `#<commit-sha>` reaches `git clone --branch`
+  # and fails, so the pin is necessarily a tag rather than a commit.
+  jq -e '.extraKnownMarketplaces | all(.[]; (.source.ref | length) > 0)' "$s" >/dev/null
 }
 
 @test "chezmoi source files exist: claude plugin reconciler script" {
   [ -f "${HOME_DIR}/run_onchange_after_17-setup-claude-plugins.sh.tmpl" ]
+}
+
+# Drive the rendered reconciler against a throwaway HOME with fake `mise`/`claude` on PATH. The fake
+# claude reproduces the two behaviours the script exists to handle: it rewrites settings.json with its
+# own serializer (dropping the hook `id` annotations), and it replaces the work account's settings.json
+# symlink with a regular file via an atomic rename.
+_reconciler_sandbox() {
+  local sandbox="$1"
+  mkdir -p "${sandbox}/home/.claude" "${sandbox}/home/.claude-r06" "${sandbox}/bin"
+  cp "${HOME_DIR}/dot_claude/settings.json" "${sandbox}/home/.claude/settings.json"
+  ln -sfn "${sandbox}/home/.claude/settings.json" "${sandbox}/home/.claude-r06/settings.json"
+
+  cat >"${sandbox}/bin/mise" <<'FAKE_MISE'
+#!/usr/bin/env bash
+[ "${1:-}" = "exec" ] && shift
+[ "${1:-}" = "--" ] && shift
+exec "$@"
+FAKE_MISE
+
+  cat >"${sandbox}/bin/claude" <<'FAKE_CLAUDE'
+#!/usr/bin/env bash
+set -euo pipefail
+cfg="${CLAUDE_CONFIG_DIR:?}"
+log="${FAKE_CLAUDE_LOG:?}"
+case "${1:-} ${2:-}" in
+  "plugin list")
+    # Exits non-zero before the runtime exists, exactly like the real CLI.
+    [ -f "${cfg}/plugins/installed.json" ] || exit 1
+    cat "${cfg}/plugins/installed.json"
+    ;;
+  "plugin marketplace")
+    src="$4"
+    echo "marketplace-add ${cfg##*/} ${src}" >>"$log"
+    case "$src" in
+      anthropics/claude-plugins-official*) key=claude-plugins-official ;;
+      openai/codex-plugin-cc*) key=openai-codex ;;
+      *) echo "unknown marketplace source: $src" >&2; exit 1 ;;
+    esac
+    mkdir -p "${cfg}/plugins"
+    [ -f "${cfg}/plugins/known_marketplaces.json" ] || echo '{}' >"${cfg}/plugins/known_marketplaces.json"
+    jq --arg k "$key" '.[$k] = {}' "${cfg}/plugins/known_marketplaces.json" >"${cfg}/plugins/km.tmp"
+    mv "${cfg}/plugins/km.tmp" "${cfg}/plugins/known_marketplaces.json"
+    ;;
+  "plugin install")
+    id="$3"
+    [ "${FAKE_CLAUDE_INSTALL_FAILS:-0}" = "1" ] && { echo "boom" >&2; exit 1; }
+    echo "install ${cfg##*/} ${id}" >>"$log"
+    mkdir -p "${cfg}/plugins"
+    [ -f "${cfg}/plugins/installed.json" ] || echo '[]' >"${cfg}/plugins/installed.json"
+    jq --arg i "$id" '. + [{id: $i, scope: "user"}]' "${cfg}/plugins/installed.json" >"${cfg}/plugins/inst.tmp"
+    mv "${cfg}/plugins/inst.tmp" "${cfg}/plugins/installed.json"
+    # Reproduce the CLI's settings.json rewrite: drop the hook annotations, and replace the file (an
+    # atomic rename, which clobbers the work account's symlink).
+    jq 'del(.hooks.SessionStart[0].id, .hooks.SessionStart[0].description)' "${cfg}/settings.json" >"${cfg}/settings.tmp"
+    mv "${cfg}/settings.tmp" "${cfg}/settings.json"
+    ;;
+  *) echo "unexpected fake claude invocation: $*" >&2; exit 1 ;;
+esac
+FAKE_CLAUDE
+  chmod +x "${sandbox}/bin/mise" "${sandbox}/bin/claude"
+  chezmoi execute-template --source "${HOME_DIR}" \
+    <"${HOME_DIR}/run_onchange_after_17-setup-claude-plugins.sh.tmpl" >"${sandbox}/reconcile.sh"
+}
+
+@test "claude plugin reconciler: installs per account, passes the pinned ref, restores settings.json" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  [ "$status" -eq 0 ]
+
+  # The declared ref must reach the CLI: declaring it in settings.json alone does not pin anything.
+  grep -qF 'marketplace-add .claude openai/codex-plugin-cc#v1.0.6' "${sandbox}/calls.log"
+  grep -qF 'marketplace-add .claude-r06 openai/codex-plugin-cc#v1.0.6' "${sandbox}/calls.log"
+  grep -qF 'marketplace-add .claude anthropics/claude-plugins-official' "${sandbox}/calls.log"
+
+  # Both plugins land in both accounts.
+  [ "$(grep -c '^install .claude ' "${sandbox}/calls.log")" -eq 2 ]
+  [ "$(grep -c '^install .claude-r06 ' "${sandbox}/calls.log")" -eq 2 ]
+
+  # The hook annotations the fake CLI stripped are back, and the work account's symlink was repaired.
+  jq -e '.hooks.SessionStart[0] | has("id") and has("description")' "${sandbox}/home/.claude/settings.json"
+  [ -L "${sandbox}/home/.claude-r06/settings.json" ]
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: a second run is a no-op" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  : >"${sandbox}/calls.log"
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  [ "$status" -eq 0 ]
+  # Nothing to add, nothing to install.
+  [ ! -s "${sandbox}/calls.log" ]
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: a failed install exits non-zero so chezmoi retries" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" FAKE_CLAUDE_INSTALL_FAILS=1 bash "${sandbox}/reconcile.sh"
+  [ "$status" -ne 0 ]
+  # A partially-reconciled run must still leave settings.json as chezmoi wrote it.
+  jq -e '.hooks.SessionStart[0] | has("id")' "${sandbox}/home/.claude/settings.json"
+
+  rm -rf "$sandbox"
 }
 
 @test "clv2 observer enable script is present and idempotently forces observer.enabled" {

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -425,6 +425,50 @@ load helpers/setup
   ' "$s" >/dev/null
 }
 
+@test "settings.json declares codex and claude-code-setup as enabled plugins" {
+  local s="${HOME_DIR}/dot_claude/settings.json"
+  [ -f "$s" ]
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  # settings.json is the single source of truth for the plugin set:
+  # run_onchange_after_17-setup-claude-plugins.sh.tmpl renders its install list from
+  # exactly these entries, so dropping one here silently stops installing it.
+  jq -e '
+    .enabledPlugins["codex@openai-codex"] == true
+      and .enabledPlugins["claude-code-setup@claude-plugins-official"] == true
+  ' "$s" >/dev/null
+}
+
+@test "settings.json: every enabled plugin resolves to a known marketplace (#17 reconciler contract)" {
+  local s="${HOME_DIR}/dot_claude/settings.json"
+  [ -f "$s" ]
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  # The reconciler resolves a plugin's "<name>@<marketplace>" suffix to a source it can pass to
+  # `claude plugin marketplace add`. It knows exactly two origins: the built-in
+  # claude-plugins-official, and whatever extraKnownMarketplaces declares. A plugin whose
+  # marketplace is neither would fail at apply time on a fresh machine, so catch it here instead.
+  jq -e '
+    (.extraKnownMarketplaces | keys) + ["claude-plugins-official"] as $known
+    | [.enabledPlugins | keys[] | sub("^.*@"; "")]
+    | all(. as $m | $known | index($m) != null)
+  ' "$s" >/dev/null
+}
+
+@test "settings.json: extraKnownMarketplaces entries carry a source the reconciler can resolve" {
+  local s="${HOME_DIR}/dot_claude/settings.json"
+  [ -f "$s" ]
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  # The template renders `repo` for github sources and `url` for everything else. An entry with
+  # neither would render an empty `marketplace add` argument.
+  jq -e '
+    .extraKnownMarketplaces
+    | all(.[]; if .source.source == "github" then (.source.repo | length) > 0 else (.source.url | length) > 0 end)
+  ' "$s" >/dev/null
+}
+
+@test "chezmoi source files exist: claude plugin reconciler script" {
+  [ -f "${HOME_DIR}/run_onchange_after_17-setup-claude-plugins.sh.tmpl" ]
+}
+
 @test "clv2 observer enable script is present and idempotently forces observer.enabled" {
   local script="${HOME_DIR}/run_onchange_after_14-enable-clv2-observer.sh.tmpl"
   [ -f "$script" ]


### PR DESCRIPTION
## Summary

Enables the Anthropic-official `claude-code-setup` plugin, and makes the whole plugin set
reproducible from `chezmoi apply` alone.

`settings.json` already declared `codex@openai-codex` under `enabledPlugins`, but that declaration
never installed anything. The work account (`~/.claude-r06`) was missing the codex plugin entirely,
because its marketplace was never registered there. This PR fixes the class of bug, not just the
instance.

## Why the declaration alone is not enough

Plugin state is split across two places:

| State | Lives in | chezmoi |
|---|---|---|
| Declaration | `settings.json`: `enabledPlugins`, `extraKnownMarketplaces` | owned, versioned |
| Runtime | `$CLAUDE_CONFIG_DIR/plugins/` (marketplace clones, install cache) | `.chezmoiignore`d — empty on a new machine |

The CLI does not bridge them. `enabledPlugins` only toggles a plugin that is *already* installed, and
declaring a marketplace does not register it. Both are upstream wontfix:

- [anthropics/claude-code#23737](https://github.com/anthropics/claude-code/issues/23737) — closed as duplicate; states `enabledPlugins` does not auto-install.
- [anthropics/claude-code#45323](https://github.com/anthropics/claude-code/issues/45323) — closed as not planned: "Plugins configured in org managed settings (`extraKnownMarketplaces` + `enabledPlugins`) do not auto-install in the CLI."

Verified against the version chezmoi actually installs — the mise-pinned **2.1.205**:
`enabledPlugins`, `extraKnownMarketplaces`, and `strictKnownMarketplaces` all appear in `strings`; the
`autoInstallEnabledPlugins` and `forcedPlugins` keys those issues ask for do not.

## Approach

`settings.json` stays the single source of truth. `run_onchange_after_17-setup-claude-plugins.sh.tmpl`
reads it at render time with `include | fromJson` and embeds just `enabledPlugins` and
`extraKnownMarketplaces` as JSON inside a **quoted heredoc**. So there is no second list to keep in
sync, no rendered value can be evaluated as shell source, and the `run_onchange` key flips only when
the declaration changes. The script then registers missing marketplaces and installs missing plugins,
once per account, exiting non-zero on failure so chezmoi retries on the next apply (the same contract
as `run_onchange_after_13-setup-mcp`).

### Pinning the marketplace

A marketplace is executable code that `chezmoi apply` installs unattended, so it must not track a
moving default branch. Measured in an isolated `CLAUDE_CONFIG_DIR`, pinning has two sharp edges:

| Method | Pinned? |
|---|---|
| `marketplace add openai/codex-plugin-cc#v1.0.4` | Yes — checks out `807e03a` |
| Declaring `ref` in `settings.json` only | **No — HEAD is checked out**, and the ref is not even recorded |
| `#<commit-sha>` | No — `fatal: Remote branch <sha> not found` (the ref reaches `git clone --branch`) |

So the `ref` is declared on the `github` source (the settings schema allows it) *and* rendered into
the CLI argument as `<repo>#<ref>`. Because a commit SHA cannot be used, the pin is a **tag**, which
is weaker than the commit pins this repo uses for chezmoi externals — a tag can be moved upstream.
Bumping it is a manual edit today; wiring Renovate's `github-tags` datasource is tracked separately.

Note that both accounts already have `openai-codex` registered from an earlier unpinned
`marketplace add`, and the script skips registration when the name is present. The pin therefore takes
effect on a fresh machine, or after the marketplace is removed and re-added.

### The settings.json rewrite hazard

`claude plugin install`, `claude plugin marketplace add`, and the interactive `/plugin` manager each
rewrite `settings.json` with their own serializer: top-level keys are reordered and every hook's `id`
and `description` annotation is dropped. Nothing breaks at runtime — hooks are identified by the
argument inside their `command`, not by those keys — but the annotations would be lost forever if the
rewritten file were ever `chezmoi add`ed. The script snapshots the file up front and writes it back on
exit, and repairs the work account's `settings.json` symlink if an atomic rewrite replaced it with a
regular file. The hazard is documented so a human doing the same by hand knows to run `chezmoi apply`.

## Changes

| File | Change |
|---|---|
| `home/dot_claude/settings.json` | Enable `claude-code-setup@claude-plugins-official`; declare the `openai-codex` marketplace, pinned to `v1.0.6` |
| `home/run_onchange_after_17-setup-claude-plugins.sh.tmpl` | New reconciler |
| `tests/files.bats` | Declaration invariants (both plugins enabled, every marketplace resolvable and pinned) plus three end-to-end tests driving the rendered script against fake `mise`/`claude` |
| `docs/agents/claude-code.{md,ja.md}` | Plugin set, why the declaration does not install, the pin's two sharp edges, the rewrite hazard |
| `docs/architecture/lifecycle-scripts.{md,ja.md}` | Script 17 in the timeline, tracked-external table, OS-guard table |

## Verification

- `make lint` — clean. Re-checked with a script that honours shellcheck's and shfmt's exit codes, because `make lint` currently swallows them (`Makefile:13-19`); every script under `home/` is clean either way.
- `make test` — 163 ok, 0 failures.
- The rendered script was run against the real environment: `~/.claude` was a no-op, `~/.claude-r06`
  gained the `openai-codex` marketplace and the `codex` plugin. `settings.json` came out byte-identical
  (same sha before and after), hook annotations intact, the work-account symlink intact. A second run
  finished in 0.67 s as a clean no-op.
- The three end-to-end bats tests were mutation-checked: deleting the `trap` line, or dropping the
  `#<ref>` suffix, each makes the corresponding assertion fail. They are not vacuous.

## Review

cc-code-review, cc-security-review, and codex reviewed this PR; every claim was checked against a
primary source before acting. Three MUSTs survived — a silent `exit 0` when `jq` is absent, rendering
settings.json values into bash array literals, and the unpinned marketplace — and all are fixed. See
the review thread for the findings that verification corrected or rejected.

## Checklist

- [x] Code review complete
- [x] Tests added
- [x] Configuration change impact verified (`chezmoi apply` reproducibility on a fresh machine)
- [x] Docs updated (EN canonical + JA mirror)
