### PR TITLE
fix(claude): migrate unmatched Write(path) permission rules to Edit(path)

### DIFF
--- a/home/dot_claude/executable_morning-radar.sh
+++ b/home/dot_claude/executable_morning-radar.sh
@@ -26,10 +26,15 @@ CLAUDE_MODEL="sonnet"
 # review-thread queries) cannot distinguish queries from mutations at the
 # prefix level; the prompt additionally forbids all writes. git is limited to
 # plain read verbs (no `git -C`, so other repos' history comes from session
-# summaries instead). Skill is scoped to the morning-brief handoff chain.
-# Everything else (Edit, WebFetch/WebSearch, Agent, mcp tools, other Bash
-# commands) stays auto-denied in print mode.
-ALLOWED_TOOLS="Bash(gh search:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh api graphql:*),Bash(git log:*),Bash(git status:*),Bash(git diff:*),Bash(git show:*),Bash(git branch:*),Bash(ls:*),Bash(cat:*),Bash(date:*),Bash(jq:*),Bash(find:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Read,Glob,Grep,Skill(morning-brief),Skill(repo-radar),Skill(gmail-triage),Write(~/dotfiles/.kryota-dev/morning-brief/**)"
+# summaries instead). Skill is scoped to the morning-brief handoff chain. File
+# edits are confined to the brief output dir and spelled as an Edit(path) rule:
+# since Claude Code v2.1.210 the file permission checks match only Edit(path)
+# and Read(path), and one Edit rule covers every file-editing tool (Write and
+# NotebookEdit included). The Write(path) form it replaced was accepted but
+# never matched, so it granted nothing while warning at every startup.
+# Everything else (edits outside that dir, WebFetch/WebSearch, Agent, mcp
+# tools, other Bash commands) stays auto-denied in print mode.
+ALLOWED_TOOLS="Bash(gh search:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh api graphql:*),Bash(git log:*),Bash(git status:*),Bash(git diff:*),Bash(git show:*),Bash(git branch:*),Bash(ls:*),Bash(cat:*),Bash(date:*),Bash(jq:*),Bash(find:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Read,Glob,Grep,Skill(morning-brief),Skill(repo-radar),Skill(gmail-triage),Edit(~/dotfiles/.kryota-dev/morning-brief/**)"
 
 notify_user() {
   # Argv-passing keeps claude-derived text out of the AppleScript source

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -109,8 +109,8 @@
       "Read(**/*credentials*)",
       "Read(**/*secret*)",
 
-      "Write(**/.env*)",
-      "Write(**/secrets/**)",
+      "Edit(**/.env*)",
+      "Edit(**/secrets/**)",
 
       "Bash(env:*)",
       "Bash(printenv:*)",

--- a/tests/claude_permissions.bats
+++ b/tests/claude_permissions.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+
+load helpers/setup
+
+# Claude Code permission rule form checks.
+#
+# Since v2.1.210 the file permission checks match only `Edit(path)` and `Read(path)` rules.
+# A `Write(path)`, `NotebookEdit(path)` or `Glob(path)` rule is still ACCEPTED — it just never
+# matches, so the rule is silently inert and every session warns at startup. That failure mode
+# (config is accepted but does nothing) is invisible in review, which is what these tests are
+# for. `Edit` rules cover all file-editing tools, so `Edit(path)` is the correct replacement.
+# A bare tool name with no path (`Write`, `Glob`) is unaffected and must NOT be flagged.
+#
+# Dependency-free on purpose — CI's bats job installs only bats/shellcheck/zsh, so a jq-based
+# assertion would `skip` there and this guard would pass vacuously in the one place it matters.
+#
+# See: https://code.claude.com/docs/en/permissions
+
+# Emit permission rules from the Claude Code settings SSOT — every rule across allow/deny/ask,
+# or only one array's rules when a section name is passed. Scoped to the top-level
+# "permissions" object so an unrelated block gaining an "allow" key can't perturb the result.
+# One rule per line is the file's own layout. Only this one settings file is inspected: it is
+# the SSOT that both profiles receive (~/.claude-r06/settings.json symlinks to it), so a second
+# settings source would need to be added here explicitly.
+_claude_permission_rules() {
+  awk -v want="${1:-}" '
+    /^  "permissions"[[:space:]]*:/                                       { in_perms = 1; next }
+    in_perms && !in_list && /^[[:space:]]*[}]/                            { in_perms = 0 }
+    in_perms && /^[[:space:]]*"(allow|deny|ask)"[[:space:]]*:[[:space:]]*\[/ {
+      match($0, /"(allow|deny|ask)"/)
+      section = substr($0, RSTART + 1, RLENGTH - 2)
+      in_list = 1
+      next
+    }
+    in_perms && in_list && /^[[:space:]]*\]/                              { in_list = 0; next }
+    in_perms && in_list && (want == "" || want == section)                { print }
+  ' "${HOME_DIR}/dot_claude/settings.json" |
+    sed -e 's/^[[:space:]]*"//' -e 's/",*[[:space:]]*$//' |
+    grep -v '^[[:space:]]*$'
+}
+
+@test "claude permissions: settings.json declares no rule in an unmatched form" {
+  [ -f "${HOME_DIR}/dot_claude/settings.json" ]
+
+  local allow_count deny_count total
+  allow_count="$(_claude_permission_rules allow | grep -c . || true)"
+  deny_count="$(_claude_permission_rules deny | grep -c . || true)"
+  total="$(_claude_permission_rules | grep -c . || true)"
+
+  # Assert PER ARRAY, not just on the total. A parser break that drops one whole array —
+  # reformatted JSON, a renamed key — leaves the other array's rules behind, and a total-only
+  # floor can be satisfied by that remainder alone while every dropped rule goes unread. The
+  # guard would then pass on rules it never looked at, which is the exact failure this suite
+  # exists to catch.
+  [ "$allow_count" -ge 1 ] || {
+    echo "sanity: permissions.allow yielded no rules — the extractor broke"
+    false
+  }
+  [ "$deny_count" -ge 1 ] || {
+    echo "sanity: permissions.deny yielded no rules — the extractor broke"
+    false
+  }
+  [ "$total" -ge 20 ] || {
+    echo "sanity: permissions.allow/deny/ask resolved to $total rules (<20) — the extractor broke"
+    false
+  }
+
+  local offenders
+  offenders="$(_claude_permission_rules | grep -E '^(Write|NotebookEdit|Glob)\(' || true)"
+  [ -z "$offenders" ] || {
+    echo "settings.json declares rules that are accepted but never matched by file permission checks:"
+    echo "$offenders"
+    echo "use Edit(<path>) for Write(<path>)/NotebookEdit(<path>), Read(<path>) for Glob(<path>)"
+    false
+  }
+}
+
+@test "claude permissions: headless --allowedTools lists declare no rule in an unmatched form" {
+  local found=0 f offenders
+  while IFS= read -r f; do
+    found=1
+    # Comment lines are stripped so a script can still DESCRIBE the deprecated form in prose.
+    offenders="$(grep -v '^[[:space:]]*#' "$f" | grep -oE '(Write|NotebookEdit|Glob)\([^)]*\)' || true)"
+    [ -z "$offenders" ] || {
+      echo "${f#"${REPO_ROOT}/"}: --allowedTools declares rules that are never matched:"
+      echo "$offenders"
+      echo "use Edit(<path>) for Write(<path>)/NotebookEdit(<path>), Read(<path>) for Glob(<path>)"
+      false
+    }
+  done < <(grep -rlF -- '--allowedTools' "${HOME_DIR}")
+  [ "$found" = 1 ] || {
+    echo "no script under ${HOME_DIR} declares --allowedTools — this guard lost its subject"
+    false
+  }
+}


### PR DESCRIPTION
## Summary

Two `permissions.deny` rules in the Claude Code settings SSOT were written in a form that
Claude Code accepts but never evaluates, so they warned on every session start **and** never
blocked anything. This migrates them to the form that is actually matched, and adds a
regression guard so the same silently-inert rule form can't come back.

Closes #318

## Root cause

Since Claude Code v2.1.210 the file permission checks match only `Edit(path)` and `Read(path)`
rules. Per the [permissions docs](https://code.claude.com/docs/en/permissions):

> The file permission checks match only `Edit(path)` and `Read(path)` rules. A `Write(path)`,
> `NotebookEdit(path)`, or `Glob(path)` rule is accepted but never matched by those checks, so
> Claude Code warns at startup for each allow, deny, or ask rule in one of these unmatched
> forms. Use `Edit(docs/**)` in place of `Write(docs/**)` […] A tool-name rule with no path,
> such as a deny rule for `Write`, isn't affected.

The `Read` deny rules already covered reads and — since v2.1.208 — the `Edit` tool on the same
path, but the docs are explicit that "Write and NotebookEdit aren't covered". The `Write(...)`
rules meant to close that gap never matched, so **this is the first time writes to `.env*` and
`secrets/**` are actually denied**. One `Edit` rule covers every file-editing tool, so nothing
is narrowed by the swap.

## What changed

| File | Change |
|---|---|
| `home/dot_claude/settings.json` | `deny`: `Write(**/.env*)` → `Edit(**/.env*)`, `Write(**/secrets/**)` → `Edit(**/secrets/**)`. Both profiles get this (`~/.claude-r06/settings.json` symlinks to it). |
| `home/dot_claude/executable_morning-radar.sh` | Same migration for the `--allowedTools` entry. The neighbouring comment claimed "Edit … stays auto-denied", which the change contradicts, so it now explains the scope and why `Edit(path)` is the correct spelling. |
| `tests/claude_permissions.bats` (new) | Fails on any `Write(path)` / `NotebookEdit(path)` / `Glob(path)` rule, in the settings SSOT and in any script declaring `--allowedTools`. Bare tool names (`Write`, `Glob`) stay valid and are not flagged. |

The guard is deliberately **dependency-free** (awk/sed/grep, following `docs_facts.bats`). CI's
bats job installs only `bats shellcheck zsh`, so a jq-based assertion would `skip` there and the
guard would pass vacuously in the one environment where it has to hold.

## Verification

- **Empirical A/B on the actual warning.** With a minimal settings file under a scratch
  `CLAUDE_CONFIG_DIR`, the `Write` form reproduces both warnings from the issue verbatim; the
  `Edit` form emits none.
- **RED → GREEN.** The test was written first and failed against the unfixed tree, listing all
  three offending rules. It passes after the change.
- **Portability.** Verified under mawk 1.3.4 (same as the Ubuntu CI runner) as well as the
  macOS BSD toolchain — identical extraction (79 rules).
- `make lint` and `make test` both exit 0 (167 bats tests, no failures).

## Review notes

A reviewer found — and reproduced — a real hole in the guard's first draft: it asserted only a
floor on the *total* rule count, and `deny` alone happened to equal that floor. Changing
`"allow": [` to `"allow" : [` dropped all 59 `allow` rules from extraction, the total landed
exactly on the threshold, and a planted `Write(**/pwned*)` went undetected — the precise
"passes on what it never read" failure the test exists to prevent. Reproduced independently,
then fixed by asserting **per array** and relaxing the parser's whitespace handling. Both the
original hole and a whole-array rename now fail loudly.

## Known residual gap (pre-existing, out of scope)

Deny rules are evaluated before a tool runs, from the command string — which covers more than
it might look like. Claude Code parses shell redirection targets too, so `printf … > .env`
inside the rule's anchor is already blocked. Verified with a controlled probe: the same command
with a non-`.env` target in the same directory is allowed, and only the `.env` target is denied.

What deny rules cannot reach is [arbitrary
subprocesses](https://code.claude.com/docs/en/permissions) that open files themselves — a Python
or Node script, say — because no static read of the command string reveals the path. Only the
OS-level sandbox enforces a boundary against those, and enabling it here is a design task in its
own right (`osascript`, which `notify` depends on, and the Go-based `gh` both need explicit
handling).

This predates the PR and is not made worse by it. The follow-up (#320) starts with the narrower
and more actionable half: deny rules are **anchored**, and a path outside the anchor is not
matched at all — so which `.env`/`secrets` paths the current rules actually reach is worth
pinning down before reaching for the sandbox.

Docs updates (`docs/agents/claude-code.md`) were explicitly scoped out of this PR.
