### PR TITLE
feat(git): add lefthook-adopt alias to coexist with the global gitleaks hook

### DIFF
--- a/docs/architecture/dev-tooling.ja.md
+++ b/docs/architecture/dev-tooling.ja.md
@@ -174,10 +174,43 @@ regex = '''(?i)({{ onepasswordRead "op://kryota.dev/Dotfiles - Redact Patterns/p
 
 誤検知が発生した場合は、他の gitleaks 検出と同じエスケープハッチを使用します: `git commit --no-verify`。
 
+### per-repo フックマネージャー（lefthook, husky）との共存
+
+`core.hooksPath` はリポジトリごとに単一値のため、グローバル policy hook と per-repo
+フックマネージャーが同時に所有することはできません。新しい lefthook（v2）はグローバル
+`core.hooksPath` が設定されていると `install` を拒否し、guardrail を壊す逃げ道しか提示しません
+— **いずれも使用しないこと**:
+
+- `lefthook install --reset-hooks-path` は `git config --global --unset-all core.hooksPath` を実行し、gitleaks guardrail を**マシン全体で無効化**します（`internal/command/install.go` の `unsetHooksPathConfig` で確認済み）。絶対に実行しないこと。
+- `lefthook install --force` を**ローカル `core.hooksPath` 未設定のまま**実行すると、グローバルディレクトリ（`~/.config/git/hooks`）へ install され、gitleaks フックをクロバーします。
+- グローバル `core.hooksPath` を手動で unset するのも `--reset-hooks-path` と同じ結果になります。
+
+lefthook には既存フックをチェーンする仕組みがない（生成フックは `lefthook run` を呼ぶだけで、
+既存フックは `.old` へ退避される）ため、両者はリポジトリごとに分離する必要があります。安全な
+レシピは `dot_gitconfig.tmpl` で定義した `lefthook-adopt` エイリアスで、**per-clone・非追跡**の
+ローカル `core.hooksPath`（`.git/hooks-lefthook`）を設定し、`lefthook install -f` がそこへ install
+されるようにします — ローカル値はこのクローンでのみグローバルを上書きするため、他のすべての
+リポジトリでは guardrail が無傷のまま残ります:
+
+```bash
+git lefthook-adopt          # ローカル core.hooksPath = .git/hooks-lefthook を設定（per-clone・非追跡）
+lefthook install -f         # そのローカルディレクトリへ install（または: pnpm exec lefthook install -f）
+```
+
+ローカル `core.hooksPath` はグローバルを上書きするため、そのリポジトリではグローバル gitleaks
+フックが走らなくなります。namespace に応じて guardrail を補います:
+
+- **自分名義リポジトリ**: リポジトリの `lefthook.yml` に `gitleaks` コマンドを追加し、lefthook にスキャンを走らせます。
+- **クライアント/業務リポジトリ**: CI/サーバーサイドの gitleaks バックストップに依存します（上記の owner-scoped な設定選択と整合）。
+
+リポジトリの `prepare`/`postinstall` が `lefthook install` を実行している場合は
+`lefthook install -f` に変更します。これはグローバル `core.hooksPath` を持たないマシンでは
+no-op の差分であり、`npm`/`pnpm install` がガードで失敗するのを防ぎます。
+
 ### 注意事項
 
 - `git commit --no-verify` はフックをバイパスします。これはハーネスごとのポリシーとして意図的です。CI/サーバーサイドの gitleaks がバックストップとなります。
-- 独自の `core.hooksPath` を設定するリポジトリ（例: husky）はグローバルフックに到達しません。
+- 独自の `core.hooksPath` を設定するリポジトリ（例: husky、または上記の `lefthook-adopt` レシピ）はグローバルフックに到達しません — [per-repo フックマネージャーとの共存](#per-repo-フックマネージャーlefthook-huskyとの共存) を参照。
 - フックがチェーンするのは `pre-commit` のみです。`.git/hooks` の他のフックタイプ（`commit-msg`、`post-commit` など）はチェーンされません。それらに依存するリポジトリは `core.hooksPath` を設定するフックマネージャーを使用する必要があります。
 
 ---

--- a/docs/architecture/dev-tooling.md
+++ b/docs/architecture/dev-tooling.md
@@ -194,10 +194,44 @@ and GitHub secret scanning does not cover custom identifier regexes. `git commit
 On a false positive, use the same escape hatch as any other gitleaks finding:
 `git commit --no-verify`.
 
+### Coexisting with per-repo hook managers (lefthook, husky)
+
+`core.hooksPath` is single-valued per repo, so a global policy hook and a per-repo
+hook manager cannot both own it. Modern lefthook (v2) refuses to `install` while a
+global `core.hooksPath` is set and offers only escape hatches that break the
+guardrail — **do not use them**:
+
+- `lefthook install --reset-hooks-path` runs `git config --global --unset-all core.hooksPath`, disabling the gitleaks guardrail **machine-wide** (verified in `internal/command/install.go`, `unsetHooksPathConfig`). Never run it.
+- `lefthook install --force` **with no local `core.hooksPath`** installs into the global dir (`~/.config/git/hooks`), clobbering the gitleaks hook.
+- Manually unsetting the global `core.hooksPath` has the same effect as `--reset-hooks-path`.
+
+lefthook has no mechanism to chain a pre-existing hook (its generated hook only
+calls `lefthook run`; any existing hook is backed up to `.old`), so the two must be
+separated per repo. The safe recipe is the `lefthook-adopt` alias defined in
+`dot_gitconfig.tmpl`, which sets a **per-clone, non-tracked** local `core.hooksPath`
+(`.git/hooks-lefthook`) so that `lefthook install -f` installs there — the local
+value overrides the global only for this clone, leaving the guardrail untouched for
+every other repo:
+
+```bash
+git lefthook-adopt          # sets local core.hooksPath = .git/hooks-lefthook (per-clone, untracked)
+lefthook install -f         # installs into that local dir (or: pnpm exec lefthook install -f)
+```
+
+Because a local `core.hooksPath` overrides the global one, the global gitleaks hook
+no longer runs in that repo. Restore the guardrail there per namespace:
+
+- **Own-namespace repos**: add a `gitleaks` command to the repo's `lefthook.yml` so lefthook runs the scan.
+- **Client/work repos**: rely on the CI/server-side gitleaks backstop (consistent with the owner-scoped config selection above).
+
+If the repo's `prepare`/`postinstall` runs `lefthook install`, change it to
+`lefthook install -f`; that is a no-op difference on machines without the global
+`core.hooksPath` and prevents `npm`/`pnpm install` from failing on the guard.
+
 ### Caveats
 
 - `git commit --no-verify` bypasses the hook. This is intentional per-harness policy. CI/server-side gitleaks is the backstop.
-- A repo that sets its own `core.hooksPath` (e.g. husky) never reaches the global hook at all.
+- A repo that sets its own `core.hooksPath` (e.g. husky, or the `lefthook-adopt` recipe above) never reaches the global hook at all — see [Coexisting with per-repo hook managers](#coexisting-with-per-repo-hook-managers-lefthook-husky).
 - The hook chains only `pre-commit`. Other hook types (`commit-msg`, `post-commit`, etc.) from `.git/hooks` are not chained; repos relying on those must use a hook manager that also sets `core.hooksPath`.
 
 ---

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -31,3 +31,13 @@
 [ghq]
 	root = ~/ghq
 	user = {{ .ghq_user }}
+[alias]
+	# Onboard a repo that uses a per-repo hook manager (lefthook, husky) WITHOUT
+	# disabling the global gitleaks guardrail. git's core.hooksPath is single-valued,
+	# so this sets a PER-CLONE, non-tracked local core.hooksPath (.git/hooks-lefthook);
+	# a following `lefthook install -f` then installs into THAT dir, leaving the global
+	# hooksPath (the gitleaks guardrail) intact for every other repo.
+	# WARNING: never run `lefthook install --reset-hooks-path` — it executes
+	# `git config --global --unset-all core.hooksPath` and disables the guardrail
+	# machine-wide. See docs/architecture/dev-tooling.md.
+	lefthook-adopt = "!f() { git config --local core.hooksPath .git/hooks-lefthook && echo 'Set local core.hooksPath -> .git/hooks-lefthook (per-clone; global gitleaks guardrail untouched).' && echo 'Next: run  lefthook install -f   (or: pnpm exec lefthook install -f).' && echo 'Own-namespace repo? add a gitleaks command to lefthook.yml so the guardrail still runs here.'; }; f"

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -14,6 +14,20 @@ load helpers/setup
   [ -f "${HOME_DIR}/dot_gitconfig.tmpl" ]
 }
 
+@test "git lefthook-adopt alias sets a per-clone LOCAL core.hooksPath and never touches global" {
+  local gc="${HOME_DIR}/dot_gitconfig.tmpl"
+  # Coexistence helper for lefthook/husky repos: it must onboard a repo WITHOUT
+  # disabling the global gitleaks guardrail (docs/architecture/dev-tooling.md).
+  local def
+  def="$(grep 'lefthook-adopt =' "$gc")"
+  [ -n "$def" ]
+  # The alias DEFINITION line must set a local hooksPath and must NEVER carry
+  # --global: unsetting/rewriting the global core.hooksPath (what lefthook's own
+  # --reset-hooks-path does) is exactly the guardrail-destroying move to avoid.
+  [[ "$def" == *"config --local core.hooksPath"* ]]
+  [[ "$def" != *"--global"* ]]
+}
+
 @test "chezmoi source files exist: private_dot_ssh/config.tmpl" {
   [ -f "${HOME_DIR}/private_dot_ssh/config.tmpl" ]
 }


### PR DESCRIPTION
## Summary

Adds a `git lefthook-adopt` alias so a repo that uses a per-repo hook manager
(lefthook, husky) can be onboarded **without disabling the global gitleaks
pre-commit guardrail**. The alias sets a per-clone, non-tracked local
`core.hooksPath` (`.git/hooks-lefthook`); a following `lefthook install -f` then
installs there, leaving the global `core.hooksPath` guardrail intact for every
other repo.

## Background — why this is needed

`core.hooksPath` is single-valued per repo. These dotfiles set a **global**
`core.hooksPath` so the gitleaks secret-scan runs on every commit across every
repo. A per-repo hook manager (lefthook v2) refuses to `install` while a global
`core.hooksPath` is set, and each escape hatch it offers destroys the guardrail:

- `lefthook install --reset-hooks-path` runs `git config --global --unset-all core.hooksPath`, disabling the guardrail **machine-wide** (verified in lefthook's `internal/command/install.go`, `unsetHooksPathConfig`).
- `lefthook install --force` **with no local `core.hooksPath`** installs into the global dir (`~/.config/git/hooks`), clobbering the gitleaks hook.
- Manually unsetting the global `core.hooksPath` has the same effect as `--reset-hooks-path`.

lefthook cannot chain a pre-existing hook (its generated hook only calls
`lefthook run`; any existing hook is backed up to `.old`), so the global hook and
the per-repo manager must be separated **per repo**. `lefthook-adopt` does that
safely and per clone, without touching global config or any tracked file in the
target repo.

## Usage

```bash
git lefthook-adopt          # sets local core.hooksPath = .git/hooks-lefthook (per-clone, untracked)
lefthook install -f         # installs into that local dir (or: pnpm exec lefthook install -f)
```

Because a local `core.hooksPath` overrides the global one, the global gitleaks
hook does not run in an adopted repo. Restore the guardrail there per namespace:

- **Own-namespace repos**: add a `gitleaks` command to the repo's `lefthook.yml`.
- **Client/work repos**: rely on the CI/server-side gitleaks backstop (consistent with the owner-scoped config selection).

## Changes

- `home/dot_gitconfig.tmpl`: new `[alias] lefthook-adopt` (+ a warning comment about `--reset-hooks-path`).
- `docs/architecture/dev-tooling.md` / `dev-tooling.ja.md`: new "Coexisting with per-repo hook managers" subsection and an updated caveat.
- `tests/files.bats`: guard asserting the alias sets `--local` and never `--global`.

## Verification

- `make lint` — pass
- `make test` (full bats suite) — pass
- The restored global gitleaks hook ran on this branch's commit (`no leaks found`).

## Checklist

- [x] Tests added/updated (`tests/files.bats` invariant guard)
- [x] Docs updated (English canonical + Japanese mirror)
- [x] `make lint` / `make test` pass locally
- [ ] Code review completed
