### PR TITLE
feat: converge Claude Code plugins onto their ref pin at apply time

### DIFF
--- a/docs/agents/claude-code.ja.md
+++ b/docs/agents/claude-code.ja.md
@@ -88,7 +88,9 @@
 
 このギャップを埋めるのが `run_onchange_after_17-setup-claude-plugins.sh.tmpl` です。settings.json から
 レンダリングした宣言を JSON として埋め込み（＝宣言の単一ソースを保つ）、不足している marketplace の
-登録とプラグインのインストールをアカウントごとに実行します。
+登録とプラグインのインストールをアカウントごとに実行します。`ref` で pin された marketplace は以降の実行でも
+pin に追従させます（pin を bump したときの挙動は
+[Codex ハーネス](codex.ja.md#claude-code-codex-プラグイン--pin-と収束) を参照）。
 
 marketplace は `chezmoi apply` が無人でインストールする実行コードなので、可変な既定ブランチを追ってはいけません。
 この pin には落とし穴が 2 つあります。宣言した `ref` は **CLI 引数に含めない限り無視される**ため、スクリプトは

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -89,7 +89,9 @@ chezmoiignored and therefore empty on a new machine.
 
 `run_onchange_after_17-setup-claude-plugins.sh.tmpl` closes that gap. It embeds the declaration as
 JSON rendered out of settings.json — so the declaration keeps a single source of truth — then
-registers the marketplaces and installs the plugins that are missing, once per account.
+registers the marketplaces and installs the plugins that are missing, once per account. A marketplace
+pinned to a `ref` is also held to it on later runs — see
+[Codex harness](codex.md#claude-code-codex-plugin--pin-and-convergence) for what a pin bump does.
 
 A marketplace is executable code that `chezmoi apply` installs unattended, so it must not track a
 moving default branch. The pin has two sharp edges. A declared `ref` is **ignored** unless it is also

--- a/docs/agents/codex.ja.md
+++ b/docs/agents/codex.ja.md
@@ -280,19 +280,27 @@ Claude Code 側は `openai-codex` marketplace の `codex` プラグインを通�
 
 ### インストール済みバージョンの収束
 
-プラグインセットアップスクリプト（`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`）はプラグインが存在しない場合にのみインストールします：install ループはプラグイン名の一致だけで skip し、バージョン比較を行いません。したがって `ref` pin の編集だけでは、インストール済みプラグインは決して収束しません — これは既知のギャップです（スクリプトへの reconcile 実装は意図的に先送り）。収束は手動で、アカウント（`CLAUDE_CONFIG_DIR`）ごとに 1 回実行します：
+プラグインセットアップスクリプト（`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`）が apply 時に両アカウントを pin へ収束させるため、`ref` を編集して `chezmoi apply` を実行すれば手順は完結します。この編集自体が再実行のトリガーでもあります：スクリプトが埋め込む宣言が変わり、それに伴って `run_onchange` のキーも変わるためです。
+
+アカウント（`CLAUDE_CONFIG_DIR`）ごとに、`ref` を宣言している marketplace それぞれについて、スクリプトはランタイムが宣言とは独立に保持している次の 2 つを比較します：
+
+- **登録内容。** `known_marketplaces.json` はランタイム自身が持つソースのコピー（ref を含む）を保持します。宣言と一致しなくなった場合、marketplace を登録解除し、宣言された ref で再登録します。`claude plugin marketplace update` では不十分です：保存済みの登録から pull するため、古い ref を追ってしまいます。
+- **インストール済みバージョン。** marketplace clone がそのプラグインに対して提供するバージョン（pin された ref で checkout された `.claude-plugin/marketplace.json` の値）と、`claude plugin list` が報告するバージョンを比較します。不一致なら `claude plugin update` を実行し、その結果は終了コードを信用せずインストール済みバージョンを読み直して検証します — CLI が成功を報告しながらプラグインを以前のリビジョンに残す挙動が観測されているためです。
+
+更新されたプラグインの反映には Claude Code の再起動が必要です。何かを収束させた場合、スクリプトはその旨を 1 回出力します（`claude plugin update` 自身も "restart required to apply" と報告します）。
+
+`ref` を宣言していない marketplace — CLI に同梱される claude-plugins-official — は、不在ならインストールされますが更新はされません：収束先となる宣言済みリビジョンが存在しないためです。
+
+収束の失敗は警告にとどまり、apply は成功のままです（警告には対象アカウントとバージョンが含まれます）。ここで失敗させると chezmoi が毎回の apply でスクリプトを再実行することになり、しかも原因（ref を無視する CLI、読み取れない marketplace clone）はリトライでは解決しません。ただし警告されたプラグインを後から拾う仕組みもありません：`run_onchange` のキーはスクリプトのレンダリング後の本文なので、宣言が変わらない限り再実行されません — 警告が唯一の行動のきっかけです。次の 2 つは従来どおり致命的で、chezmoi が次回 apply で再試行します：*install* の失敗と、marketplace を登録解除した後の再登録の失敗（放置すると、宣言しているはずの marketplace が無いアカウントが残るため）。手動の fallback はスクリプトの動作をなぞるもので、アカウントごとに 1 回実行します：
 
 ```bash
-# デフォルトアカウント (~/.claude)
-claude plugin marketplace update openai-codex
+# デフォルトアカウント (~/.claude)。<pinned ref> は settings.json の値
+claude plugin marketplace rm openai-codex
+claude plugin marketplace add openai/codex-plugin-cc#<pinned ref>
 claude plugin update codex@openai-codex
 
-# ワークアカウント (~/.claude-r06)
-CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace update openai-codex
-CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin update codex@openai-codex
+# ワークアカウント: 同じ 3 コマンドを CLAUDE_CONFIG_DIR=~/.claude-r06 付きで実行
 ```
-
-反映には、その後 Claude Code の再起動が必要です（`claude plugin update` 自身が "restart required to apply" と報告します）。将来 ref を bump する際の注意点：marketplace 登録はソース ref の独自コピー（ランタイムの `known_marketplaces.json`）を保持し、`marketplace update` はその保存済み登録から pull します — したがって `settings.json` の pin を変更した後は、登録済み ref を確認し、遅れている場合は marketplace を再登録（`claude plugin marketplace rm` + `add`）してください。
 
 ### codex:codex-rescue — 手動レスキュー専用
 

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -280,19 +280,27 @@ The Claude Code side reaches Codex through the `codex` plugin from the `openai-c
 
 ### Converging the installed version
 
-The plugin setup script (`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`) installs a plugin only when it is absent: its install loop skips on a plugin-name match alone, with no version comparison. Editing the `ref` pin therefore never converges an already-installed plugin — a known gap (implementing reconciliation in the script is deliberately deferred). Convergence is manual, run once per account (`CLAUDE_CONFIG_DIR`):
+The plugin setup script (`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`) converges both accounts onto the pin at apply time, so editing the `ref` and running `chezmoi apply` is the whole procedure. That edit is also what re-triggers the script: it changes the declaration the script embeds, and with it the `run_onchange` key.
+
+Per account (`CLAUDE_CONFIG_DIR`), for every marketplace that declares a `ref`, the script compares the two things the runtime keeps independently of the declaration:
+
+- **The registration.** `known_marketplaces.json` holds the runtime's own copy of the source, ref included. When it no longer matches the declaration, the marketplace is unregistered and re-added at the declared ref. `claude plugin marketplace update` is not enough: it pulls from the stored registration, so it follows the stale ref.
+- **The installed version.** The version the marketplace clone offers for the plugin (from its `.claude-plugin/marketplace.json`, checked out at the pinned ref) against the version `claude plugin list` reports. A mismatch runs `claude plugin update`, and the outcome is verified by re-reading the installed version instead of trusting the exit code — the CLI has been seen leaving a plugin on its previous revision after reporting success.
+
+A Claude Code restart is required for an updated plugin to take effect; the script says so once when it converged anything (`claude plugin update` itself reports "restart required to apply").
+
+A marketplace with no declared `ref` — claude-plugins-official, which ships with the CLI — is installed when absent but never updated: there is no declared revision to converge onto.
+
+A convergence failure warns and leaves the apply successful, naming the account and the versions involved. Failing instead would make chezmoi re-run the script on every apply, and the causes (a CLI that ignores the ref, an unreadable marketplace clone) do not resolve by being retried. Nothing picks a warned-about plugin up later, either: the `run_onchange` key is the script's rendered body, so an unchanged declaration will not re-trigger the run — the warning is the only prompt to act. Two failures do stay fatal, so that chezmoi retries them on the next apply: a failed *install*, and a failed re-registration after the marketplace was already unregistered, which would otherwise leave the account without a marketplace it declares. The manual fallback mirrors what the script does, once per account:
 
 ```bash
-# default account (~/.claude)
-claude plugin marketplace update openai-codex
+# default account (~/.claude); <pinned ref> is the value from settings.json
+claude plugin marketplace rm openai-codex
+claude plugin marketplace add openai/codex-plugin-cc#<pinned ref>
 claude plugin update codex@openai-codex
 
-# work account (~/.claude-r06)
-CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace update openai-codex
-CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin update codex@openai-codex
+# work account: the same three commands prefixed with CLAUDE_CONFIG_DIR=~/.claude-r06
 ```
-
-A Claude Code restart is required afterwards for the updated plugin to take effect (`claude plugin update` itself reports "restart required to apply"). One caveat for a future ref bump: the marketplace registration keeps its own copy of the source ref (in the runtime's `known_marketplaces.json`), and `marketplace update` pulls from that stored registration — so after changing the `settings.json` pin, verify the registered ref and re-register the marketplace (`claude plugin marketplace rm` + `add`) if it lags.
 
 ### codex:codex-rescue — manual rescue only
 

--- a/docs/architecture/lifecycle-scripts.ja.md
+++ b/docs/architecture/lifecycle-scripts.ja.md
@@ -38,7 +38,7 @@ flowchart TD
         E --> F["13 setup-mcp\nrun_onchange\n(mise exec -- claude 経由で\n4つの user-scope MCP サーバーを登録)"]
         F --> G["14 enable-clv2-observer\nrun_onchange\n(per-account homunculus config.json に\nobserver.enabled=true を書き込む)"]
         G --> H["16 migrate-claude-binary\nrun_once\n(~/.local/bin/claude を\nmise installs/claude/latest へ symlink)"]
-        H --> H2["17 setup-claude-plugins\nrun_onchange\n(dot_claude/settings.json が宣言する\nmarketplace 登録 + plugin インストール)"]
+        H --> H2["17 setup-claude-plugins\nrun_onchange\n(dot_claude/settings.json が宣言する\nmarketplace 登録 + plugin インストール\npin 済みは ref へ収束)"]
         H2 --> I["18 setup-agent-browser\nrun_onchange\n(mise exec 経由で agent-browser install)"]
         I --> J["20 macos-defaults\nrun_onchange · macOS のみ\n(defaults write + killall Dock/Finder)"]
         J --> J2["30 register-launchd-agents\nrun_onchange · macOS のみ\n(repo 管理 LaunchAgent の launchctl bootstrap\nCI ではスキップ)"]

--- a/docs/architecture/lifecycle-scripts.md
+++ b/docs/architecture/lifecycle-scripts.md
@@ -38,7 +38,7 @@ flowchart TD
         E --> F["13 setup-mcp\nrun_onchange\n(registers 4 user-scope MCP servers\nvia mise exec -- claude)"]
         F --> G["14 enable-clv2-observer\nrun_onchange\n(sets observer.enabled=true\nin per-account homunculus config.json)"]
         G --> H["16 migrate-claude-binary\nrun_once\n(symlink ~/.local/bin/claude\n-> mise installs/claude/latest)"]
-        H --> H2["17 setup-claude-plugins\nrun_onchange\n(registers marketplaces + installs plugins\ndeclared in dot_claude/settings.json)"]
+        H --> H2["17 setup-claude-plugins\nrun_onchange\n(registers marketplaces + installs plugins\ndeclared in dot_claude/settings.json,\nconverging pinned ones onto their ref)"]
         H2 --> I["18 setup-agent-browser\nrun_onchange\n(agent-browser install via mise exec)"]
         I --> J["20 macos-defaults\nrun_onchange · macOS only\n(defaults write + killall Dock/Finder)"]
         J --> J2["30 register-launchd-agents\nrun_onchange · macOS only\n(launchctl bootstrap of repo-managed\nLaunchAgents; skipped in CI)"]

--- a/home/run_onchange_after_17-setup-claude-plugins.sh.tmpl
+++ b/home/run_onchange_after_17-setup-claude-plugins.sh.tmpl
@@ -130,23 +130,108 @@ marketplace_source() {
   '
 }
 
+# The user-scoped plugins the runtime reports, as a JSON array. `plugin list --json` prints one object
+# per installed plugin. Filter to user scope, the scope this script installs into: a project- or
+# local-scoped plugin of the same name must not mask a missing user-scoped one. The command is empty
+# (and exits non-zero) before the plugin runtime exists, which is the expected state on a first apply,
+# so an unreadable list degrades to "nothing installed" rather than aborting.
+list_installed_plugins() {
+  local out
+  out="$(CLAUDE_CONFIG_DIR="$1" mise exec -- claude plugin list --json 2>/dev/null | "${jq_cmd[@]}" -c '[.[] | select(.scope == "user")]' 2>/dev/null || true)"
+  if [ -z "$out" ]; then
+    printf '[]'
+    return 0
+  fi
+  printf '%s' "$out"
+}
+
+# Whether the runtime lists a plugin at all, keyed on its "<name>@<marketplace>" id.
+plugin_is_installed() {
+  # shellcheck disable=SC2016  # $id is a jq variable bound by --arg, not a shell expansion.
+  printf '%s' "$installed_json" | "${jq_cmd[@]}" -e --arg id "$1" 'any(.[]; .id == $id)' >/dev/null 2>&1
+}
+
+# The version the runtime records for an installed plugin, empty when it is absent or unversioned.
+installed_plugin_version() {
+  # shellcheck disable=SC2016  # $id is a jq variable bound by --arg, not a shell expansion.
+  printf '%s' "$installed_json" | "${jq_cmd[@]}" -r --arg id "$1" 'map(select(.id == $id)) | .[0].version // ""'
+}
+
+# The ref settings.json pins a marketplace to, empty when none is declared. Only a pinned marketplace
+# can be converged: without a declared ref there is no expected revision to hold the runtime against,
+# so claude-plugins-official (ships with the CLI, never pinned here) is installed but never updated.
+declared_marketplace_ref() {
+  # shellcheck disable=SC2016  # $m is a jq variable bound by --arg, not a shell expansion.
+  printf '%s' "$declaration_json" | "${jq_cmd[@]}" -r --arg m "$1" '.extraKnownMarketplaces[$m].source.ref // ""'
+}
+
+# How the runtime's registration compares to what settings.json declares: 0 it matches, 1 it differs,
+# 2 it cannot be told. The registration keeps its own copy of the source (ref included) in
+# known_marketplaces.json, so a bumped pin stays invisible until the two copies are compared -- and
+# `claude plugin marketplace update` would keep pulling the stale registered ref. Both sides are reduced
+# to the fields that decide what gets checked out instead of being compared whole, so a field the CLI
+# later adds to its own copy cannot make every apply look like a pin change.
+#
+# "Cannot be told" is kept distinct from "differs" because acting on a difference unregisters a
+# marketplace: a file caught half-written by a concurrent CLI run is not evidence that the pin moved.
+registration_state() {
+  local name="$1" known_file="$2" verdict
+  [ -f "$known_file" ] || return 2
+  # shellcheck disable=SC2016  # $m and $known are jq variables bound by --arg/--slurpfile.
+  verdict="$(printf '%s' "$declaration_json" | "${jq_cmd[@]}" -r --arg m "$name" --slurpfile known "$known_file" '
+    def ident: [(.source // ""), (.repo // .url // ""), (.ref // "")];
+    if (.extraKnownMarketplaces[$m].source // {} | ident) == ($known[0][$m].source // {} | ident)
+    then "match" else "differ" end
+  ' 2>/dev/null)" || return 2
+  case "$verdict" in
+    match) return 0 ;;
+    differ) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
+# The version a pinned marketplace offers for a plugin, read from the local marketplace clone rather
+# than from the network: once the registration matches the pin, the clone sits at the pinned ref, so
+# its manifest is the expected version. `installLocation` is where the runtime says it put the clone;
+# the conventional path is only a fallback for an entry that predates the field. Fails when the clone
+# or the plugin entry is missing, which the caller reports instead of guessing a version.
+marketplace_plugin_version() {
+  local name="$1" plugin_name="$2" known_file="$3" config_dir="$4"
+  local location=""
+  if [ -f "$known_file" ]; then
+    # shellcheck disable=SC2016  # $m is a jq variable bound by --arg, not a shell expansion.
+    location="$("${jq_cmd[@]}" -r --arg m "$name" '.[$m].installLocation // ""' "$known_file" 2>/dev/null || true)"
+  fi
+  if [ -z "$location" ]; then
+    location="${config_dir}/plugins/marketplaces/${name}"
+  fi
+  local manifest="${location}/.claude-plugin/marketplace.json"
+  [ -f "$manifest" ] || return 1
+  # shellcheck disable=SC2016  # $p is a jq variable bound by --arg, not a shell expansion.
+  "${jq_cmd[@]}" -er --arg p "$plugin_name" 'first(.plugins[] | select(.name == $p) | .version)' "$manifest" 2>/dev/null
+}
+
+# A failure to install, or to re-register a marketplace that was just unregistered, is fatal (chezmoi
+# retries); any other failure to converge an already-installed plugin only warns. See the exit contract
+# at the bottom of this script.
 failed=0
+warned=0
+converged=0
 for config_dir in "${config_dirs[@]}"; do
   echo "==> Reconciling Claude Code plugins in ${config_dir}..."
   mkdir -p "$config_dir"
   known_marketplaces="${config_dir}/plugins/known_marketplaces.json"
-  # `plugin list --json` prints one object per installed plugin. Filter to user scope, the scope this
-  # script installs into: a project- or local-scoped plugin of the same name must not mask a missing
-  # user-scoped one. The command is empty (and exits non-zero) before the plugin runtime exists, which
-  # is the expected state on a first apply.
-  installed="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin list --json 2>/dev/null | "${jq_cmd[@]}" -r '.[] | select(.scope == "user") | .id' || true)"
+  installed_json="$(list_installed_plugins "$config_dir")"
 
   for plugin in "${plugins[@]}"; do
     marketplace="${plugin##*@}"
+    plugin_name="${plugin%@*}"
+    declared_ref="$(declared_marketplace_ref "$marketplace")"
 
-    # Presence is keyed on the marketplace name only: an entry already registered under a different
+    # An unpinned marketplace is keyed on its name only: an entry already registered under a different
     # source is trusted as-is. Rewriting it would need local write access to known_marketplaces.json,
-    # which already implies control of this machine.
+    # which already implies control of this machine. A pinned one is held to its declaration, because
+    # the pin is the whole point of declaring it.
     # shellcheck disable=SC2016  # $m is a jq variable bound by --arg, not a shell expansion.
     if [ ! -f "$known_marketplaces" ] || ! "${jq_cmd[@]}" -e --arg m "$marketplace" 'has($m)' "$known_marketplaces" >/dev/null 2>&1; then
       if ! source_spec="$(marketplace_source "$marketplace")"; then
@@ -159,23 +244,113 @@ for config_dir in "${config_dirs[@]}"; do
         failed=1
         continue
       fi
+      # An earlier plugin in this loop may have unregistered this marketplace to re-register it, and
+      # unregistering can take its plugins with it, so the list captured at the top of the account may
+      # no longer be true.
+      installed_json="$(list_installed_plugins "$config_dir")"
+    elif [ -n "$declared_ref" ]; then
+      registration=0
+      registration_state "$marketplace" "$known_marketplaces" || registration=$?
+      if [ "$registration" -eq 2 ]; then
+        printf 'WARNING: cannot read the registration of marketplace %s in %s; leaving it untouched\n' "$marketplace" "$config_dir" >&2
+        warned=1
+        continue
+      fi
+      if [ "$registration" -eq 1 ]; then
+        # The pin moved. Updating the marketplace in place would follow the ref stored in the stale
+        # registration, so the registration itself is replaced.
+        if ! source_spec="$(marketplace_source "$marketplace")"; then
+          printf 'WARNING: cannot resolve a source for marketplace %s (needed by %s) in %s; leaving its registration on the previous ref\n' "$marketplace" "$plugin" "$config_dir" >&2
+          warned=1
+          continue
+        fi
+        echo "==> Re-registering marketplace ${marketplace} in ${config_dir} at ${declared_ref}..."
+        if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin marketplace remove "$marketplace" --scope user 2>&1)"; then
+          # Only a warning: the previous registration is still in place, so the account keeps working
+          # off the ref it already had.
+          printf 'WARNING: failed to unregister marketplace %s in %s; it stays on its previous ref\n%s\n' "$marketplace" "$config_dir" "$out" >&2
+          warned=1
+          continue
+        fi
+        if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin marketplace add "$source_spec" --scope user 2>&1)"; then
+          # Fatal, unlike the other convergence failures: the marketplace has just been unregistered,
+          # so the account is left without one it declares -- strictly worse than the stale ref it
+          # started from. Nothing would pick this up later either, because the run_onchange key is the
+          # rendered body and the declaration has not changed; exiting non-zero is what makes chezmoi
+          # retry on the next apply.
+          printf 'ERROR: failed to register marketplace %s (%s) in %s after unregistering it\n%s\n' "$marketplace" "$source_spec" "$config_dir" "$out" >&2
+          failed=1
+          continue
+        fi
+        # Unregistering a marketplace can take its plugins with it, so the list captured before the
+        # re-registration may still claim a plugin is installed when it no longer is.
+        installed_json="$(list_installed_plugins "$config_dir")"
+      fi
     fi
 
-    if printf '%s\n' "$installed" | grep -qxF "$plugin"; then
+    if ! plugin_is_installed "$plugin"; then
+      if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin install "$plugin" --scope user 2>&1)"; then
+        printf 'ERROR: failed to install plugin %s in %s\n%s\n' "$plugin" "$config_dir" "$out" >&2
+        failed=1
+      fi
       continue
     fi
-    if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin install "$plugin" --scope user 2>&1)"; then
-      printf 'ERROR: failed to install plugin %s in %s\n%s\n' "$plugin" "$config_dir" "$out" >&2
-      failed=1
+
+    # Installed, so from here on the question is whether it matches the pin. Nothing to match against
+    # without one.
+    [ -n "$declared_ref" ] || continue
+
+    if ! expected_version="$(marketplace_plugin_version "$marketplace" "$plugin_name" "$known_marketplaces" "$config_dir")"; then
+      printf 'WARNING: cannot read the version %s offers for %s in %s; skipping the version check\n' "$marketplace" "$plugin" "$config_dir" >&2
+      warned=1
+      continue
     fi
+    installed_version="$(installed_plugin_version "$plugin")"
+    if [ "$installed_version" = "$expected_version" ]; then
+      continue
+    fi
+
+    echo "==> Updating ${plugin} in ${config_dir} (${installed_version:-unknown} -> ${expected_version})..."
+    if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin update "$plugin" --scope user 2>&1)"; then
+      printf 'WARNING: failed to update plugin %s in %s from %s to %s\n%s\n' "$plugin" "$config_dir" "${installed_version:-unknown}" "$expected_version" "$out" >&2
+      warned=1
+      continue
+    fi
+
+    # Verify instead of trusting the exit code: the CLI has been seen leaving a plugin on its previous
+    # revision after reporting success. Checked once and not retried -- a retry would repeat the same
+    # call against the same inputs.
+    installed_json="$(list_installed_plugins "$config_dir")"
+    installed_version="$(installed_plugin_version "$plugin")"
+    if [ "$installed_version" != "$expected_version" ]; then
+      printf 'WARNING: %s in %s is still at %s after updating to %s; converge it by hand (docs/agents/codex.md, "Converging the installed version")\n' "$plugin" "$config_dir" "${installed_version:-unknown}" "$expected_version" >&2
+      warned=1
+      continue
+    fi
+    converged=1
   done
 done
 
 if [ "$failed" -ne 0 ]; then
   # Exit non-zero so chezmoi does not record this run as successful and retries on the next apply,
   # instead of freezing a partially-reconciled state (same contract as run_onchange_after_13-setup-mcp).
-  echo "ERROR: one or more Claude Code plugins failed to install; chezmoi will retry on the next apply." >&2
+  echo "ERROR: one or more Claude Code plugins could not be installed or registered; chezmoi will retry on the next apply." >&2
   exit 1
+fi
+
+if [ "$warned" -ne 0 ]; then
+  # Deliberately not fatal. A plugin that is installed but off its pin still works, whereas failing
+  # here would make chezmoi re-run this script on every apply -- and the causes above (a CLI that
+  # ignores the ref, an unreadable marketplace clone) do not resolve by being retried.
+  #
+  # Nothing picks these up later on its own, though: the run_onchange key is this script's rendered
+  # body, so an unchanged declaration will not re-trigger the run. The warning is the only prompt to
+  # act, which is why it names the manual procedure.
+  echo "WARNING: one or more plugins could not be converged onto their pinned version; converge them by hand (docs/agents/codex.md, \"Converging the installed version\") -- an unchanged declaration will not re-trigger this script." >&2
+fi
+
+if [ "$converged" -ne 0 ]; then
+  echo "==> Restart Claude Code for the updated plugins to take effect."
 fi
 
 echo "==> Claude Code plugins reconciled."

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -616,6 +616,10 @@ load helpers/setup
 # claude reproduces the two behaviours the script exists to handle: it rewrites settings.json with its
 # own serializer (dropping the hook `id` annotations), and it replaces the work account's settings.json
 # symlink with a regular file via an atomic rename.
+#
+# It also mirrors the parts of the runtime the version reconciliation reads: the registration keeps its
+# own copy of the source (ref included) plus an installLocation, the marketplace clone carries a
+# manifest whose version is whatever the requested ref ships, and installed plugins carry a version.
 _reconciler_sandbox() {
   local sandbox="$1"
   mkdir -p "${sandbox}/home/.claude" "${sandbox}/home/.claude-r06" "${sandbox}/bin"
@@ -634,6 +638,15 @@ FAKE_MISE
 set -euo pipefail
 cfg="${CLAUDE_CONFIG_DIR:?}"
 log="${FAKE_CLAUDE_LOG:?}"
+
+# The version the marketplace clone offers for a plugin id, empty when it offers none.
+_clone_version() {
+  local id="$1"
+  local marketplace="${id##*@}" name="${id%@*}"
+  jq -r --arg p "$name" 'first(.plugins[] | select(.name == $p) | .version) // ""' \
+    "${cfg}/plugins/marketplaces/${marketplace}/.claude-plugin/marketplace.json" 2>/dev/null || true
+}
+
 case "${1:-} ${2:-}" in
   "plugin list")
     # Exits non-zero before the runtime exists, exactly like the real CLI.
@@ -641,17 +654,50 @@ case "${1:-} ${2:-}" in
     cat "${cfg}/plugins/installed.json"
     ;;
   "plugin marketplace")
-    src="$4"
-    echo "marketplace-add ${cfg##*/} ${src}" >>"$log"
-    case "$src" in
-      anthropics/claude-plugins-official*) key=claude-plugins-official ;;
-      openai/codex-plugin-cc*) key=openai-codex ;;
-      *) echo "unknown marketplace source: $src" >&2; exit 1 ;;
+    case "$3" in
+      add)
+        src="$4"
+        [ "${FAKE_CLAUDE_MARKETPLACE_ADD_FAILS:-0}" = "1" ] && { echo "add boom" >&2; exit 1; }
+        echo "marketplace-add ${cfg##*/} ${src}" >>"$log"
+        repo="${src%%#*}"
+        ref=""
+        [ "$src" = "$repo" ] || ref="${src#*#}"
+        case "$repo" in
+          anthropics/claude-plugins-official) key=claude-plugins-official; provides=claude-code-setup ;;
+          openai/codex-plugin-cc) key=openai-codex; provides=codex ;;
+          *) echo "unknown marketplace source: $src" >&2; exit 1 ;;
+        esac
+        # The clone lands on the requested ref, so its manifest is what that ref ships.
+        version="${ref#v}"
+        [ -n "$version" ] || version="1.0.0"
+        location="${cfg}/plugins/marketplaces/${key}"
+        mkdir -p "${cfg}/plugins" "${location}/.claude-plugin"
+        jq -n --arg n "$key" --arg p "$provides" --arg v "$version" \
+          '{name: $n, plugins: [{name: $p, version: $v}]}' >"${location}/.claude-plugin/marketplace.json"
+        [ -f "${cfg}/plugins/known_marketplaces.json" ] || echo '{}' >"${cfg}/plugins/known_marketplaces.json"
+        jq --arg k "$key" --arg r "$repo" --arg ref "$ref" --arg loc "$location" \
+          '.[$k] = {
+             source: ({source: "github", repo: $r} + (if $ref == "" then {} else {ref: $ref} end)),
+             installLocation: $loc
+           }' "${cfg}/plugins/known_marketplaces.json" >"${cfg}/plugins/km.tmp"
+        mv "${cfg}/plugins/km.tmp" "${cfg}/plugins/known_marketplaces.json"
+        ;;
+      remove)
+        name="$4"
+        echo "marketplace-remove ${cfg##*/} ${name}" >>"$log"
+        jq --arg k "$name" 'del(.[$k])' "${cfg}/plugins/known_marketplaces.json" >"${cfg}/plugins/km.tmp"
+        mv "${cfg}/plugins/km.tmp" "${cfg}/plugins/known_marketplaces.json"
+        rm -rf "${cfg}/plugins/marketplaces/${name}"
+        # Optional: a CLI that takes the marketplace's plugins with it, which is what the reconciler
+        # re-reads the installed list for.
+        if [ "${FAKE_CLAUDE_REMOVE_UNINSTALLS:-0}" = "1" ] && [ -f "${cfg}/plugins/installed.json" ]; then
+          jq --arg m "$name" 'map(select((.id | split("@") | last) != $m))' \
+            "${cfg}/plugins/installed.json" >"${cfg}/plugins/inst.tmp"
+          mv "${cfg}/plugins/inst.tmp" "${cfg}/plugins/installed.json"
+        fi
+        ;;
+      *) echo "unexpected fake claude marketplace invocation: $*" >&2; exit 1 ;;
     esac
-    mkdir -p "${cfg}/plugins"
-    [ -f "${cfg}/plugins/known_marketplaces.json" ] || echo '{}' >"${cfg}/plugins/known_marketplaces.json"
-    jq --arg k "$key" '.[$k] = {}' "${cfg}/plugins/known_marketplaces.json" >"${cfg}/plugins/km.tmp"
-    mv "${cfg}/plugins/km.tmp" "${cfg}/plugins/known_marketplaces.json"
     ;;
   "plugin install")
     id="$3"
@@ -659,12 +705,26 @@ case "${1:-} ${2:-}" in
     echo "install ${cfg##*/} ${id}" >>"$log"
     mkdir -p "${cfg}/plugins"
     [ -f "${cfg}/plugins/installed.json" ] || echo '[]' >"${cfg}/plugins/installed.json"
-    jq --arg i "$id" '. + [{id: $i, scope: "user"}]' "${cfg}/plugins/installed.json" >"${cfg}/plugins/inst.tmp"
+    jq --arg i "$id" --arg v "$(_clone_version "$id")" \
+      '. + [{id: $i, version: $v, scope: "user"}]' "${cfg}/plugins/installed.json" >"${cfg}/plugins/inst.tmp"
     mv "${cfg}/plugins/inst.tmp" "${cfg}/plugins/installed.json"
     # Reproduce the CLI's settings.json rewrite: drop the hook annotations, and replace the file (an
     # atomic rename, which clobbers the work account's symlink).
     jq 'del(.hooks.SessionStart[0].id, .hooks.SessionStart[0].description)' "${cfg}/settings.json" >"${cfg}/settings.tmp"
     mv "${cfg}/settings.tmp" "${cfg}/settings.json"
+    ;;
+  "plugin update")
+    id="$3"
+    [ "${FAKE_CLAUDE_UPDATE_FAILS:-0}" = "1" ] && { echo "update boom" >&2; exit 1; }
+    echo "update ${cfg##*/} ${id}" >>"$log"
+    # The record is updated straight away, as observed on a real runtime: "restart required to apply"
+    # is about the running session picking the plugin up, not about when `plugin list` reports it.
+    # Reports success while leaving the plugin where it was -- the behaviour the reconciler verifies
+    # against instead of trusting the exit code.
+    [ "${FAKE_CLAUDE_UPDATE_NOOP:-0}" = "1" ] && exit 0
+    jq --arg i "$id" --arg v "$(_clone_version "$id")" \
+      'map(if .id == $i then .version = $v else . end)' "${cfg}/plugins/installed.json" >"${cfg}/plugins/inst.tmp"
+    mv "${cfg}/plugins/inst.tmp" "${cfg}/plugins/installed.json"
     ;;
   *) echo "unexpected fake claude invocation: $*" >&2; exit 1 ;;
 esac
@@ -672,6 +732,36 @@ FAKE_CLAUDE
   chmod +x "${sandbox}/bin/mise" "${sandbox}/bin/claude"
   chezmoi execute-template --source "${HOME_DIR}" \
     <"${HOME_DIR}/run_onchange_after_17-setup-claude-plugins.sh.tmpl" >"${sandbox}/reconcile.sh"
+}
+
+# The ref settings.json pins openai-codex to. Read rather than hardcoded so a pin bump does not have to
+# be mirrored into every convergence test.
+_pinned_codex_ref() {
+  jq -r '.extraKnownMarketplaces["openai-codex"].source.ref' "${HOME_DIR}/dot_claude/settings.json"
+}
+
+# Rewind one account's runtime to the state a `chezmoi apply` finds right after the pin is bumped: the
+# registration and the marketplace clone still sit on the previous ref, and the installed plugin is the
+# version that ref shipped. The unpinned marketplace is left with an installed version its clone does
+# not offer, so a reconciler that converged unpinned marketplaces too would show up as an update call.
+_reconciler_rewind() {
+  local sandbox="$1" account="$2" ref="$3"
+  local dir="${sandbox}/home/${account}/plugins"
+  local version="${ref#v}"
+
+  jq --arg r "$ref" '.["openai-codex"].source.ref = $r' "${dir}/known_marketplaces.json" >"${dir}/km.tmp"
+  mv "${dir}/km.tmp" "${dir}/known_marketplaces.json"
+
+  jq --arg v "$version" '.plugins = [.plugins[] | .version = $v]' \
+    "${dir}/marketplaces/openai-codex/.claude-plugin/marketplace.json" >"${dir}/mp.tmp"
+  mv "${dir}/mp.tmp" "${dir}/marketplaces/openai-codex/.claude-plugin/marketplace.json"
+
+  jq --arg v "$version" '
+    map(if .id == "codex@openai-codex" then .version = $v
+        elif .id == "claude-code-setup@claude-plugins-official" then .version = "0.0.1"
+        else . end)
+  ' "${dir}/installed.json" >"${dir}/inst.tmp"
+  mv "${dir}/inst.tmp" "${dir}/installed.json"
 }
 
 @test "claude plugin reconciler: installs per account, passes the pinned ref, restores settings.json" {
@@ -732,6 +822,173 @@ FAKE_CLAUDE
   [ "$status" -ne 0 ]
   # A partially-reconciled run must still leave settings.json as chezmoi wrote it.
   jq -e '.hooks.SessionStart[0] | has("id")' "${sandbox}/home/.claude/settings.json"
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: a moved pin re-registers the marketplace and converges the plugin" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox pinned_ref pinned_version account
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+  pinned_ref="$(_pinned_codex_ref)"
+  pinned_version="${pinned_ref#v}"
+
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  _reconciler_rewind "$sandbox" .claude v0.0.9
+  _reconciler_rewind "$sandbox" .claude-r06 v0.0.9
+  : >"${sandbox}/calls.log"
+
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  [ "$status" -eq 0 ]
+
+  for account in .claude .claude-r06; do
+    # Updating the marketplace in place would follow the ref its stale registration stored, so the
+    # registration is replaced before the plugin is updated -- once per account.
+    grep -qF "marketplace-remove ${account} openai-codex" "${sandbox}/calls.log"
+    grep -qF "marketplace-add ${account} openai/codex-plugin-cc#${pinned_ref}" "${sandbox}/calls.log"
+    grep -qF "update ${account} codex@openai-codex" "${sandbox}/calls.log"
+    jq -e --arg v "$pinned_version" 'any(.[]; .id == "codex@openai-codex" and .version == $v)' \
+      "${sandbox}/home/${account}/plugins/installed.json"
+  done
+
+  # An unpinned marketplace has no declared revision to converge onto, so it is never updated -- even
+  # though the rewind left its clone offering a version the runtime does not have installed.
+  ! grep -qE '^update .* claude-code-setup@claude-plugins-official' "${sandbox}/calls.log"
+
+  [[ "$output" == *"Restart Claude Code"* ]]
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: a failed update warns instead of failing the apply" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  _reconciler_rewind "$sandbox" .claude v0.0.9
+  _reconciler_rewind "$sandbox" .claude-r06 v0.0.9
+  : >"${sandbox}/calls.log"
+
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" FAKE_CLAUDE_UPDATE_FAILS=1 bash "${sandbox}/reconcile.sh"
+  # Zero on purpose: a plugin that is off its pin still works, and failing here would make chezmoi
+  # re-run this script on every apply for a cause that retrying does not fix.
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARNING"* ]]
+  [[ "$output" != *"Restart Claude Code"* ]]
+  jq -e 'any(.[]; .id == "codex@openai-codex" and .version == "0.0.9")' \
+    "${sandbox}/home/.claude/plugins/installed.json"
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: an update the CLI ignores is caught by verification, not retried" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  _reconciler_rewind "$sandbox" .claude v0.0.9
+  _reconciler_rewind "$sandbox" .claude-r06 v0.0.9
+  : >"${sandbox}/calls.log"
+
+  # The fake reports success while leaving the plugin on its previous version.
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" FAKE_CLAUDE_UPDATE_NOOP=1 bash "${sandbox}/reconcile.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARNING"* ]]
+  [[ "$output" != *"Restart Claude Code"* ]]
+  # One attempt per account: retrying would repeat the same call against the same inputs.
+  [ "$(grep -c '^update ' "${sandbox}/calls.log")" -eq 2 ]
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: an unreadable clone manifest warns instead of guessing a version" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  rm -f "${sandbox}/home/.claude/plugins/marketplaces/openai-codex/.claude-plugin/marketplace.json"
+  : >"${sandbox}/calls.log"
+
+  # stderr is redirected inside the command rather than read out of bats' merged $output, so this
+  # pins the "warnings go to stderr" half of the contract too.
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" FAKE_CLAUDE_LOG="${sandbox}/calls.log" \
+    bash -c 'bash "$1" 2>"$2"' _ "${sandbox}/reconcile.sh" "${sandbox}/err.log"
+  [ "$status" -eq 0 ]
+  grep -q 'WARNING' "${sandbox}/err.log"
+  # No expected version means no basis for an update, so none is attempted.
+  ! grep -q '^update ' "${sandbox}/calls.log"
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: failing to re-register after unregistering is fatal" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  # Only the default account drifts, so the run also covers the asymmetric case.
+  _reconciler_rewind "$sandbox" .claude v0.0.9
+  : >"${sandbox}/calls.log"
+
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" FAKE_CLAUDE_MARKETPLACE_ADD_FAILS=1 bash "${sandbox}/reconcile.sh"
+  # Non-zero unlike the other convergence failures: the marketplace is now unregistered, and an
+  # unchanged declaration would never re-trigger this run_onchange script on its own.
+  [ "$status" -ne 0 ]
+  grep -qF 'marketplace-remove .claude openai-codex' "${sandbox}/calls.log"
+  jq -e 'has("openai-codex") | not' "${sandbox}/home/.claude/plugins/known_marketplaces.json"
+  # The work account was already on the pin, so it is left alone.
+  ! grep -q ' .claude-r06 ' "${sandbox}/calls.log"
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: a re-registration that uninstalls the plugin reinstalls it" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox pinned_version
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+  pinned_version="$(_pinned_codex_ref)"
+  pinned_version="${pinned_version#v}"
+
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  _reconciler_rewind "$sandbox" .claude v0.0.9
+  _reconciler_rewind "$sandbox" .claude-r06 v0.0.9
+  : >"${sandbox}/calls.log"
+
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" FAKE_CLAUDE_REMOVE_UNINSTALLS=1 bash "${sandbox}/reconcile.sh"
+  [ "$status" -eq 0 ]
+  # Re-reading the installed list after the re-registration is what makes this reachable: the list
+  # captured at the top of the account still claimed the plugin was there.
+  grep -qF 'install .claude codex@openai-codex' "${sandbox}/calls.log"
+  grep -qF 'install .claude-r06 codex@openai-codex' "${sandbox}/calls.log"
+  jq -e --arg v "$pinned_version" 'any(.[]; .id == "codex@openai-codex" and .version == $v)' \
+    "${sandbox}/home/.claude/plugins/installed.json"
 
   rm -rf "$sandbox"
 }


### PR DESCRIPTION
Closes #342

## Summary

`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl` installed a plugin only when it was
absent, so editing `extraKnownMarketplaces.<name>.source.ref` in `home/dot_claude/settings.json`
never moved an already-installed plugin — the pin was the source of truth on paper only, and
convergence was a manual, per-account procedure.

The script now reconciles both accounts (`~/.claude`, `~/.claude-r06`) at apply time, for every
marketplace that declares a `ref`:

- **The registration.** `known_marketplaces.json` keeps the runtime's own copy of the source, ref
  included. When it no longer matches the declaration, the marketplace is unregistered and re-added
  at the declared ref. `claude plugin marketplace update` pulls from the stored registration, so it
  would keep following the stale ref.
- **The installed version.** The version the marketplace clone offers (its
  `.claude-plugin/marketplace.json`, checked out at the pinned ref) against what
  `claude plugin list` reports. A mismatch runs `claude plugin update`, and the result is verified
  by re-reading the installed version instead of trusting the exit code.

Both comparisons read local files, so a run with nothing to do makes no extra CLI calls and no
network requests. Editing the pin is also what re-triggers the script — the declaration is rendered
into the body, which is the `run_onchange` key.

## Exit contract

| Outcome | Result |
|---|---|
| Failed install, or a re-registration that fails after the marketplace was unregistered | `exit 1` — chezmoi retries on the next apply |
| Failed update, verification mismatch, unreadable clone manifest or registration | `WARNING` on stderr, `exit 0` |

Convergence failures do not fail the apply: their causes (a CLI that ignores the ref, an unreadable
clone) do not resolve by being retried, and failing would re-run the script on every apply. A
marketplace with no declared `ref` (claude-plugins-official, which ships with the CLI) is installed
when absent but never updated.

## Review notes

- **`run_onchange` re-run semantics.** The key is the rendered script body, so an unchanged
  declaration never re-triggers the run. An earlier draft warned on a re-registration that had
  already unregistered the marketplace and claimed "the next apply retries" — it would not have.
  That one case is now fatal, and the warning text and docs say plainly that a warning is the only
  prompt to act.
- **Unreadable registration is not a difference.** The comparison is tri-state (matches / differs /
  cannot tell) so a file caught half-written by a concurrent CLI run cannot trigger the destructive
  unregister.
- **Installed list is re-read after any successful marketplace add**, not only after a
  re-registration: unregistering can take a marketplace's plugins with it, which would otherwise be
  missed for a second plugin from the same marketplace.

## Test plan

- [x] `make lint` — shellcheck, shfmt, zsh syntax
- [x] `make test` — 183 tests, 0 failures
- [x] Reconciler suite (12 tests). The three pre-existing ones pass with their assertions unchanged;
      the no-op test now also proves convergence is idempotent, because the fake records a faithful
      registration.
- [x] New scenarios: moved pin re-registers and converges (and leaves the unpinned marketplace
      alone); failed update warns and exits 0; an update the CLI ignores is caught by verification
      and not retried; an unreadable clone manifest warns on stderr without attempting an update; a
      re-registration whose add fails exits non-zero and leaves the other account untouched; a
      re-registration that uninstalls the plugin reinstalls it.
- [x] Rendered template passes `bash -n` via `chezmoi execute-template`
- [x] EN/JA docs lockstep: `codex.md` and `codex.ja.md` both 321 lines with identical heading lines
- [ ] No `chezmoi apply` was run — the live plugin state is deliberately untouched by this PR

## Docs

`docs/agents/codex.md` / `.ja.md` describe the automated path and keep the manual commands as the
fallback. `docs/agents/claude-code.md` / `.ja.md` and `docs/architecture/lifecycle-scripts.md` /
`.ja.md` no longer describe the script as registering and installing only.
