### PR TITLE
docs(codex): agent profile, unmanaged-config trust policy, and plugin convergence

### DIFF
--- a/docs/agents/codex.ja.md
+++ b/docs/agents/codex.ja.md
@@ -108,12 +108,9 @@ multi_agent = true
 
 `home/.chezmoitemplates/codex-agent-config.toml` が設定本体で、`dot_codex/private_agent.config.toml.tmpl` と `dot_codex-r06/private_agent.config.toml.tmpl` の両方からインクルードされ、両アカウントに `$CODEX_HOME/agent.config.toml`（mode 0600）としてデプロイされます。`--profile agent` で選択される named `agent` プロファイルであり、Codex が実装ワーカーや CI 修正ワーカーとして動くときにスキルが使う非対話ポスチャです。
 
-`shared` と同様に `codex-model-pin.toml` から model pin をインクルードします。2 つのプロファイルを分けるのは permission キーです（レンダリング結果、コメント省略）：
+`shared` と同様に `codex-model-pin.toml` から model pin をインクルードします（値は pin 側にあり、ここでは再掲しません）。2 つのプロファイルを分けるのは permission キーです：
 
 ```toml
-personality = "pragmatic"
-model = "gpt-5.6-terra"
-model_reasoning_effort = "xhigh"
 sandbox_mode = "workspace-write"
 approval_policy = "never"
 web_search = "cached"
@@ -125,7 +122,7 @@ multi_agent = true
 network_access = false
 ```
 
-- `sandbox_mode = "workspace-write"` — Codex はワークスペース内のファイルを編集できます。保護パス（`.git`、`.agents`、`.codex`）は再帰的に read-only のままのため、Codex は git 状態を stage・commit・その他の書き込みできません。親の Claude セッションが diff をレビューしてコミットします。
+- `sandbox_mode = "workspace-write"` — Codex はワークスペース内のファイルを編集できます。保護パス（`.git`、`.agents`、`.codex`）は再帰的に read-only のままです（この保護はプロファイルの宣言ではなく Codex CLI 自体が提供します）。そのため Codex は git 状態への stage・commit などの書き込みはできません。親の Claude セッションが diff をレビューしてコミットします。
 - `approval_policy = "never"` — 承認プロンプトに応答できる人間がいない非対話 `codex exec` 実行に必要です。
 - `web_search = "cached"` と `network_access = false` — デフォルトではライブネットワークなし。本当にネットワークアクセスが必要な呼び出し側だけが、呼び出しごとにオプトインします（`-c sandbox_workspace_write.network_access=true`）。このオプトイン境界はポリシー統制であり技術統制ではありません — `-c` オーバーライドはプロファイル値より優先されます。この区別は `codex` skill が所有します。
 
@@ -286,11 +283,16 @@ Claude Code 側は `openai-codex` marketplace の `codex` プラグインを通�
 プラグインセットアップスクリプト（`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`）はプラグインが存在しない場合にのみインストールします：install ループはプラグイン名の一致だけで skip し、バージョン比較を行いません。したがって `ref` pin の編集だけでは、インストール済みプラグインは決して収束しません — これは既知のギャップです（スクリプトへの reconcile 実装は意図的に先送り）。収束は手動で、アカウント（`CLAUDE_CONFIG_DIR`）ごとに 1 回実行します：
 
 ```bash
+# デフォルトアカウント (~/.claude)
 claude plugin marketplace update openai-codex
 claude plugin update codex@openai-codex
+
+# ワークアカウント (~/.claude-r06)
+CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace update openai-codex
+CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin update codex@openai-codex
 ```
 
-反映には、その後 Claude Code の再起動が必要です（`claude plugin update` 自身が "restart required to apply" と報告します）。
+反映には、その後 Claude Code の再起動が必要です（`claude plugin update` 自身が "restart required to apply" と報告します）。将来 ref を bump する際の注意点：marketplace 登録はソース ref の独自コピー（ランタイムの `known_marketplaces.json`）を保持し、`marketplace update` はその保存済み登録から pull します — したがって `settings.json` の pin を変更した後は、登録済み ref を確認し、遅れている場合は marketplace を再登録（`claude plugin marketplace rm` + `add`）してください。
 
 ### codex:codex-rescue — 手動レスキュー専用
 

--- a/docs/agents/codex.ja.md
+++ b/docs/agents/codex.ja.md
@@ -14,12 +14,15 @@
 - [2 アカウントモデル](#2-アカウントモデル)
 - [hooks.json — PreToolUse ゲートガード](#hooksjson--pretooluse-ゲートガード)
 - [shared.config.toml — shared プロファイル](#sharedconfigtoml--shared-プロファイル)
+- [agent.config.toml — agent プロファイル](#agentconfigtoml--agent-プロファイル)
 - [テンプレート SSOT — アカウントドリフト防止](#テンプレート-ssot--アカウントドリフト防止)
 - [--profile shared の仕組み](#--profile-shared-の仕組み)
   - [cdx / cdx-r06 エイリアス](#cdx--cdx-r06-エイリアス)
   - [素の codex は SSOT 設定をスキップする](#素の-codex-は-ssot-設定をスキップする)
+- [管理外ベース設定とプロジェクト trust](#管理外ベース設定とプロジェクト-trust)
 - [ゲートガード](#ゲートガード)
 - [共有ルールとスキルレイヤー](#共有ルールとスキルレイヤー)
+- [Claude Code codex プラグイン — pin と収束](#claude-code-codex-プラグイン--pin-と収束)
 - [関連ドキュメント](#関連ドキュメント)
 
 ---
@@ -35,7 +38,7 @@
 | `home/dot_codex/symlink_AGENTS.md.tmpl` | `~/.codex/AGENTS.md -> ~/AGENTS.md` | `~/.codex-r06/AGENTS.md -> ~/AGENTS.md` |
 | `home/dot_codex/symlink_skills.tmpl` | `~/.codex/skills -> ~/.agents/skills` | `~/.codex-r06/skills -> ~/.agents/skills` |
 
-加えて `home/dot_codex/private_agent.config.toml.tmpl` → `~/.codex/agent.config.toml`（0600）があり、これはスキルが使う非対話 workspace-write プロファイルです（後述の `agent` プロファイルの注記を参照）。`home/dot_codex-r06/` には同じファイル群が含まれています；テンプレート本体は同じ `home/.chezmoitemplates/` ソースを指す同一の 1 行です。
+加えて `home/dot_codex/private_agent.config.toml.tmpl` → `~/.codex/agent.config.toml`（0600）があり、これはスキルが使う非対話 workspace-write プロファイルです（[agent.config.toml — agent プロファイル](#agentconfigtoml--agent-プロファイル) を参照）。`home/dot_codex-r06/` には同じファイル群が含まれています；テンプレート本体は同じ `home/.chezmoitemplates/` ソースを指す同一の 1 行です。
 
 ---
 
@@ -101,6 +104,37 @@ multi_agent = true
 
 ---
 
+## agent.config.toml — agent プロファイル
+
+`home/.chezmoitemplates/codex-agent-config.toml` が設定本体で、`dot_codex/private_agent.config.toml.tmpl` と `dot_codex-r06/private_agent.config.toml.tmpl` の両方からインクルードされ、両アカウントに `$CODEX_HOME/agent.config.toml`（mode 0600）としてデプロイされます。`--profile agent` で選択される named `agent` プロファイルであり、Codex が実装ワーカーや CI 修正ワーカーとして動くときにスキルが使う非対話ポスチャです。
+
+`shared` と同様に `codex-model-pin.toml` から model pin をインクルードします。2 つのプロファイルを分けるのは permission キーです（レンダリング結果、コメント省略）：
+
+```toml
+personality = "pragmatic"
+model = "gpt-5.6-terra"
+model_reasoning_effort = "xhigh"
+sandbox_mode = "workspace-write"
+approval_policy = "never"
+web_search = "cached"
+
+[features]
+multi_agent = true
+
+[sandbox_workspace_write]
+network_access = false
+```
+
+- `sandbox_mode = "workspace-write"` — Codex はワークスペース内のファイルを編集できます。保護パス（`.git`、`.agents`、`.codex`）は再帰的に read-only のままのため、Codex は git 状態を stage・commit・その他の書き込みできません。親の Claude セッションが diff をレビューしてコミットします。
+- `approval_policy = "never"` — 承認プロンプトに応答できる人間がいない非対話 `codex exec` 実行に必要です。
+- `web_search = "cached"` と `network_access = false` — デフォルトではライブネットワークなし。本当にネットワークアクセスが必要な呼び出し側だけが、呼び出しごとにオプトインします（`-c sandbox_workspace_write.network_access=true`）。このオプトイン境界はポリシー統制であり技術統制ではありません — `-c` オーバーライドはプロファイル値より優先されます。この区別は `codex` skill が所有します。
+
+このプロファイルは自己完結です：その permission ポスチャは、管理外のベース `~/.codex/config.toml` のどのキーにも依存しません。
+
+使い分け：実装と CI 修正タスクは `--profile agent` で実行し、レビュータスクは `--profile shared --sandbox read-only`（推奨は `codex exec review` 経由）に留めます。完全な呼び出し契約 — fail-closed なワークツリーガード、禁止フラグ、diff レビューをホスト側検証より先に行う順序 — は `codex` skill（`home/dot_agents/skills/codex/SKILL.md`）が所有しており、このページでは意図的に再掲しません。
+
+---
+
 ## テンプレート SSOT — アカウントドリフト防止
 
 `dot_codex/` と `dot_codex-r06/` にはそれぞれ薄い 1 行テンプレートファイルが含まれています：
@@ -111,6 +145,9 @@ multi_agent = true
 
 # dot_codex/private_shared.config.toml.tmpl (および dot_codex-r06/private_shared.config.toml.tmpl)
 {{ includeTemplate "codex-shared-config.toml" . }}
+
+# dot_codex/private_agent.config.toml.tmpl (および dot_codex-r06/private_agent.config.toml.tmpl)
+{{ includeTemplate "codex-agent-config.toml" . }}
 ```
 
 実際の本体は `home/.chezmoitemplates/` にのみ存在します。両方のアカウントディレクトリが同じテンプレートを参照するため、ドリフトは構造的に不可能です — テンプレートを編集すると次の `chezmoi apply` で両アカウントがアトミックに更新されます。
@@ -138,6 +175,24 @@ cdx-r06  → CODEX_HOME=$HOME/.codex-r06 codex --profile shared "$@"
 ### 素の codex は SSOT 設定をスキップする
 
 エイリアスなしの直接 `codex` 呼び出しは `shared.config.toml` を**ロードしません**。`--profile shared` フラグが適用する唯一のメカニズムです。これは意図的なもの（Codex ではプロファイルはオプトイン）ですが、`codex` を直接呼び出すスクリプト、CI、またはエディタ統合では気づきにくい落とし穴です。
+
+---
+
+## 管理外ベース設定とプロジェクト trust
+
+### ~/.codex/config.toml は意図的に管理外
+
+ベースの `$CODEX_HOME/config.toml` は Codex CLI 自身が書き込むファイルであり、意図的に — かつ恒久的に — chezmoi 管理**外**です。理由は 3 つ：
+
+- CLI がランタイムでこのファイルを書き換える（プロジェクト trust 決定、モデル移行通知）ため、chezmoi 管理下では `apply` のたびに衝突します。
+- `chezmoi apply` がユーザー承認済みの `[projects.*] trust_level` エントリを戻してしまいます。
+- コミットすると無関係なプロジェクトの絶対パスが public リポジトリに漏れます。
+
+コストは、既知の許容されたドリフト源が残ることです：ベース設定は SSOT pin とは独立に古くなる model 設定の独自コピーを持ちます。プロファイルベースの呼び出し（`--profile shared` / `--profile agent`）はその上にレイヤーされるため影響を受けません。素の `codex` 実行は管理外ベース設定だけで解決されます（[素の codex は SSOT 設定をスキップする](#素の-codex-は-ssot-設定をスキップする) を参照）。
+
+### プロジェクト trust ポリシー
+
+本リポジトリは、どの Codex 設定においても `trust_level = "trusted"` で `[projects.*]` に決して追加しません。untrusted-by-default の状態は load-bearing です：Codex は untrusted プロジェクトの project-local `.codex/` 設定レイヤーを読み込まないため、これが、悪意ある PR ブランチが自身の権限を広げる `.codex/` 設定を持ち込むことへの防御になります。
 
 ---
 
@@ -219,6 +274,31 @@ graph LR
 ```
 
 プロベナンス分類（curated / external / system / evolved / unmanaged）とスキルの追加方法については、[スキルプロベナンス](skills-provenance.ja.md) を参照してください。
+
+---
+
+## Claude Code codex プラグイン — pin と収束
+
+Claude Code 側は `openai-codex` marketplace の `codex` プラグインを通じて Codex に到達します。バージョン pin は `home/dot_claude/settings.json` の `extraKnownMarketplaces.openai-codex.source.ref` にあります — このキーが SSOT であり、このページではバージョン文字列を意図的に再掲しません。
+
+### インストール済みバージョンの収束
+
+プラグインセットアップスクリプト（`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`）はプラグインが存在しない場合にのみインストールします：install ループはプラグイン名の一致だけで skip し、バージョン比較を行いません。したがって `ref` pin の編集だけでは、インストール済みプラグインは決して収束しません — これは既知のギャップです（スクリプトへの reconcile 実装は意図的に先送り）。収束は手動で、アカウント（`CLAUDE_CONFIG_DIR`）ごとに 1 回実行します：
+
+```bash
+claude plugin marketplace update openai-codex
+claude plugin update codex@openai-codex
+```
+
+反映には、その後 Claude Code の再起動が必要です（`claude plugin update` 自身が "restart required to apply" と報告します）。
+
+### codex:codex-rescue — 手動レスキュー専用
+
+プラグインの `codex:codex-rescue` サブエージェントは、skill orchestration（`pr-workflow` / `sdd` / `multi-review`）からは決して呼び出されません。人間が直接ループに入る ad-hoc な手動レスキュー用途にのみ残されています。これは第二の、統制外の permission path であり、既知のギャップがあります：
+
+- `--profile` を渡さないため、SSOT プロファイルではなく管理外ベース設定に対して解決されます。
+- `CODEX_HOME` を伝播しないため、`cld-r06` セッションから呼び出しても個人の `~/.codex` アカウントに作用します — アカウント分離のリークです。
+- デフォルトで write 可能な実行になり、`approval_policy: "never"` が付きます。
 
 ---
 

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -14,12 +14,15 @@ This document covers the OpenAI Codex CLI harness configuration deployed by this
 - [Two-account model](#two-account-model)
 - [hooks.json — PreToolUse gateguard](#hooksjson--pretooluse-gateguard)
 - [shared.config.toml — the shared profile](#sharedconfigtoml--the-shared-profile)
+- [agent.config.toml — the agent profile](#agentconfigtoml--the-agent-profile)
 - [Template SSOT — preventing account drift](#template-ssot--preventing-account-drift)
 - [--profile shared mechanism](#--profile-shared-mechanism)
   - [cdx / cdx-r06 aliases](#cdx--cdx-r06-aliases)
   - [Bare codex skips the SSOT config](#bare-codex-skips-the-ssot-config)
+- [The unmanaged base config and project trust](#the-unmanaged-base-config-and-project-trust)
 - [Gateguard](#gateguard)
 - [Shared rule and skill layers](#shared-rule-and-skill-layers)
+- [Claude Code codex plugin — pin and convergence](#claude-code-codex-plugin--pin-and-convergence)
 - [See also](#see-also)
 
 ---
@@ -35,7 +38,7 @@ Each `CODEX_HOME` receives an identical file set. Both are rendered from the sam
 | `home/dot_codex/symlink_AGENTS.md.tmpl` | `~/.codex/AGENTS.md -> ~/AGENTS.md` | `~/.codex-r06/AGENTS.md -> ~/AGENTS.md` |
 | `home/dot_codex/symlink_skills.tmpl` | `~/.codex/skills -> ~/.agents/skills` | `~/.codex-r06/skills -> ~/.agents/skills` |
 
-There is also `home/dot_codex/private_agent.config.toml.tmpl` → `~/.codex/agent.config.toml` (0600), the non-interactive workspace-write profile used by skills (see the `agent` profile note below). `home/dot_codex-r06/` contains the same files; their template bodies are identical one-liners pointing to the same `home/.chezmoitemplates/` sources.
+There is also `home/dot_codex/private_agent.config.toml.tmpl` → `~/.codex/agent.config.toml` (0600), the non-interactive workspace-write profile used by skills (see [agent.config.toml — the agent profile](#agentconfigtoml--the-agent-profile)). `home/dot_codex-r06/` contains the same files; their template bodies are identical one-liners pointing to the same `home/.chezmoitemplates/` sources.
 
 ---
 
@@ -101,6 +104,37 @@ This file is deployed as `$CODEX_HOME/shared.config.toml` (mode 0600, via chezmo
 
 ---
 
+## agent.config.toml — the agent profile
+
+`home/.chezmoitemplates/codex-agent-config.toml` is the config body, included by both `dot_codex/private_agent.config.toml.tmpl` and `dot_codex-r06/private_agent.config.toml.tmpl` and deployed as `$CODEX_HOME/agent.config.toml` (mode 0600) to both accounts. It is the named `agent` profile selected with `--profile agent` — the non-interactive posture skills use when Codex acts as an implementation or CI-fix worker.
+
+Like `shared`, it includes the model pin from `codex-model-pin.toml`; the permission keys are what set the two profiles apart (rendered, comments elided):
+
+```toml
+personality = "pragmatic"
+model = "gpt-5.6-terra"
+model_reasoning_effort = "xhigh"
+sandbox_mode = "workspace-write"
+approval_policy = "never"
+web_search = "cached"
+
+[features]
+multi_agent = true
+
+[sandbox_workspace_write]
+network_access = false
+```
+
+- `sandbox_mode = "workspace-write"` — Codex may edit files inside the workspace. Protected paths stay read-only recursively (`.git`, `.agents`, `.codex`), so Codex cannot stage, commit, or otherwise write git state: the parent Claude session reviews the diff and commits.
+- `approval_policy = "never"` — required for non-interactive `codex exec` runs, which have no human available to answer approval prompts.
+- `web_search = "cached"` and `network_access = false` — no live network by default. A call site that genuinely needs network access opts in per invocation (`-c sandbox_workspace_write.network_access=true`). The opt-in boundary is a policy control, not a technical one — `-c` overrides take precedence over profile values; the `codex` skill owns that distinction.
+
+The profile is self-contained: its permission posture does not depend on any key in the unmanaged base `~/.codex/config.toml`.
+
+Division of use: implementation and CI-fix tasks run `--profile agent`; review tasks stay on `--profile shared --sandbox read-only` (preferably via `codex exec review`). The full invocation contract — the fail-closed worktree guard, the prohibited flags, and the diff-review-before-host-verification ordering — is owned by the `codex` skill (`home/dot_agents/skills/codex/SKILL.md`); this page deliberately does not restate it.
+
+---
+
 ## Template SSOT — preventing account drift
 
 `dot_codex/` and `dot_codex-r06/` each contain thin one-liner template files:
@@ -111,6 +145,9 @@ This file is deployed as `$CODEX_HOME/shared.config.toml` (mode 0600, via chezmo
 
 # dot_codex/private_shared.config.toml.tmpl (and dot_codex-r06/private_shared.config.toml.tmpl)
 {{ includeTemplate "codex-shared-config.toml" . }}
+
+# dot_codex/private_agent.config.toml.tmpl (and dot_codex-r06/private_agent.config.toml.tmpl)
+{{ includeTemplate "codex-agent-config.toml" . }}
 ```
 
 The real bodies live exclusively in `home/.chezmoitemplates/`. Because both account directories reference the same template, they cannot diverge — editing the template changes both accounts atomically on the next `chezmoi apply`.
@@ -138,6 +175,24 @@ cdx-r06  → CODEX_HOME=$HOME/.codex-r06 codex --profile shared "$@"
 ### Bare codex skips the SSOT config
 
 A direct `codex` invocation — without the aliases — does **not** load `shared.config.toml`. The `--profile shared` flag is the only mechanism that applies it. This is intentional (profiles are opt-in in Codex), but easy to trip over in scripts, CI, or editor integrations that invoke `codex` directly.
+
+---
+
+## The unmanaged base config and project trust
+
+### ~/.codex/config.toml is intentionally unmanaged
+
+The base `$CODEX_HOME/config.toml` is written by the Codex CLI itself and is deliberately — and permanently — **not** chezmoi-managed. Three reasons:
+
+- The CLI rewrites the file at runtime (project trust decisions, model-migration notices), so chezmoi would fight it on every `apply`.
+- `chezmoi apply` would revert user-approved `[projects.*] trust_level` entries.
+- Committing it would leak absolute paths of unrelated projects into a public repository.
+
+The cost is a known, accepted drift source: the base config carries its own copy of model settings that ages independently of the SSOT pin. Profile-based invocations (`--profile shared` / `--profile agent`) layer over it and are unaffected; a bare `codex` run resolves against the unmanaged base config alone (see [Bare codex skips the SSOT config](#bare-codex-skips-the-ssot-config)).
+
+### Project trust policy
+
+This repository is never added to `[projects.*]` with `trust_level = "trusted"` in any Codex config. The untrusted-by-default status is load-bearing: Codex skips project-local `.codex/` config layers for untrusted projects, which is the defense against a malicious PR branch carrying a `.codex/` config that would otherwise widen its own permissions.
 
 ---
 
@@ -219,6 +274,31 @@ graph LR
 ```
 
 For the provenance taxonomy (curated / external / system / evolved / unmanaged) and how skills are added, see [Skills provenance](skills-provenance.md).
+
+---
+
+## Claude Code codex plugin — pin and convergence
+
+The Claude Code side reaches Codex through the `codex` plugin from the `openai-codex` marketplace. Its version pin lives in `home/dot_claude/settings.json` under `extraKnownMarketplaces.openai-codex.source.ref` — that key is the SSOT; this page intentionally does not restate the version string.
+
+### Converging the installed version
+
+The plugin setup script (`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`) installs a plugin only when it is absent: its install loop skips on a plugin-name match alone, with no version comparison. Editing the `ref` pin therefore never converges an already-installed plugin — a known gap (implementing reconciliation in the script is deliberately deferred). Convergence is manual, run once per account (`CLAUDE_CONFIG_DIR`):
+
+```bash
+claude plugin marketplace update openai-codex
+claude plugin update codex@openai-codex
+```
+
+A Claude Code restart is required afterwards for the updated plugin to take effect (`claude plugin update` itself reports "restart required to apply").
+
+### codex:codex-rescue — manual rescue only
+
+The plugin's `codex:codex-rescue` subagent is never invoked by skill orchestration (`pr-workflow` / `sdd` / `multi-review`); it stays available for ad-hoc manual rescue, where a human is directly in the loop. It is a second, ungoverned permission path with known gaps:
+
+- It does not pass `--profile`, so it resolves against the unmanaged base config rather than the SSOT profiles.
+- It does not propagate `CODEX_HOME`, so invoked from a `cld-r06` session it acts on the personal `~/.codex` account — an account-isolation leak.
+- It defaults to write-capable runs with `approval_policy: "never"`.
 
 ---
 

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -108,12 +108,9 @@ This file is deployed as `$CODEX_HOME/shared.config.toml` (mode 0600, via chezmo
 
 `home/.chezmoitemplates/codex-agent-config.toml` is the config body, included by both `dot_codex/private_agent.config.toml.tmpl` and `dot_codex-r06/private_agent.config.toml.tmpl` and deployed as `$CODEX_HOME/agent.config.toml` (mode 0600) to both accounts. It is the named `agent` profile selected with `--profile agent` — the non-interactive posture skills use when Codex acts as an implementation or CI-fix worker.
 
-Like `shared`, it includes the model pin from `codex-model-pin.toml`; the permission keys are what set the two profiles apart (rendered, comments elided):
+Like `shared`, it includes the model pin from `codex-model-pin.toml` (values live there and are not restated here); the permission keys are what set the two profiles apart:
 
 ```toml
-personality = "pragmatic"
-model = "gpt-5.6-terra"
-model_reasoning_effort = "xhigh"
 sandbox_mode = "workspace-write"
 approval_policy = "never"
 web_search = "cached"
@@ -125,7 +122,7 @@ multi_agent = true
 network_access = false
 ```
 
-- `sandbox_mode = "workspace-write"` — Codex may edit files inside the workspace. Protected paths stay read-only recursively (`.git`, `.agents`, `.codex`), so Codex cannot stage, commit, or otherwise write git state: the parent Claude session reviews the diff and commits.
+- `sandbox_mode = "workspace-write"` — Codex may edit files inside the workspace. Protected paths stay read-only recursively (`.git`, `.agents`, `.codex`) — an enforcement the Codex CLI itself provides, not something this profile declares — so Codex cannot stage, commit, or otherwise write git state: the parent Claude session reviews the diff and commits.
 - `approval_policy = "never"` — required for non-interactive `codex exec` runs, which have no human available to answer approval prompts.
 - `web_search = "cached"` and `network_access = false` — no live network by default. A call site that genuinely needs network access opts in per invocation (`-c sandbox_workspace_write.network_access=true`). The opt-in boundary is a policy control, not a technical one — `-c` overrides take precedence over profile values; the `codex` skill owns that distinction.
 
@@ -286,11 +283,16 @@ The Claude Code side reaches Codex through the `codex` plugin from the `openai-c
 The plugin setup script (`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`) installs a plugin only when it is absent: its install loop skips on a plugin-name match alone, with no version comparison. Editing the `ref` pin therefore never converges an already-installed plugin — a known gap (implementing reconciliation in the script is deliberately deferred). Convergence is manual, run once per account (`CLAUDE_CONFIG_DIR`):
 
 ```bash
+# default account (~/.claude)
 claude plugin marketplace update openai-codex
 claude plugin update codex@openai-codex
+
+# work account (~/.claude-r06)
+CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace update openai-codex
+CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin update codex@openai-codex
 ```
 
-A Claude Code restart is required afterwards for the updated plugin to take effect (`claude plugin update` itself reports "restart required to apply").
+A Claude Code restart is required afterwards for the updated plugin to take effect (`claude plugin update` itself reports "restart required to apply"). One caveat for a future ref bump: the marketplace registration keeps its own copy of the source ref (in the runtime's `known_marketplaces.json`), and `marketplace update` pulls from that stored registration — so after changing the `settings.json` pin, verify the registered ref and re-register the marketplace (`claude plugin marketplace rm` + `add`) if it lags.
 
 ### codex:codex-rescue — manual rescue only
 


### PR DESCRIPTION
## Summary

Fourth and final PR implementing #330, per the finalized PRD
(`.claude/prds/330-model-tier-codex-permissions.prd.md`, merged in PR-2; the 4-PR
packaging is its Resolved Decision 4). Intent gate: skipped — the PRD was finalized and
user-approved on 2026-07-25, and a fresh gap investigation against `main` confirmed the
PR-4 scope unchanged before implementation.

Docs-only diff (`docs/agents/codex.md` + `codex.ja.md`, EN/JA in lockstep):

- **`agent` profile section (AC-026)**: both pages forward-referenced an `agent` profile
  section (lines 38/89) that was never written. It now exists: rendered permission keys
  from the SSOT template, the protected-path/commit division of labour (Codex edits, the
  parent commits), the network opt-in documented as a policy control rather than a
  technical one, and a pointer to the `codex` skill as the invocation-contract SSOT —
  deliberately restating no values.
- **Unmanaged base config + project trust (AC-026, AC-027)**: `~/.codex/config.toml` is
  documented as an intentional, permanent unmanaged drift source (three reasons), and the
  untrusted-by-default policy is documented as load-bearing: this repo is never added to
  `[projects.*] trust_level = "trusted"`, because untrusted projects skip project-local
  `.codex/` config layers — the defense against malicious PR branches.
- **Plugin pin and convergence (AC-024 docs)**: the convergence procedure
  (`claude plugin marketplace update` + `claude plugin update` per `CLAUDE_CONFIG_DIR`,
  restart required to apply) and the setup script's known gap (name-match-only skip, no
  version reconcile) are recorded; the version string stays a SSOT pointer to the
  `settings.json` ref pin, never a literal.
- **codex-rescue positioning (AC-012 docs)**: manual-rescue-only, never invoked by skill
  orchestration, with its three known gaps (no `--profile`, no `CODEX_HOME` propagation →
  account-isolation leak from `cld-r06`, write-by-default + `approval_policy: never`).

## Plugin convergence verification (AC-024, post-hoc)

Observed machine state at implementation time — **the convergence has already completed**,
so this PR records and verifies it rather than performing it:

| Check | Result |
|---|---|
| Installed version, `~/.claude` | 1.0.6, `.in_use`, gitCommitSha `db52e28f` |
| Installed version, `~/.claude-r06` | 1.0.6, same SHA (no 1.0.4 in this account's cache at all) |
| Marketplace clone | `db52e28` "Remove shell expansion for git commands (#447)", tagged `v1.0.6` — the `shell: false` hardening commit |
| `settings.json` ref pin | `v1.0.6` — matches the installed state |
| Orphan marker | now on **1.0.4** (`~/.claude` cache only) |

Note the transition direction is the opposite of the PRD's correction-3 snapshot
(then: 1.0.4 installed, 1.0.6 orphaned). Convergence happened between that snapshot
(2026-07-25) and this PR; recovery from the orphaned-1.0.6 cache state is confirmed by
1.0.6 now being the in-use install on both accounts. The setup script still has no
version-reconcile path — documented as a known gap per the PRD (implementation optional,
deliberately deferred).

## Review

Implemented via sdd with a two-reviewer team (code-quality, security), both verifying
claims against the live machine and SSOT files. Both APPROVE. One MUST was fixed:
the agent-profile section enumerated the three prohibited-flag values in the same
sentence that declared it would not restate the invocation contract — the values are
removed so the `codex` skill remains the sole copy. Two security SHOULDs were adopted:
the restart-required note on the convergence procedure (verified against
`claude plugin update --help`), and the policy-vs-technical-control note on the network
opt-in.

## AC-029 checklist

Every "Current state" row and every decision row of #330 §3/§5, with disposition.

### Current state — Claude side

| Row | Disposition | Where / why |
|---|---|---|
| `settings.json` model pin stale (`claude-opus-4-8[1m]`) | updated | PR-3: literal `claude-opus-5[1m]` (AC-013) |
| `settings.json` missing `effortLevel` | updated | PR-3: `"xhigh"` adopted into the repo (AC-014) |
| `docs/agents/claude-code.md` / `.ja.md` stale pin rows | updated | PR-3: FACT marker + string-comparison bats assertion (AC-025) |
| `fable-orchestrator-prompt.md` silent on effort | updated | PR-3: effort axis documented (AC-030) |
| `pr-workflow` model-tier policy, no effort axis | updated | PR-3 delegation rewires add the effort axis |
| `pr-workflow:79` small tier → sonnet | kept | already correct |
| `sdd:330` review agents → sonnet | kept, extended | PR-3 adds `effort: high` pins to review delegation |
| `sdd:644` Haiku claim not pinned | updated | PR-3: Explore pinned by task shape — haiku for verbatim retrieval, sonnet for pattern recognition (AC-019) |
| `multi-review:581-582` reviewers on `inherit` | updated | PR-3: sonnet + `effort: xhigh`, cost note inverted to caller opt-in (AC-015) |
| `multi-review:83,100` specialists → sonnet | kept, extended | PR-3: `effort: high` floor pins (AC-017) |
| 8 agent definitions: `inherit` ×3 / `sonnet` ×5 | updated | PR-3: every finding-generating agent pins `model`; `adversarial-verifier` added (AC-015/016/017/018) |
| No agent definition pins `effort` | updated | PR-3: every finding-generating agent pins both axes, bats-swept |

### Current state — Codex / GPT side

| Row | Disposition | Where / why |
|---|---|---|
| `codex-shared-config.toml` on `gpt-5.5` | updated | PR-2: `gpt-5.6-terra` @ xhigh via the `codex-model-pin.toml` SSOT fragment, smoke-tested first (AC-001/006) |
| `shared` profile carries no permission keys | intentionally held back | permissions live in the new `agent` profile; `shared` stays conservative (Option C, AC-004) |
| Both accounts include the shared template | kept, extended | PR-2 deploys the `agent` profile to both accounts the same dual-account way (AC-003) |
| Unmanaged `~/.codex/config.toml` drifts independently | documented (this PR) | intentionally-unmanaged drift source, three reasons; chezmoi-managing it was rejected (PRD alt 8) |
| `codex/SKILL.md` documents deprecated `--full-auto` | updated | PR-1: removed entirely (AC-008) |
| `codex/SKILL.md` pins every example `read-only` | updated | PR-1/2: `--profile agent` shape for implementation/CI-fix; review stays read-only |
| `codex/SKILL.md:90` stale version/model prose | updated | PR-1/2: replaced by a pointer to the SSOT template |
| `codex:codex-rescue` old assumptions, no profile | excluded + documented | PR-3 bars it from skill orchestration (AC-012); this PR documents the positioning and gaps |
| `codex:codex-cli-runtime` spark hardcode | intentionally skipped | upstream-managed, not ours to fix (PRD out-of-scope) |
| Plugin pin `v1.0.6` vs installed 1.0.4 | converged + verified (this PR) | see the AC-024 table above |

### §3 use table

| Use | Disposition | Where / why |
|---|---|---|
| `multi-review` Codex leg via `codex exec review --base` | adopted | PR-3, heredoc-diff shape kept as documented fallback (AC-009) |
| Codex as implementation worker | adopted | PR-3: small-tier / self-contained sdd tasks, `--profile agent`, parent commits (AC-010) |
| Codex fixing CI failures | adopted | PR-3: triage-diagnosis handoff, parent fetches logs (AC-011) |
| Codex verifying its own claims | adopted via config route | `codex exec` has no `--search`; the verified `-c web_search="live"` route is documented in the codex skill with untrusted-input handling (AC-007) |
| Codex running git / `gh` writes | not adopted | `.git` protected by design; lifting it would bypass gitleaks + commit signing (PRD alt 15) |
| Codex running `chezmoi apply` | not adopted | target is `$HOME`, outside any workspace root; protected paths (PRD alt 14) |

### §5 delegation table

| Phase | Disposition | Where / why |
|---|---|---|
| `pr-workflow` Phase 5 CI log triage | adopted, refined | PR-3: Haiku first-pass **sequentially escalating** to Sonnet (serial gate, not fan-out); summary diagnoses only (AC-020) |
| `pr-workflow` Phase 6 adversarial verify | adopted | PR-3: 3 × `adversarial-verifier` (sonnet @ xhigh) with distinct framings (AC-018) |
| `pr-workflow` Phase 0 classification | skipped | one judgment call feeding the GATEs; stays inline (per the Issue) |
| `sdd` Phase 1/2 Explore research | adopted, refined | PR-3: pinned by task shape, not uniform haiku (AC-019; PRD alt 9) |
| `sdd` Phase 3 task decomposition | skipped | the design judgment itself; stays with the Leader |
| `sdd` Phase 4 implementation | partially delegated | PR-3: self-contained single-task items → Sonnet/Codex worker; multi-file work stays with the Leader (AC-010) |
| `sdd` Phase 5 review agents | kept, effort added | PR-3: `effort: high` so a low-effort session cannot degrade review |
| `multi-review` Phase 3 fact-checking | adopted | PR-3: per-finding `fact-check-worker` fan-out; synthesis stays with the parent (AC-021) |
| `multi-review` Phase 4 dedup | skipped | needs every finding and existing review in one view; stays with the parent |
| `cc-code-review` / `cc-security-review` off `inherit` | adopted | PR-3: sonnet + xhigh with caller opt-in inversion (AC-015) |
| Advisor tool (API beta) | not adopted | no Claude Code surface exists; the cheap-worker/expensive-judge shape is implemented natively (PRD alt 13) |

## Test

- `make test` green (lint + 177 bats, including `docs_facts.bats` and the EN/JA mirror
  existence checks); EN/JA heading structure verified identical by line-number diff.

Refs #330
