### PR TITLE
fix(clv2): move the homunculus dir out of the Claude config dir so instincts can be written

### DIFF
--- a/docs/agents/account-isolation.ja.md
+++ b/docs/agents/account-isolation.ja.md
@@ -18,12 +18,14 @@
 |---|---|---|
 | `CLAUDE_CONFIG_DIR` | `~/.claude` | `~/.claude-r06` |
 | `ECC_AGENT_DATA_HOME` | `~/.claude` | `~/.claude-r06` |
-| `CLV2_HOMUNCULUS_DIR` | `~/.claude/ecc-homunculus` | `~/.claude-r06/ecc-homunculus` |
+| `CLV2_HOMUNCULUS_DIR` | `~/.local/share/ecc-homunculus-default` | `~/.local/share/ecc-homunculus-r06` |
 | `ECC_MCP_HEALTH_STATE_PATH` | `~/.claude/mcp-health-cache.json` | `~/.claude-r06/mcp-health-cache.json` |
 | `GATEGUARD_STATE_DIR` | `~/.claude/.gateguard` | `~/.claude-r06/.gateguard` |
 | `CODEX_HOME` | （デフォルト — `~/.codex`） | `~/.codex-r06` |
 
 r06 の Claude 設定ディレクトリ（`~/.claude-r06`）には、すべての設定アーティファクト（settings、agents、commands、skills）が `~/.claude` を指すシンボリックリンクのみが含まれます。アカウント間で異なるのは、これらの環境変数がツールに書き込むよう指示するランタイム状態のみです。
+
+`CLV2_HOMUNCULUS_DIR` だけは `~/.claude` / `~/.claude-r06` の外、`~/.local/share/` 配下に完全に置かれています。Claude Code は config dir 配下のすべてのパスを sensitive file として扱い Write に対話承認を要求しますが、CLV2 の解析セッションは headless（`claude --model haiku --print`）で動くためその承認を得ることができず、instinct の書き込みがすべて失敗していました（issue #336）。他のアカウント別変数（`CLAUDE_CONFIG_DIR`、`ECC_AGENT_DATA_HOME`、`ECC_MCP_HEALTH_STATE_PATH`、`GATEGUARD_STATE_DIR`）が config dir 配下のままなのは、それらが Claude Code の Write ツールを経由せず node / shell コードから直接書き込まれるため、このゲートに引っかからないからです。
 
 ---
 
@@ -67,9 +69,16 @@ _claude_with_home() {
   local home_dir="$1"
   shift
   (($#)) || set -- claude
+  local account_dir_name="${home_dir:t}"
+  local homunculus_slug
+  case "$account_dir_name" in
+    .claude) homunculus_slug=default ;;
+    .claude-*) homunculus_slug="${account_dir_name#.claude-}" ;;
+    *) homunculus_slug="$account_dir_name" ;;
+  esac
   CLAUDE_CONFIG_DIR="$home_dir" \
     ECC_AGENT_DATA_HOME="$home_dir" \
-    CLV2_HOMUNCULUS_DIR="$home_dir/ecc-homunculus" \
+    CLV2_HOMUNCULUS_DIR="$HOME/.local/share/ecc-homunculus-${homunculus_slug}" \
     ECC_MCP_HEALTH_STATE_PATH="$home_dir/mcp-health-cache.json" \
     GATEGUARD_STATE_DIR="$home_dir/.gateguard" \
     EXA_API_KEY="${EXA_API_KEY:-}" \

--- a/docs/agents/account-isolation.ja.md
+++ b/docs/agents/account-isolation.ja.md
@@ -74,7 +74,7 @@ _claude_with_home() {
   case "$account_dir_name" in
     .claude) homunculus_slug=default ;;
     .claude-*) homunculus_slug="${account_dir_name#.claude-}" ;;
-    *) homunculus_slug="$account_dir_name" ;;
+    *) homunculus_slug="${account_dir_name#.}" ;;
   esac
   CLAUDE_CONFIG_DIR="$home_dir" \
     ECC_AGENT_DATA_HOME="$home_dir" \

--- a/docs/agents/account-isolation.md
+++ b/docs/agents/account-isolation.md
@@ -74,7 +74,7 @@ _claude_with_home() {
   case "$account_dir_name" in
     .claude) homunculus_slug=default ;;
     .claude-*) homunculus_slug="${account_dir_name#.claude-}" ;;
-    *) homunculus_slug="$account_dir_name" ;;
+    *) homunculus_slug="${account_dir_name#.}" ;;
   esac
   CLAUDE_CONFIG_DIR="$home_dir" \
     ECC_AGENT_DATA_HOME="$home_dir" \

--- a/docs/agents/account-isolation.md
+++ b/docs/agents/account-isolation.md
@@ -18,12 +18,14 @@ These variables are set inline on the agent subprocess — they are never export
 |---|---|---|
 | `CLAUDE_CONFIG_DIR` | `~/.claude` | `~/.claude-r06` |
 | `ECC_AGENT_DATA_HOME` | `~/.claude` | `~/.claude-r06` |
-| `CLV2_HOMUNCULUS_DIR` | `~/.claude/ecc-homunculus` | `~/.claude-r06/ecc-homunculus` |
+| `CLV2_HOMUNCULUS_DIR` | `~/.local/share/ecc-homunculus-default` | `~/.local/share/ecc-homunculus-r06` |
 | `ECC_MCP_HEALTH_STATE_PATH` | `~/.claude/mcp-health-cache.json` | `~/.claude-r06/mcp-health-cache.json` |
 | `GATEGUARD_STATE_DIR` | `~/.claude/.gateguard` | `~/.claude-r06/.gateguard` |
 | `CODEX_HOME` | (default — `~/.codex`) | `~/.codex-r06` |
 
 The r06 Claude config directory (`~/.claude-r06`) contains only symlinks pointing back to `~/.claude` for every config artifact (settings, agents, commands, skills). What differs between accounts is entirely in the state that these env vars direct the tools to write.
+
+`CLV2_HOMUNCULUS_DIR` is the one directory that lives entirely outside `~/.claude` / `~/.claude-r06`, under `~/.local/share/`: Claude Code treats every path under the config dir as a sensitive file requiring interactive Write approval, and the CLV2 analysis session runs headless (`claude --model haiku --print`), so it could never grant that approval and every instinct write failed (issue #336). The other per-account vars (`CLAUDE_CONFIG_DIR`, `ECC_AGENT_DATA_HOME`, `ECC_MCP_HEALTH_STATE_PATH`, `GATEGUARD_STATE_DIR`) stay under the config dir because they are written directly by node/shell code rather than through Claude Code's Write tool, so they never hit that gate.
 
 ---
 
@@ -67,9 +69,16 @@ _claude_with_home() {
   local home_dir="$1"
   shift
   (($#)) || set -- claude
+  local account_dir_name="${home_dir:t}"
+  local homunculus_slug
+  case "$account_dir_name" in
+    .claude) homunculus_slug=default ;;
+    .claude-*) homunculus_slug="${account_dir_name#.claude-}" ;;
+    *) homunculus_slug="$account_dir_name" ;;
+  esac
   CLAUDE_CONFIG_DIR="$home_dir" \
     ECC_AGENT_DATA_HOME="$home_dir" \
-    CLV2_HOMUNCULUS_DIR="$home_dir/ecc-homunculus" \
+    CLV2_HOMUNCULUS_DIR="$HOME/.local/share/ecc-homunculus-${homunculus_slug}" \
     ECC_MCP_HEALTH_STATE_PATH="$home_dir/mcp-health-cache.json" \
     GATEGUARD_STATE_DIR="$home_dir/.gateguard" \
     EXA_API_KEY="${EXA_API_KEY:-}" \

--- a/docs/agents/claude-code.ja.md
+++ b/docs/agents/claude-code.ja.md
@@ -458,10 +458,12 @@ kryota-dev/dotfiles#257: launchd LaunchAgent が平日朝に `/morning-brief` �
 |---|---|---|
 | `CLAUDE_CONFIG_DIR` | `~/.claude` | `~/.claude-r06` |
 | `ECC_AGENT_DATA_HOME` | `~/.claude` | `~/.claude-r06` |
-| `CLV2_HOMUNCULUS_DIR` | `~/.claude/ecc-homunculus` | `~/.claude-r06/ecc-homunculus` |
+| `CLV2_HOMUNCULUS_DIR` | `~/.local/share/ecc-homunculus-default` | `~/.local/share/ecc-homunculus-r06` |
 | `GATEGUARD_STATE_DIR` | `~/.claude/.gateguard` | `~/.claude-r06/.gateguard` |
 
 セッション、ガバナンス `state.db`、本能、bash コマンドログ、キャッシュは各ランタイムコードがこれらの環境変数からパスを解決するため自然に分離されます。
+
+`CLV2_HOMUNCULUS_DIR` だけは意図的に config dir の**外**に置き、アカウントをパスのサフィックスで表現しています。Claude Code は config dir 配下の全パスを sensitive file として扱い、書き込み前に対話承認を要求します。一方 CLV2 の分析パスは headless（`claude --model haiku --print`）で承認者がいないため、この変数が `<account>/ecc-homunculus` を指していた間は本能の書き込みが一度も成功しませんでした。observer は承認交渉で turn を使い切り "Reached max turns" で終了し、本能の生成数はゼロのままでした（#336）。他の 3 変数が config dir 配下のままなのは、それらを書くコード（node フック、シェルスクリプト）が Claude Code の Write ツールを経由せず直接書き込むため、sensitive-file ゲートの対象にならないからです。
 
 `cld`/`cld-r06` エイリアスを使わない素の `claude` 呼び出しはこれらの変数がセットされず、`~/.claude` と `$XDG_DATA_HOME/ecc-homunculus` にフォールバックします — エイリアスとは異なる状態の場所です。
 
@@ -480,8 +482,10 @@ kryota-dev/dotfiles#257: launchd LaunchAgent が平日朝に `/morning-brief` �
 | `CLAUDE_PLUGIN_ROOT` | `ecc-hook.sh` | `~/.agents/skills/ecc` に固定；ECC のプラグインフォールバック走査をスキップ |
 | `CLAUDE_CONFIG_DIR` | `cld`/`cld-r06` エイリアス | Claude Code が使用する `~/.claude*` ディレクトリを選択 |
 | `ECC_AGENT_DATA_HOME` | `cld`/`cld-r06` エイリアス | ECC（とフック fork）が状態を書き込む場所 |
-| `CLV2_HOMUNCULUS_DIR` | `cld`/`cld-r06` エイリアス | CLV2 本能/クラスターの homunculus データディレクトリ |
+| `CLV2_HOMUNCULUS_DIR` | `cld`/`cld-r06` エイリアス | CLV2 本能/クラスターの homunculus データディレクトリ。`~/.local/share/ecc-homunculus-<アカウント slug>` に置き、config dir の外に出すことで headless な本能書き込みが sensitive-file ゲートに阻まれないようにしている（#336） |
 | `ECC_OBSERVER_TIMEOUT_SECONDS` | `cld`/`cld-r06` エイリアス | 既定 300。CLV2 observer の watchdog を引き上げ、Haiku 分析が 120s で SIGTERM されるのを防ぐ（#256）。`:-` 形式のため明示 override が優先 |
+| `OBSERVER_ACTIVE_HOURS_START` / `OBSERVER_ACTIVE_HOURS_END` | `cld`/`cld-r06` エイリアス | 両方の既定を `0` にして CLV2 session-guardian の時刻ゲート（upstream 既定 800-2300）を無効化する。この環境ではセッションが深夜帯に及ぶため、時刻ゲートが分析サイクルを丸ごと skip していた。guardian の cooldown ゲートと idle ゲートは引き続きサイクルを抑制する（#336） |
+| `ECC_OBSERVER_MAX_TURNS` | `cld`/`cld-r06` エイリアス | 既定 100（upstream の上限値）。自動スケールの下限 20 では Read → 重複チェック → Write の途中で打ち切られていた。サイクルの実際の上限は turn 数ではなく上記の watchdog が決める（#336） |
 
 ---
 

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -460,10 +460,12 @@ Config is one SSOT; runtime state is isolated by the environment variables set i
 |---|---|---|
 | `CLAUDE_CONFIG_DIR` | `~/.claude` | `~/.claude-r06` |
 | `ECC_AGENT_DATA_HOME` | `~/.claude` | `~/.claude-r06` |
-| `CLV2_HOMUNCULUS_DIR` | `~/.claude/ecc-homunculus` | `~/.claude-r06/ecc-homunculus` |
+| `CLV2_HOMUNCULUS_DIR` | `~/.local/share/ecc-homunculus-default` | `~/.local/share/ecc-homunculus-r06` |
 | `GATEGUARD_STATE_DIR` | `~/.claude/.gateguard` | `~/.claude-r06/.gateguard` |
 
 Sessions, the governance `state.db`, instincts, bash-command logs, and caches are naturally isolated because each piece of runtime code resolves its paths from these environment variables.
+
+`CLV2_HOMUNCULUS_DIR` is the one entry that deliberately sits *outside* the config dir, encoding the account as a path suffix instead. Claude Code classifies every path under the config dir as a sensitive file and asks for interactive approval before a write, while the CLV2 analysis pass runs headless (`claude --model haiku --print`) with nobody to approve it — so no instinct write ever succeeded while this pointed at `<account>/ecc-homunculus`. The observer spent its turn budget negotiating permission, died at "Reached max turns", and produced exactly zero instincts (#336). The other three variables stay under the config dir because the code that writes them (node hooks, shell scripts) writes directly rather than through Claude Code's Write tool, so the sensitive-file gate never applies to them.
 
 A bare `claude` invocation (without the `cld`/`cld-r06` alias) leaves these variables unset and falls back to `~/.claude` and `$XDG_DATA_HOME/ecc-homunculus` — a different state location than the aliases use.
 
@@ -482,8 +484,10 @@ A bare `claude` invocation (without the `cld`/`cld-r06` alias) leaves these vari
 | `CLAUDE_PLUGIN_ROOT` | `ecc-hook.sh` | Fixed to `~/.agents/skills/ecc`; skips ECC's plugin fallback scan |
 | `CLAUDE_CONFIG_DIR` | `cld`/`cld-r06` alias | Selects which `~/.claude*` directory Claude Code uses |
 | `ECC_AGENT_DATA_HOME` | `cld`/`cld-r06` alias | Governs where ECC (and the hook forks) write state |
-| `CLV2_HOMUNCULUS_DIR` | `cld`/`cld-r06` alias | Homunculus data directory for CLV2 instincts/clusters |
+| `CLV2_HOMUNCULUS_DIR` | `cld`/`cld-r06` alias | Homunculus data directory for CLV2 instincts/clusters. Sits at `~/.local/share/ecc-homunculus-<account-slug>`, outside the config dir, so a headless instinct write is not blocked by the sensitive-file gate (#336) |
 | `ECC_OBSERVER_TIMEOUT_SECONDS` | `cld`/`cld-r06` alias | Default 300; raises the CLV2 observer watchdog so the Haiku analysis pass can finish instead of dying at 120s (#256). The `:-` form keeps an explicit override winning |
+| `OBSERVER_ACTIVE_HOURS_START` / `OBSERVER_ACTIVE_HOURS_END` | `cld`/`cld-r06` alias | Both default to `0`, which disables the CLV2 session-guardian clock gate (upstream default 800-2300). Sessions here routinely run past midnight, so that gate skipped analysis cycles wholesale; the guardian's cooldown and idle gates still throttle them (#336) |
+| `ECC_OBSERVER_MAX_TURNS` | `cld`/`cld-r06` alias | Default 100 (the upstream cap) rather than the auto-scaled floor of 20, which cut the Read → dedup-check → Write pass off mid-write. The watchdog above, not the turn ceiling, is what bounds a cycle (#336) |
 
 ---
 

--- a/docs/architecture/lifecycle-scripts.ja.md
+++ b/docs/architecture/lifecycle-scripts.ja.md
@@ -151,7 +151,7 @@ Xcode CLI ツール（macOS、`xcode-select -p` が成功するまでポーリ�
 
 ### 14 — enable-clv2-observer (`run_onchange`、after)
 
-各アカウントの `ecc-homunculus/config.json` に `observer.enabled = true` を `jq` のアトミックマージ（一時ファイルへ書き込み後 `mv`）で設定します。chezmoi 管理の CLV2 スキルディレクトリではなく、per-account のランタイム状態ディレクトリに書き込むことで、external の 168時間リフレッシュサイクルをまたいでフラグが保持されます。PATH の `jq` を優先し、`mise exec -- jq` にフォールバックし、どちらも利用できない場合は非 0 で終了（chezmoi がリトライ）します。
+各アカウントの `~/.local/share/ecc-homunculus-<slug>/config.json`（`<slug>` は `~/.claude` なら `default`、それ以外は `.claude-` 以降のサフィックス）に `observer.enabled = true` を `jq` のアトミックマージ（一時ファイルへ書き込み後 `mv`）で設定します。chezmoi 管理の CLV2 スキルディレクトリではなく、per-account のランタイム状態ディレクトリに書き込むことで、external の 168時間リフレッシュサイクルをまたいでフラグが保持されます。PATH の `jq` を優先し、`mise exec -- jq` にフォールバックし、どちらも利用できない場合は非 0 で終了（chezmoi がリトライ）します。
 
 ### 16 — migrate-claude-binary (`run_once`、after)
 

--- a/docs/architecture/lifecycle-scripts.md
+++ b/docs/architecture/lifecycle-scripts.md
@@ -152,7 +152,7 @@ Registers four user-scope Claude Code MCP servers (`context7`, `deepwiki`, `exa`
 
 ### 14 — enable-clv2-observer (`run_onchange`, after)
 
-Sets `observer.enabled = true` in each per-account `ecc-homunculus/config.json` via an atomic `jq` merge (write to a temp file, `mv` into place). Writes to the per-account runtime state directory rather than the chezmoi-managed CLV2 skill directory so the flag survives the external's 168-hour refresh cycle. Prefers a PATH `jq`; falls back to `mise exec -- jq`; exits non-zero if neither is available (so chezmoi retries).
+Sets `observer.enabled = true` in each per-account `~/.local/share/ecc-homunculus-<slug>/config.json` (`<slug>` is `default` for `~/.claude`, the `.claude-` suffix otherwise) via an atomic `jq` merge (write to a temp file, `mv` into place). Writes to the per-account runtime state directory rather than the chezmoi-managed CLV2 skill directory so the flag survives the external's 168-hour refresh cycle. Prefers a PATH `jq`; falls back to `mise exec -- jq`; exits non-zero if neither is available (so chezmoi retries).
 
 ### 16 — migrate-claude-binary (`run_once`, after)
 

--- a/docs/contributing/ci-and-tests.ja.md
+++ b/docs/contributing/ci-and-tests.ja.md
@@ -72,7 +72,7 @@ lint ジョブは `make lint` を実行する前に、shfmt（`v3.13.1`）を Gi
 
 `_claude_with_home` ヘルパーとアカウントごとのラッパーのふるまいリグレッションガードです。最小限の `zsh -f` 環境（rc ファイルなし）で `claude.zsh` をソースし、基礎となる関数を直接駆動します。主な確認事項：
 
-- `_claude_with_home` が指定したホームディレクトリ配下に複数の環境変数を設定し、指定したコマンドを実行する。テストが確認するのは `CLAUDE_CONFIG_DIR`、`ECC_AGENT_DATA_HOME`、`GATEGUARD_STATE_DIR` の 3 つです（`_claude_with_home` は実行時に `CLV2_HOMUNCULUS_DIR` と `ECC_MCP_HEALTH_STATE_PATH` も設定しますが、bats テストはそれらを確認しません）。
+- `_claude_with_home` が指定したホームディレクトリ配下に複数の環境変数を設定し、指定したコマンドを実行する。テストが確認するのは `CLAUDE_CONFIG_DIR`、`ECC_AGENT_DATA_HOME`、`GATEGUARD_STATE_DIR` の 3 つです。`CLV2_HOMUNCULUS_DIR` は別のテストが両アカウント分の値を pin し、config dir 配下に解決されないことを確認します（#336）。`ECC_MCP_HEALTH_STATE_PATH` は実行時に設定されますが確認対象外です。
 - MCP API キー（`EXA_API_KEY`、`FIRECRAWL_API_KEY`）がサブプロセス環境にエクスポートされるが、親シェルにはエクスポートされない。
 
 ### `tests/skill_provenance.bats`

--- a/docs/contributing/ci-and-tests.md
+++ b/docs/contributing/ci-and-tests.md
@@ -72,7 +72,7 @@ Behavioral tests for `dot_claude/executable_statusline.sh`. Pipes mock JSON thro
 
 Behavioral regression guard for the `_claude_with_home` helper and the per-account wrappers. Sources `claude.zsh` in a minimal `zsh -f` environment (no rc files) and drives the underlying functions directly. Key assertions:
 
-- `_claude_with_home` sets several env vars rooted at the given home dir and runs the given command. The test asserts three of them: `CLAUDE_CONFIG_DIR`, `ECC_AGENT_DATA_HOME`, and `GATEGUARD_STATE_DIR`. (`_claude_with_home` also sets `CLV2_HOMUNCULUS_DIR` and `ECC_MCP_HEALTH_STATE_PATH` at runtime, but the bats test does not assert those.)
+- `_claude_with_home` sets several env vars rooted at the given home dir and runs the given command. The test asserts three of them: `CLAUDE_CONFIG_DIR`, `ECC_AGENT_DATA_HOME`, and `GATEGUARD_STATE_DIR`. A separate test pins `CLV2_HOMUNCULUS_DIR` for both accounts and asserts it never resolves under the config dir (#336). `ECC_MCP_HEALTH_STATE_PATH` is set at runtime but is not asserted.
 - MCP API keys (`EXA_API_KEY`, `FIRECRAWL_API_KEY`) are exported into the subprocess env but are not exported into the parent shell.
 
 ### `tests/skill_provenance.bats`

--- a/docs/explanation/secrets-and-isolation.ja.md
+++ b/docs/explanation/secrets-and-isolation.ja.md
@@ -136,7 +136,7 @@ _claude_with_home() {
   local home_dir="$1"; shift
   CLAUDE_CONFIG_DIR="$home_dir" \          # アカウント分離
     ECC_AGENT_DATA_HOME="$home_dir" \      # アカウント分離
-    CLV2_HOMUNCULUS_DIR="$home_dir/ecc-homunculus" \   # アカウント分離
+    CLV2_HOMUNCULUS_DIR="$HOME/.local/share/ecc-homunculus-<slug>" \   # アカウント分離、config dir 外（#336）
     ECC_MCP_HEALTH_STATE_PATH="$home_dir/mcp-health-cache.json" \
     GATEGUARD_STATE_DIR="$home_dir/.gateguard" \       # アカウント分離
     EXA_API_KEY="${EXA_API_KEY:-}" \       # シークレットスコーピング

--- a/docs/explanation/secrets-and-isolation.md
+++ b/docs/explanation/secrets-and-isolation.md
@@ -136,7 +136,7 @@ _claude_with_home() {
   local home_dir="$1"; shift
   CLAUDE_CONFIG_DIR="$home_dir" \          # account isolation
     ECC_AGENT_DATA_HOME="$home_dir" \      # account isolation
-    CLV2_HOMUNCULUS_DIR="$home_dir/ecc-homunculus" \   # account isolation
+    CLV2_HOMUNCULUS_DIR="$HOME/.local/share/ecc-homunculus-<slug>" \   # account isolation, outside the config dir (#336)
     ECC_MCP_HEALTH_STATE_PATH="$home_dir/mcp-health-cache.json" \
     GATEGUARD_STATE_DIR="$home_dir/.gateguard" \       # account isolation
     EXA_API_KEY="${EXA_API_KEY:-}" \       # secret scoping

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -18,7 +18,9 @@
 .claude/teams
 .claude/todos
 
-# ECC runtime state (hooks, governance state.db, continuous-learning, gateguard)
+# ECC runtime state (hooks, governance state.db, continuous-learning, gateguard).
+# The ecc-homunculus entries cover state left behind by the pre-#336 layout only: live CLV2
+# state now sits at ~/.local/share/ecc-homunculus-<slug>, outside chezmoi's target tree.
 .claude/ecc
 .claude/ecc-homunculus
 .claude/.gateguard

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -19,8 +19,12 @@
 .claude/todos
 
 # ECC runtime state (hooks, governance state.db, continuous-learning, gateguard).
-# The ecc-homunculus entries cover state left behind by the pre-#336 layout only: live CLV2
-# state now sits at ~/.local/share/ecc-homunculus-<slug>, outside chezmoi's target tree.
+# The ecc-homunculus entries under the account dirs cover state left behind by the pre-#336
+# layout only; live CLV2 state now sits at ~/.local/share/ecc-homunculus-<slug>. That path is
+# outside chezmoi's target tree today, but it is ignored below anyway: observations.jsonl holds
+# tool input/output whose redaction is best-effort, and this is a public repo, so a stray
+# `chezmoi add` under ~/.local/share must not be able to pick it up.
+.local/share/ecc-homunculus-*
 .claude/ecc
 .claude/ecc-homunculus
 .claude/.gateguard

--- a/home/dot_agents/skills/knowledge-distill/SKILL.md
+++ b/home/dot_agents/skills/knowledge-distill/SKILL.md
@@ -40,12 +40,14 @@ user-invocable: true
 ## Phase 0: 健全性診断（必ず実施）
 
 ```bash
-H="${CLV2_HOMUNCULUS_DIR:-$HOME/.claude/ecc-homunculus}"    # 未設定なら既定へ fallback（診断表に明記）
+H="${CLV2_HOMUNCULUS_DIR:-$HOME/.local/share/ecc-homunculus-default}"    # 未設定なら既定へ fallback（診断表に明記）
 jq '.observer' "$H/config.json"                              # enabled / run_interval / min_observations
 ls "$H/instincts/personal/" 2>/dev/null | wc -l              # instinct 蓄積数
 ls -lt "$H"/projects/*/observations.jsonl 2>/dev/null | head -3   # 観測の鮮度（記録が進んでいるか）
 ls "$H"/projects/*/observations.archive/ 2>/dev/null | tail -3    # 分析の処理痕跡（processed-<時刻> 名はソート=時系列のため tail が直近）
 grep -h 'timed out' "$H"/projects/*/*.log 2>/dev/null | tail -3   # timeout 痕跡（#256 の再発監視）
+grep -h 'Reached max turns' "$H"/projects/*/*.log 2>/dev/null | tail -3   # turn 枯渇痕跡（#336 の再発監視）
+grep -h 'sensitive file' "$H"/projects/*/*.log 2>/dev/null | tail -3      # 保存先が config dir 配下へ戻った兆候（#336）
 printf '%s\n' "${ECC_OBSERVER_TIMEOUT_SECONDS:-unset (この場合 observer は既定 120s)}"
 ```
 
@@ -59,17 +61,22 @@ printf '%s\n' "${ECC_OBSERVER_TIMEOUT_SECONDS:-unset (この場合 observer は�
 | observations の鮮度 | 対象週内に更新 | | |
 | 分析完走の痕跡（archive） | 増加している | | |
 | timeout 痕跡 | なし | | |
+| turn 枯渇痕跡（Reached max turns） | なし | | |
+| sensitive-file 痕跡 | なし | | |
 | ECC_OBSERVER_TIMEOUT_SECONDS | 300 以上 | | |
 | instinct 蓄積数 | ≥ --min-instincts | | |
 
 - `ECC_OBSERVER_TIMEOUT_SECONDS` が unset の場合、cld / cld-r06 wrapper（claude.zsh）を経由しない起動の可能性を指摘する（#256 の修正は wrapper の env 注入で効く）。
-- **timeout 痕跡が残る場合**: 既に起動済みの**長寿命 observer プロセスには新しい env が届いていない**。推奨アクションに observer の再起動を含める（新しい wrapper セッションからの起動し直しでも可）:
+- **timeout / turn 枯渇痕跡が残る場合**: 既に起動済みの**長寿命 observer プロセスには新しい env が届いていない**。推奨アクションに observer の再起動を含める（cld / cld-r06 セッションからの起動し直しが確実 — wrapper が保存先・timeout・active-hours・max-turns の env を一式注入するため、手動起動では取りこぼしやすい）:
 
 ```bash
 ~/.agents/skills/continuous-learning-v2/agents/start-observer.sh stop || true
+# 手動起動は timeout のみを固定する例。他の env は wrapper 側（claude.zsh）が SSOT。
 ECC_OBSERVER_TIMEOUT_SECONDS="${ECC_OBSERVER_TIMEOUT_SECONDS:-300}" \
   ~/.agents/skills/continuous-learning-v2/agents/start-observer.sh start
 ```
+
+- **sensitive-file 痕跡が残る場合**: 保存先が config dir 配下（`~/.claude*`）に戻っている。Claude Code は config dir 配下を sensitive file として扱い、非対話セッションは instinct の Write を承認できない。`claude.zsh` の `CLV2_HOMUNCULUS_DIR` が `~/.local/share/ecc-homunculus-<slug>` を指しているか確認する（#336）。
 
 - その他の判定 NG の項目には修理手段を添える（例: chezmoi apply の再実行、`run_onchange_after_14-enable-clv2-observer` の確認、issue 起票）。
 

--- a/home/dot_agents/skills/knowledge-distill/SKILL.md
+++ b/home/dot_agents/skills/knowledge-distill/SKILL.md
@@ -96,7 +96,10 @@ instinct 蓄積数 < `--min-instincts` の場合、**縮退レポート**を出�
 - cluster 候補を取得する（instinct 3 件未満は exit 1 になるため、その場合はこの経路を skip）:
 
 ```bash
-python3 ~/.agents/skills/continuous-learning-v2/scripts/instinct-cli.py evolve
+# $H を明示的に渡す: CLV2_HOMUNCULUS_DIR 未設定のまま呼ぶと、CLI は upstream の fallback
+# （$XDG_DATA_HOME/ecc-homunculus か ~/.local/share/ecc-homunculus）を解決し、Phase 0 で診断した
+# ストアとは別の場所を見てしまう（診断と evolve が食い違う）。
+CLV2_HOMUNCULUS_DIR="$H" python3 ~/.agents/skills/continuous-learning-v2/scripts/instinct-cli.py evolve
 # 出力の「## SKILL CANDIDATES」節（trigger / 構成 instinct ID / avg confidence）を候補として読む
 ```
 

--- a/home/dot_claude/executable_clv2-session-notify.sh
+++ b/home/dot_claude/executable_clv2-session-notify.sh
@@ -16,8 +16,10 @@
 # in settings.json means this adds zero latency to session start.
 #
 # Per-account: the homunculus dir is selected by CLV2_HOMUNCULUS_DIR, set per account by
-# _claude_with_home (cld -> ~/.claude/ecc-homunculus, cld-r06 -> ~/.claude-r06/ecc-homunculus),
-# so the cache and throttle files are naturally isolated between accounts.
+# _claude_with_home (cld -> ~/.local/share/ecc-homunculus-default, cld-r06 ->
+# ~/.local/share/ecc-homunculus-r06 — outside the config dir, whose contents Claude Code
+# treats as sensitive files that a headless write cannot get approved (#336)), so the cache
+# and throttle files are naturally isolated between accounts.
 
 set -eu
 

--- a/home/dot_claude/executable_morning-radar.sh
+++ b/home/dot_claude/executable_morning-radar.sh
@@ -113,9 +113,12 @@ log "start: claude -p /morning-brief (model=$CLAUDE_MODEL, max-turns=$MAX_TURNS)
 # #257), minus the MCP web-search keys — the brief does not need them and the
 # MCP servers tolerate missing keys. Headless launch + watchdog mirror the
 # CLV2 observer-loop.sh pattern.
+# CLV2_HOMUNCULUS_DIR carries the "default" slug that _claude_with_home derives for
+# ~/.claude, and deliberately sits outside the config dir: Claude Code treats every path
+# under it as a sensitive file, which no headless session can approve a write to (#336).
 CLAUDE_CONFIG_DIR="$HOME/.claude" \
   ECC_AGENT_DATA_HOME="$HOME/.claude" \
-  CLV2_HOMUNCULUS_DIR="$HOME/.claude/ecc-homunculus" \
+  CLV2_HOMUNCULUS_DIR="$HOME/.local/share/ecc-homunculus-default" \
   ECC_MCP_HEALTH_STATE_PATH="$HOME/.claude/mcp-health-cache.json" \
   GATEGUARD_STATE_DIR="$HOME/.claude/.gateguard" \
   ECC_OBSERVER_TIMEOUT_SECONDS="${ECC_OBSERVER_TIMEOUT_SECONDS:-300}" \

--- a/home/dot_claude/executable_morning-radar.sh
+++ b/home/dot_claude/executable_morning-radar.sh
@@ -114,14 +114,21 @@ log "start: claude -p /morning-brief (model=$CLAUDE_MODEL, max-turns=$MAX_TURNS)
 # MCP servers tolerate missing keys. Headless launch + watchdog mirror the
 # CLV2 observer-loop.sh pattern.
 # CLV2_HOMUNCULUS_DIR carries the "default" slug that _claude_with_home derives for
-# ~/.claude, and deliberately sits outside the config dir: Claude Code treats every path
-# under it as a sensitive file, which no headless session can approve a write to (#336).
+# ~/.claude, and deliberately sits outside the config dir: Claude Code treats paths under it
+# as sensitive files, which no headless session can approve a write to (#336).
+# The observer knobs have to be mirrored here as well, not just the storage path: this session
+# lazy-starts a CLV2 observer through the PreToolUse hook, and that observer inherits this
+# environment for its whole lifetime. Omitting them would leave the brief's observer on the
+# upstream clock gate and the auto-scaled turn floor that #336 exists to get past.
 CLAUDE_CONFIG_DIR="$HOME/.claude" \
   ECC_AGENT_DATA_HOME="$HOME/.claude" \
   CLV2_HOMUNCULUS_DIR="$HOME/.local/share/ecc-homunculus-default" \
   ECC_MCP_HEALTH_STATE_PATH="$HOME/.claude/mcp-health-cache.json" \
   GATEGUARD_STATE_DIR="$HOME/.claude/.gateguard" \
   ECC_OBSERVER_TIMEOUT_SECONDS="${ECC_OBSERVER_TIMEOUT_SECONDS:-300}" \
+  OBSERVER_ACTIVE_HOURS_START="${OBSERVER_ACTIVE_HOURS_START:-0}" \
+  OBSERVER_ACTIVE_HOURS_END="${OBSERVER_ACTIVE_HOURS_END:-0}" \
+  ECC_OBSERVER_MAX_TURNS="${ECC_OBSERVER_MAX_TURNS:-100}" \
   claude "${CLAUDE_ARGS[@]}" -p "$PROMPT" >"$STDOUT_FILE" 2>>"$LOG_FILE" &
 CLAUDE_PID=$!
 

--- a/home/dot_config/zsh/claude.zsh
+++ b/home/dot_config/zsh/claude.zsh
@@ -28,12 +28,39 @@ _claude_with_home() {
   # the Haiku analysis pass (up to a 500-line observation batch and 100 --max-turns) cannot
   # finish in 120s, so every run was SIGTERMed (observer log exit 143) and no instinct was
   # ever written (#256). The :- default keeps an explicit override winning.
+  # CLV2 state must stay OUTSIDE the account config dir. Claude Code classifies every path
+  # under the config dir as a sensitive file and demands interactive approval before a Write,
+  # but the CLV2 analysis pass runs headless (claude --model haiku --print), so every instinct
+  # write failed with "... which is a sensitive file", spent the turn budget negotiating
+  # permission and ended at "Reached max turns" — not one instinct was ever produced while
+  # this pointed at <account>/ecc-homunculus (#336). The per-account suffix keeps cld and
+  # cld-r06 isolated from each other and both from the bare-`claude` fallback
+  # (~/.local/share/ecc-homunculus). XDG_DATA_HOME is deliberately NOT consulted: morning-radar.sh
+  # reproduces this same value, and a second precedence chain there is what would let the two
+  # drift apart.
+  # OBSERVER_ACTIVE_HOURS_* are both 0 to disable the CLV2 session-guardian clock gate
+  # (default 800-2300), which skipped ~90 analysis cycles per project because sessions here
+  # routinely run past midnight (#336). The guardian's cooldown and idle gates still throttle
+  # cycles, so this does not make the observer busier while nobody is at the keyboard.
+  # ECC_OBSERVER_MAX_TURNS pins the ceiling at the upstream cap rather than the auto-scaled
+  # floor of 20, which cut the Read -> dedup-check -> Write pass off mid-write; the 300s
+  # watchdog above is what actually bounds a cycle.
+  local account_dir_name="${home_dir:t}"
+  local homunculus_slug
+  case "$account_dir_name" in
+    .claude) homunculus_slug=default ;;
+    .claude-*) homunculus_slug="${account_dir_name#.claude-}" ;;
+    *) homunculus_slug="${account_dir_name#.}" ;;
+  esac
   CLAUDE_CONFIG_DIR="$home_dir" \
     ECC_AGENT_DATA_HOME="$home_dir" \
-    CLV2_HOMUNCULUS_DIR="$home_dir/ecc-homunculus" \
+    CLV2_HOMUNCULUS_DIR="$HOME/.local/share/ecc-homunculus-${homunculus_slug}" \
     ECC_MCP_HEALTH_STATE_PATH="$home_dir/mcp-health-cache.json" \
     GATEGUARD_STATE_DIR="$home_dir/.gateguard" \
     ECC_OBSERVER_TIMEOUT_SECONDS="${ECC_OBSERVER_TIMEOUT_SECONDS:-300}" \
+    OBSERVER_ACTIVE_HOURS_START="${OBSERVER_ACTIVE_HOURS_START:-0}" \
+    OBSERVER_ACTIVE_HOURS_END="${OBSERVER_ACTIVE_HOURS_END:-0}" \
+    ECC_OBSERVER_MAX_TURNS="${ECC_OBSERVER_MAX_TURNS:-100}" \
     EXA_API_KEY="${EXA_API_KEY:-}" \
     FIRECRAWL_API_KEY="${FIRECRAWL_API_KEY:-}" \
     "$@"

--- a/home/dot_config/zsh/claude.zsh
+++ b/home/dot_config/zsh/claude.zsh
@@ -45,6 +45,9 @@ _claude_with_home() {
   # ECC_OBSERVER_MAX_TURNS pins the ceiling at the upstream cap rather than the auto-scaled
   # floor of 20, which cut the Read -> dedup-check -> Write pass off mid-write; the 300s
   # watchdog above is what actually bounds a cycle.
+  # Supported account dirs are ~/.claude and ~/.claude-<suffix>; the last branch only exists so an
+  # unexpected name still yields a usable dir name. Do not name an account dir ".claude-default":
+  # its slug would collide with ~/.claude's and silently merge two accounts' observations.
   local account_dir_name="${home_dir:t}"
   local homunculus_slug
   case "$account_dir_name" in

--- a/home/run_onchange_after_14-enable-clv2-observer.sh.tmpl
+++ b/home/run_onchange_after_14-enable-clv2-observer.sh.tmpl
@@ -10,7 +10,9 @@
 #
 # Privacy note: with the observer on, observe.sh records tool input/output to a local
 # observations.jsonl (secret redaction + truncation are upstream observe.sh's responsibility).
-# This is local at-rest data under each homunculus dir; nothing leaves the machine.
+# That recording step is local at-rest data under each homunculus dir, but the analysis step is
+# not: the observer feeds batches of it to `claude --model haiku --print`, so observations do
+# reach the API. The homunculus dir is created 0700 below for that reason.
 #
 # Homunculus dirs (all that apply): the cld / cld-r06 wrappers point CLV2_HOMUNCULUS_DIR at
 # "~/.local/share/ecc-homunculus-<slug>" — outside the account config dir, because Claude Code

--- a/home/run_onchange_after_14-enable-clv2-observer.sh.tmpl
+++ b/home/run_onchange_after_14-enable-clv2-observer.sh.tmpl
@@ -13,7 +13,9 @@
 # This is local at-rest data under each homunculus dir; nothing leaves the machine.
 #
 # Homunculus dirs (all that apply): the cld / cld-r06 wrappers point CLV2_HOMUNCULUS_DIR at
-# "<account>/ecc-homunculus"; bare `claude` (no wrapper, env unset) falls back to
+# "~/.local/share/ecc-homunculus-<slug>" — outside the account config dir, because Claude Code
+# treats every path under that dir as a sensitive file and the headless observer has nobody to
+# approve the instinct write (#336); bare `claude` (no wrapper, env unset) falls back to
 # $XDG_DATA_HOME/ecc-homunculus or ~/.local/share/ecc-homunculus. Idempotent.
 set -euo pipefail
 
@@ -36,6 +38,11 @@ enable_config='{"version":"2.1","observer":{"enabled":true,"run_interval_minutes
 _enable_in() {
   local dir="$1"
   mkdir -p "$dir"
+  # 700 on the state dir: observations.jsonl records tool input/output, and unlike the old
+  # location under the Claude config dir this now lives in ~/.local/share, which other tools
+  # share. Applied on every run so an existing dir is healed instead of left at the umask
+  # default.
+  chmod 700 "$dir"
   local cfg="${dir}/config.json"
   if [ -f "$cfg" ]; then
     # Preserve any existing fields; only force observer.enabled=true. mktemp in the target
@@ -54,10 +61,22 @@ _enable_in() {
   echo "[clv2-observer] observer enabled in ${cfg}" >&2
 }
 
-# Wrapper accounts: enable under each account config dir that exists.
+# Wrapper accounts: enable in the homunculus dir belonging to each account config dir that
+# exists. The config dir still selects WHICH accounts are in use; only the state location moved
+# out of it. The slug mapping mirrors _claude_with_home in dot_config/zsh/claude.zsh — the two
+# must stay in sync or the observer would be enabled in a dir no session ever reads.
 for account in "${HOME}/.claude" "${HOME}/.claude-r06"; do
   if [ -d "$account" ]; then
-    _enable_in "${account}/ecc-homunculus"
+    # Derive the slug from the basename only, in the same three branches as the zsh helper, so
+    # the two cannot disagree on a name neither of them was written for (a path-based strip
+    # here would also leak a trailing slash into the slug).
+    account_dir_name="${account##*/}"
+    case "$account_dir_name" in
+      .claude) slug=default ;;
+      .claude-*) slug="${account_dir_name#.claude-}" ;;
+      *) slug="${account_dir_name#.}" ;;
+    esac
+    _enable_in "${HOME}/.local/share/ecc-homunculus-${slug}"
   fi
 done
 

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -152,18 +152,30 @@ load helpers/setup
   # repeating the literal, so the two can only ever drift together.
   command -v zsh >/dev/null || skip "zsh not available"
   local wrapper="${HOME_DIR}/dot_claude/executable_morning-radar.sh"
-  local expected
-  expected=$(zsh -fc "
+  local vals
+  vals=$(zsh -fc "
     export HOME='$BATS_TEST_TMPDIR'
     source '${HOME_DIR}/dot_config/zsh/claude.zsh'
-    claude() { print -r -- \"\$CLV2_HOMUNCULUS_DIR\"; }
+    claude() { print -r -- \"\$CLV2_HOMUNCULUS_DIR|\$OBSERVER_ACTIVE_HOURS_START|\$OBSERVER_ACTIVE_HOURS_END|\$ECC_OBSERVER_MAX_TURNS\"; }
     _claude_with_home \"\$HOME/.claude\"
   ")
-  [ -n "$expected" ]
+  [ -n "$vals" ]
+  local dir start end turns
+  dir=$(printf '%s' "$vals" | cut -d'|' -f1)
+  start=$(printf '%s' "$vals" | cut -d'|' -f2)
+  end=$(printf '%s' "$vals" | cut -d'|' -f3)
+  turns=$(printf '%s' "$vals" | cut -d'|' -f4)
   # The wrapper keeps $HOME unexpanded, so compare on the $HOME-relative tail.
-  grep -qF "CLV2_HOMUNCULUS_DIR=\"\$HOME${expected#"$BATS_TEST_TMPDIR"}\"" "$wrapper"
+  grep -qF "CLV2_HOMUNCULUS_DIR=\"\$HOME${dir#"$BATS_TEST_TMPDIR"}\"" "$wrapper"
   run grep -qF '.claude/ecc-homunculus' "$wrapper"
   [ "$status" -ne 0 ]
+  # The observer knobs have to be mirrored too, not just the storage path: this session
+  # lazy-starts an observer that inherits its environment for the whole process lifetime, so a
+  # wrapper missing these would run the brief's observer on the upstream clock gate and turn
+  # floor. Derived from the helper as well, so changing a default in claude.zsh forces it here.
+  grep -qF "OBSERVER_ACTIVE_HOURS_START=\"\${OBSERVER_ACTIVE_HOURS_START:-${start}}\"" "$wrapper"
+  grep -qF "OBSERVER_ACTIVE_HOURS_END=\"\${OBSERVER_ACTIVE_HOURS_END:-${end}}\"" "$wrapper"
+  grep -qF "ECC_OBSERVER_MAX_TURNS=\"\${ECC_OBSERVER_MAX_TURNS:-${turns}}\"" "$wrapper"
 }
 
 @test "morning-radar wrapper does not carry a dead ECC_DISABLED_HOOKS alias-level default (#280)" {

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -710,11 +710,9 @@ FAKE_CLAUDE
   # there approved, which is exactly what kept instinct generation dead (#336).
   [ ! -e "$tmp/.claude/ecc-homunculus" ]
   # The state dir stays private. observations.jsonl records tool input/output, and it now lives
-  # in the shared ~/.local/share tree rather than under the config dir. stat's flags differ
-  # between macOS and Linux, so try the BSD form first and fall back to the GNU one.
+  # in the shared ~/.local/share tree rather than under the config dir.
   local mode
-  mode=$(stat -f '%Lp' "$tmp/.local/share/ecc-homunculus-default" 2>/dev/null ||
-    stat -c '%a' "$tmp/.local/share/ecc-homunculus-default")
+  mode=$(_file_mode "$tmp/.local/share/ecc-homunculus-default")
   [ "$mode" = "700" ]
   # Fresh-write branch: an account dir with no prior config gets a fully-formed enabled config.
   mkdir -p "$tmp/.claude-r06"

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -144,6 +144,28 @@ load helpers/setup
   grep -q 'on run argv' "$wrapper"
 }
 
+@test "morning-radar wrapper points CLV2 state at the dir _claude_with_home derives (#336)" {
+  # The wrapper duplicates this value by hand ("Keep in sync with _claude_with_home"), so a
+  # revert to <account>/ecc-homunculus here alone would silently reintroduce #336 for the
+  # launchd brief: Claude Code treats the config dir as sensitive, and a headless session has
+  # nobody to approve the instinct write. Derive the expectation from the zsh helper instead of
+  # repeating the literal, so the two can only ever drift together.
+  command -v zsh >/dev/null || skip "zsh not available"
+  local wrapper="${HOME_DIR}/dot_claude/executable_morning-radar.sh"
+  local expected
+  expected=$(zsh -fc "
+    export HOME='$BATS_TEST_TMPDIR'
+    source '${HOME_DIR}/dot_config/zsh/claude.zsh'
+    claude() { print -r -- \"\$CLV2_HOMUNCULUS_DIR\"; }
+    _claude_with_home \"\$HOME/.claude\"
+  ")
+  [ -n "$expected" ]
+  # The wrapper keeps $HOME unexpanded, so compare on the $HOME-relative tail.
+  grep -qF "CLV2_HOMUNCULUS_DIR=\"\$HOME${expected#"$BATS_TEST_TMPDIR"}\"" "$wrapper"
+  run grep -qF '.claude/ecc-homunculus' "$wrapper"
+  [ "$status" -ne 0 ]
+}
+
 @test "morning-radar wrapper does not carry a dead ECC_DISABLED_HOOKS alias-level default (#280)" {
   # settings.json's env block is the effective SSOT for ECC_DISABLED_HOOKS (Claude Code
   # applies it with precedence over shell-inherited env vars), so a "${ECC_DISABLED_HOOKS:-...}"
@@ -671,22 +693,36 @@ FAKE_CLAUDE
   # Pin XDG_DATA_HOME inside the sandbox so the bare-`claude` fallback branch can never
   # touch the developer's real ~/.local/share/ecc-homunculus.
   local run=(env "HOME=$tmp" "XDG_DATA_HOME=$tmp/.local/share" bash "$script")
+  # The account config dir still selects WHICH accounts are in use, but the state it enables
+  # now lives at ~/.local/share/ecc-homunculus-<slug>, outside that config dir (#336).
   # Seed a pre-existing config (disabled + unrelated keys) to exercise the jq-merge branch:
   # it must force enabled=true while preserving every other field, and stay stable on re-run.
-  mkdir -p "$tmp/.claude/ecc-homunculus"
+  mkdir -p "$tmp/.claude" "$tmp/.local/share/ecc-homunculus-default"
   printf '%s' '{"version":"2.1","observer":{"enabled":false,"run_interval_minutes":7},"custom":42}' \
-    > "$tmp/.claude/ecc-homunculus/config.json"
+    > "$tmp/.local/share/ecc-homunculus-default/config.json"
   "${run[@]}" >/dev/null 2>&1
   "${run[@]}" >/dev/null 2>&1
-  local cfg="$tmp/.claude/ecc-homunculus/config.json"
+  local cfg="$tmp/.local/share/ecc-homunculus-default/config.json"
   [ "$(jq -r '.observer.enabled' "$cfg")" = "true" ]
   [ "$(jq -r '.observer.run_interval_minutes' "$cfg")" = "7" ]
   [ "$(jq -r '.custom' "$cfg")" = "42" ]
+  # Nothing is created under the Claude config dir: a headless observer can never get a write
+  # there approved, which is exactly what kept instinct generation dead (#336).
+  [ ! -e "$tmp/.claude/ecc-homunculus" ]
+  # The state dir stays private. observations.jsonl records tool input/output, and it now lives
+  # in the shared ~/.local/share tree rather than under the config dir. stat's flags differ
+  # between macOS and Linux, so try the BSD form first and fall back to the GNU one.
+  local mode
+  mode=$(stat -f '%Lp' "$tmp/.local/share/ecc-homunculus-default" 2>/dev/null ||
+    stat -c '%a' "$tmp/.local/share/ecc-homunculus-default")
+  [ "$mode" = "700" ]
   # Fresh-write branch: an account dir with no prior config gets a fully-formed enabled config.
   mkdir -p "$tmp/.claude-r06"
   "${run[@]}" >/dev/null 2>&1
-  [ "$(jq -r '.observer.enabled' "$tmp/.claude-r06/ecc-homunculus/config.json")" = "true" ]
-  # Bare-`claude` fallback: not created speculatively, but enabled once it exists.
+  [ "$(jq -r '.observer.enabled' "$tmp/.local/share/ecc-homunculus-r06/config.json")" = "true" ]
+  [ ! -e "$tmp/.claude-r06/ecc-homunculus" ]
+  # Bare-`claude` fallback: a distinct, unsuffixed dir — not created speculatively, but enabled
+  # once it exists, and never conflated with either account's dir.
   [ ! -e "$tmp/.local/share/ecc-homunculus/config.json" ]
   mkdir -p "$tmp/.local/share/ecc-homunculus"
   "${run[@]}" >/dev/null 2>&1

--- a/tests/helpers/setup.bash
+++ b/tests/helpers/setup.bash
@@ -24,6 +24,20 @@ _ecc_skill_list() {
   ' "${HOME_DIR}/.chezmoidata.toml" | grep -oE '"[^"]+"' | tr -d '"'
 }
 
+# Octal permission bits of a file or directory (e.g. 700), on both CI platforms.
+#
+# The obvious `stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"` chain is wrong on GNU: there
+# `-f` means --file-system, so stat prints a multi-line filesystem report to stdout AND exits
+# non-zero, and the command substitution ends up capturing that report concatenated with the
+# fallback's output. Detect the implementation instead — only GNU stat understands --version.
+_file_mode() {
+  if stat --version >/dev/null 2>&1; then
+    stat -c '%a' "$1"
+  else
+    stat -f '%Lp' "$1"
+  fi
+}
+
 # Resolve the ITEMS=(...) array in run_once_after_11-validate-1password.sh.tmpl.
 # Each entry is a "op://kryota.dev/..." string; comments inside the array (starting
 # with #) are ignored. Kept dependency-free (no yq / no chezmoi).

--- a/tests/zsh_aliases.bats
+++ b/tests/zsh_aliases.bats
@@ -35,6 +35,50 @@ load helpers/setup
   [ "${lines[1]}" = "45" ]
 }
 
+@test "claude.zsh: _claude_with_home keeps the CLV2 homunculus dir out of the config dir" {
+  # Regression guard for #336: Claude Code classifies every path under the Claude config dir as
+  # a sensitive file, so the headless CLV2 analysis pass (claude --model haiku --print) can
+  # never get an instinct write there approved — instinct generation stayed at exactly zero for
+  # as long as this pointed at <account>/ecc-homunculus. Pin the real values, then pin the
+  # property that made them necessary, so moving the dir back under ~/.claude* fails here.
+  run zsh -fc "
+    export HOME='$BATS_TEST_TMPDIR'
+    source '${HOME_DIR}/dot_config/zsh/claude.zsh'
+    claude() { print -r -- \"\$CLV2_HOMUNCULUS_DIR\"; }
+    _claude_with_home \"\$HOME/.claude\"
+    _claude_with_home \"\$HOME/.claude-r06\"
+  "
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$BATS_TEST_TMPDIR/.local/share/ecc-homunculus-default" ]
+  [ "${lines[1]}" = "$BATS_TEST_TMPDIR/.local/share/ecc-homunculus-r06" ]
+  # Neither account may resolve under the config dir.
+  [[ "${lines[0]}" != "$BATS_TEST_TMPDIR/.claude"* ]]
+  [[ "${lines[1]}" != "$BATS_TEST_TMPDIR/.claude"* ]]
+  # The accounts stay distinct from each other and from the bare-`claude` fallback, which
+  # carries no account suffix.
+  [ "${lines[0]}" != "${lines[1]}" ]
+  [ "${lines[0]}" != "$BATS_TEST_TMPDIR/.local/share/ecc-homunculus" ]
+  [ "${lines[1]}" != "$BATS_TEST_TMPDIR/.local/share/ecc-homunculus" ]
+}
+
+@test "claude.zsh: _claude_with_home disables the observer clock gate and lifts its turn ceiling" {
+  # #336: the CLV2 session-guardian clock gate (default 800-2300) skipped ~90 analysis cycles
+  # per project because sessions here run past midnight, and the auto-scaled --max-turns floor
+  # of 20 cut the Read -> dedup-check -> Write pass off mid-write. BOTH halves of the window
+  # must be 0 — the guardian only skips the gate when START and END are both zero — and all
+  # three values must stay overridable.
+  run zsh -fc "
+    export HOME='$BATS_TEST_TMPDIR'
+    source '${HOME_DIR}/dot_config/zsh/claude.zsh'
+    claude() { print -r -- \"\$OBSERVER_ACTIVE_HOURS_START|\$OBSERVER_ACTIVE_HOURS_END|\$ECC_OBSERVER_MAX_TURNS\"; }
+    _claude_with_home \"\$HOME/.claude\"
+    OBSERVER_ACTIVE_HOURS_START=900 OBSERVER_ACTIVE_HOURS_END=2200 ECC_OBSERVER_MAX_TURNS=40 _claude_with_home \"\$HOME/.claude\"
+  "
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "0|0|100" ]
+  [ "${lines[1]}" = "900|2200|40" ]
+}
+
 @test "claude.zsh: _claude_with_home defaults to claude when no command is given" {
   run zsh -fc "
     source '${HOME_DIR}/dot_config/zsh/claude.zsh'


### PR DESCRIPTION
## Why

CLV2's Haiku observer had never produced a single instinct. `instincts/personal/` and
`instincts/inherited/` were empty across every project, so the ECC SessionStart instinct
injection block was always empty, and every analysis cycle burned Haiku cost for zero output.

#336 filed this as an active-hours plus `--max-turns` problem. Those are real, but they are
symptoms. The root cause, confirmed by direct measurement, is that `CLV2_HOMUNCULUS_DIR`
pointed inside the Claude Code **config dir**:

1. `_claude_with_home` set `CLV2_HOMUNCULUS_DIR="$home_dir/ecc-homunculus"`, i.e.
   `~/.claude/ecc-homunculus` and `~/.claude-r06/ecc-homunculus`.
2. Claude Code classifies every path under the config dir as a *sensitive file* and requires
   interactive approval before a write. Measured verbatim:

   ```
   Claude requested permissions to edit
   /Users/<user>/.claude/ecc-homunculus/projects/<id>/instincts/personal/zz-probe.md
   which is a sensitive file.
   ```

3. The CLV2 analysis pass is headless — `claude --model haiku --print --allowedTools "Read,Write"`
   (`continuous-learning-v2/agents/observer-loop.sh`) — so nobody can approve it.
4. Haiku therefore spent its turn budget negotiating permission and ended at
   `Error: Reached max turns (20)` (37 occurrences in one project's observer log). Instinct
   count stayed at exactly zero.

Two alternatives were tested and rejected against primary evidence:

| Option | Measured result |
|---|---|
| Write outside the config dir (`~/.local/share/...`) while headless | **Succeeds** — adopted |
| `permissions.allow` with `Edit(//Users/<user>/.claude/ecc-homunculus/**)` | Fails with the same sensitive-file error; an allow rule does not override the gate |
| Fork CLV2 to pass `--permission-mode` | Not pursued — requires forking a SHA-pinned external and weakens the observer's safety boundary |

The gate is a legitimate protection (an agent should not silently rewrite its own config dir).
CLV2 instincts are learned *runtime state*, not agent configuration, so the fix moves the state
out of the config dir instead of loosening the gate.

## What changed

**Root cause**

- `home/dot_config/zsh/claude.zsh` — derive an account slug from the config dir basename
  (`.claude` → `default`, `.claude-*` → suffix) and point `CLV2_HOMUNCULUS_DIR` at
  `~/.local/share/ecc-homunculus-<slug>`. The per-account suffix keeps `cld` and `cld-r06`
  isolated from each other and both distinct from the bare-`claude` fallback
  (`~/.local/share/ecc-homunculus`), which is unchanged. `XDG_DATA_HOME` is deliberately not
  consulted so this and `morning-radar.sh` cannot drift apart through two precedence chains.

**The symptoms #336 originally reported**

- Same file — `OBSERVER_ACTIVE_HOURS_START` / `OBSERVER_ACTIVE_HOURS_END` default to `0`, which
  disables the session-guardian clock gate (upstream default 800–2300). That gate skipped ~90
  analysis cycles per project because sessions here routinely run past midnight. The guardian's
  cooldown and idle gates still throttle cycles, so the observer does not get busier while
  nobody is at the keyboard.
- Same file — `ECC_OBSERVER_MAX_TURNS` defaults to `100`, the upstream cap, instead of the
  auto-scaled floor of 20 that cut the Read → dedup-check → Write pass off mid-write. The
  existing 300 s watchdog, not the turn ceiling, bounds a cycle — and the comment added in #256
  already assumed 100 turns, so the two are now consistent.
- All three follow the existing `${VAR:-default}` form, so an explicit override still wins.

**Keeping every reference consistent**

- `home/run_onchange_after_14-enable-clv2-observer.sh.tmpl` — writes `observer.enabled=true` to
  the new per-account paths. The account config dir still selects *which* accounts are in use;
  only the state location moved. Missing this would have left the observer disabled at the new
  path. It also restricts the state dir to `700`, since `observations.jsonl` records tool
  input/output and now sits in the shared `~/.local/share` tree instead of under the config dir;
  the `chmod` runs every time so an existing dir is healed rather than left at the umask default.
  Its slug derivation mirrors `_claude_with_home` branch for branch, both switching on the
  basename, so the two cannot disagree on a directory name neither of them was written for.
- `home/dot_claude/executable_morning-radar.sh` — the headless morning brief uses the `default`
  slug *and* mirrors the three observer knobs, honouring the existing "keep in sync with
  `_claude_with_home`" contract. Both halves matter: the brief lazy-starts a CLV2 observer through
  the `PreToolUse` hook and that observer inherits the wrapper's environment for its whole
  lifetime, so a wrapper carrying only the path would have kept running its own observer on
  exactly the clock gate and turn floor this PR removes.
- `home/dot_agents/skills/knowledge-distill/SKILL.md` — fallback default updated, plus the Phase 0
  diagnostic now greps for both #336 failure signatures (`Reached max turns`, `sensitive file`)
  and reports them as table rows, so a regression is detectable by diagnosis rather than by
  noticing that instincts never appear.
- `home/dot_claude/executable_clv2-session-notify.sh` — comment only; resolution already goes
  through `CLV2_HOMUNCULUS_DIR` first.
- `home/.chezmoiignore` — the account-dir entries stay, now labelled as covering pre-#336 leftovers
  only, and `.local/share/ecc-homunculus-*` is added alongside them. That path is outside
  chezmoi's target tree today, but `observations.jsonl` holds tool input/output whose redaction is
  best-effort, so in a public repo a stray `chezmoi add` under `~/.local/share` must not be able to
  pick it up.
- `home/dot_claude/executable_statusline.sh` — **not changed**: its XDG/`~/.local/share` branch is
  the bare-`claude` fallback, which remains correct. It reads `CLV2_HOMUNCULUS_DIR` first, so the
  🧬N segment follows the move automatically.
- Docs (EN + JA mirrors): `docs/agents/claude-code.*`, `docs/agents/account-isolation.*`,
  `docs/explanation/secrets-and-isolation.*`, `docs/architecture/lifecycle-scripts.*` — new paths,
  the three new env vars documented, and the design reason recorded (why CLV2 state must sit
  outside the config dir while `CLAUDE_CONFIG_DIR` / `ECC_AGENT_DATA_HOME` /
  `GATEGUARD_STATE_DIR` legitimately stay inside it: their writers bypass the Write tool).

**Tests**

- `tests/zsh_aliases.bats` — pins the real per-account values, then pins the property that made
  them necessary: neither account may resolve under `~/.claude*`, the two must differ, and both
  must differ from the unsuffixed fallback. Also pins the three observer env defaults and their
  overridability.
- `tests/files.bats` — the observer-enable test now asserts the new paths, that nothing is created
  under the config dir, and that the state dir ends up at mode `700` (with a BSD/GNU `stat`
  fallback so it holds on both CI platforms). A new test pins the `morning-radar.sh` sync
  contract by deriving the expected value from `_claude_with_home` itself rather than repeating
  the literal, so reverting that one hand-copied line can no longer pass CI.

The `Write(**/.env*)` deny-rule warning that #336 noted as a secondary observation needs no
action: source and deployed `settings.json` already use the `Edit(...)` form.

## Verification

- `make lint` — pass
- `make test` — pass (lint + 173 bats tests)
- `chezmoi diff` — only the intended lines change in the four deployed files
- Reviewed in two rounds. The first (code quality, security, test coverage) returned APPROVE with
  no blocking findings and contributed the `chmod 700`, the mirrored slug derivation and two extra
  assertions; it also injected three regressions (reverting the path, collapsing both accounts onto
  one slug, reverting only the `r06` branch of the enable script) and confirmed each is caught. The
  second round added a cross-model pass and found the half-honoured sync contract described above —
  the only MUST across either round. Overall security risk: low. The posted review comment lists
  every finding with its resolution, including the four rejected with reasons.

## Migration (run locally after merge)

The observer state itself is runtime data, so no migration script is added: this repo manages
config, not state. Run the move **before** `chezmoi apply`, so the destinations do not exist yet:

```bash
# 0. Confirm the destinations are still absent (expected: both "absent")
for d in ~/.local/share/ecc-homunculus-default ~/.local/share/ecc-homunculus-r06; do
  [ -e "$d" ] && echo "PRESENT: $d" || echo "absent:  $d"
done

# 1. Move the accumulated observations/projects state (~450 KB, 171+ observations)
mv ~/.claude/ecc-homunculus     ~/.local/share/ecc-homunculus-default
mv ~/.claude-r06/ecc-homunculus ~/.local/share/ecc-homunculus-r06

# 2. Deploy: run_onchange_after_14 re-runs and merges observer.enabled=true into the moved config
chezmoi apply -v

# 3. Pick up the new alias env, then retire the observers still holding the old one
exec zsh
~/.agents/skills/continuous-learning-v2/agents/start-observer.sh stop || true
```

If step 0 reports `PRESENT` because `chezmoi apply` already ran, those dirs hold only a generated
`config.json`; copy the history in over it instead of moving
(`rsync -a ~/.claude/ecc-homunculus/ ~/.local/share/ecc-homunculus-default/`). The old
`config.json` also carries `observer.enabled: true`, so overwriting the generated one is safe.

## Post-merge verification (issue AC 1)

#336's first acceptance criterion — at least one instinct generated from a real session — needs
the state move plus an observer restart, so it is verified after merge, not in CI:

```bash
# The wrapper points outside the config dir
_claude_with_home "$HOME/.claude" printenv CLV2_HOMUNCULUS_DIR

# The observer is enabled at the new path
jq '.observer' ~/.local/share/ecc-homunculus-default/config.json

# After a cld session has run long enough for an analysis cycle: at least one instinct exists
ls ~/.local/share/ecc-homunculus-default/instincts/personal/ 2>/dev/null
ls ~/.local/share/ecc-homunculus-default/projects/*/instincts/personal/ 2>/dev/null

# The old failure signatures stop appearing
grep -h 'sensitive file\|Reached max turns' \
  ~/.local/share/ecc-homunculus-default/projects/*/observer.log 2>/dev/null | tail -5
```

closes #336
