### PR TITLE
feat(claude): reconcile codex plugin ref at chezmoi apply time

### DIFF
--- a/docs/agents/codex.ja.md
+++ b/docs/agents/codex.ja.md
@@ -280,19 +280,29 @@ Claude Code 側は `openai-codex` marketplace の `codex` プラグインを通�
 
 ### インストール済みバージョンの収束
 
-プラグインセットアップスクリプト（`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`）はプラグインが存在しない場合にのみインストールします：install ループはプラグイン名の一致だけで skip し、バージョン比較を行いません。したがって `ref` pin の編集だけでは、インストール済みプラグインは決して収束しません — これは既知のギャップです（スクリプトへの reconcile 実装は意図的に先送り）。収束は手動で、アカウント（`CLAUDE_CONFIG_DIR`）ごとに 1 回実行します：
+プラグインセットアップスクリプト（`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`）は、pin が変わったときにインストール済みプラグインを pin された `ref` へ収束させます。pin はスクリプトの `run_onchange` キーの一部（レンダリングされた `extraKnownMarketplaces` 経由）なので、**`ref` を編集すると次の `chezmoi apply` でスクリプトが再実行され、両アカウント（`~/.claude` と `~/.claude-r06`）が自動的に収束します** — 手動のプラグインコマンドは不要です（宣言が変わらない apply では再実行されません）。
+
+収束は、pin された `ref` とランタイムが `known_marketplaces.json` に記録した ref を比較して行います。両者が異なる場合、marketplace を新しい ref で再登録し（`marketplace update` だけでは stale な登録 ref を pull し直してしまうため `marketplace rm` + `add`）、続いて `plugin update` を実行します。この収束は意図的に fail-safe です：
+
+- **silent success ではなく post-verification** — 収束後に登録済み ref を再読込し、依然として遅れている場合（CLI が一部の経路で ref を無視することが観測されています）は、成功として報告せず明示的な `WARNING` を出力します。
+- **収束の失敗は warning であり、apply を fail させません** — `chezmoi apply` は green のまま（`exit 0`）で、CLI が拒否した ref は毎回 retry されるのではなく一度だけ surface されます。fatal を維持するのは *fresh* install（プラグインが存在せずインストールもできない）のみで、その場合は chezmoi が retry します。
+- **再起動 notice** — プラグインを更新した際は、反映に Claude Code の再起動が必要である旨を出力します（`claude plugin update` 自身が "restart required to apply" と報告します）。
+
+**手動フォールバック** — 自動化パスが収束できなかったと warning を出した場合にのみ必要です。アカウント（`CLAUDE_CONFIG_DIR`）ごとに 1 回、`<ref>` を pin されたタグに置き換えて実行します：
 
 ```bash
 # デフォルトアカウント (~/.claude)
-claude plugin marketplace update openai-codex
+claude plugin marketplace rm openai-codex
+claude plugin marketplace add openai/codex-plugin-cc#<ref>
 claude plugin update codex@openai-codex
 
 # ワークアカウント (~/.claude-r06)
-CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace update openai-codex
+CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace rm openai-codex
+CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace add openai/codex-plugin-cc#<ref>
 CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin update codex@openai-codex
 ```
 
-反映には、その後 Claude Code の再起動が必要です（`claude plugin update` 自身が "restart required to apply" と報告します）。将来 ref を bump する際の注意点：marketplace 登録はソース ref の独自コピー（ランタイムの `known_marketplaces.json`）を保持し、`marketplace update` はその保存済み登録から pull します — したがって `settings.json` の pin を変更した後は、登録済み ref を確認し、遅れている場合は marketplace を再登録（`claude plugin marketplace rm` + `add`）してください。
+`marketplace update` ではなく `rm` + `add` を使うのは、marketplace 登録がソース ref の独自コピーを `known_marketplaces.json` に保持し、`marketplace update` がその保存済み（stale な）登録から pull するためです。反映には、その後 Claude Code の再起動が必要です。
 
 ### codex:codex-rescue — 手動レスキュー専用
 

--- a/docs/agents/codex.ja.md
+++ b/docs/agents/codex.ja.md
@@ -282,7 +282,7 @@ Claude Code 側は `openai-codex` marketplace の `codex` プラグインを通�
 
 プラグインセットアップスクリプト（`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`）は、pin が変わったときにインストール済みプラグインを pin された `ref` へ収束させます。pin はスクリプトの `run_onchange` キーの一部（レンダリングされた `extraKnownMarketplaces` 経由）なので、**`ref` を編集すると次の `chezmoi apply` でスクリプトが再実行され、両アカウント（`~/.claude` と `~/.claude-r06`）が自動的に収束します** — 手動のプラグインコマンドは不要です（宣言が変わらない apply では再実行されません）。
 
-収束は、pin された `ref` とランタイムが `known_marketplaces.json` に記録した ref を比較して行います。両者が異なる場合、marketplace を新しい ref で再登録し（`marketplace update` だけでは stale な登録 ref を pull し直してしまうため `marketplace rm` + `add`）、続いて `plugin update` を実行します。この収束は意図的に fail-safe です：
+収束は、pin された `ref` とランタイムが `known_marketplaces.json` に記録した ref を比較して行います。両者が異なる場合、plain な `marketplace add` で marketplace を新しい ref に再登録し（`marketplace add` は既登録を in-place で上書きします。`marketplace update` だけでは stale な登録 ref を pull し直し、`marketplace rm` はプラグインをカスケード・アンインストールしてしまうため）、続いて `plugin update` を実行します。この収束は意図的に fail-safe です：
 
 - **silent success ではなく post-verification** — 収束後に登録済み ref を再読込し、依然として遅れている場合（CLI が一部の経路で ref を無視することが観測されています）は、成功として報告せず明示的な `WARNING` を出力します。
 - **収束の失敗は warning であり、apply を fail させません** — `chezmoi apply` は green のまま（`exit 0`）で、CLI が拒否した ref は毎回 retry されるのではなく一度だけ surface されます。fatal を維持するのは *fresh* install（プラグインが存在せずインストールもできない）のみで、その場合は chezmoi が retry します。
@@ -292,17 +292,15 @@ Claude Code 側は `openai-codex` marketplace の `codex` プラグインを通�
 
 ```bash
 # デフォルトアカウント (~/.claude)
-claude plugin marketplace rm openai-codex
 claude plugin marketplace add openai/codex-plugin-cc#<ref>
 claude plugin update codex@openai-codex
 
 # ワークアカウント (~/.claude-r06)
-CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace rm openai-codex
 CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace add openai/codex-plugin-cc#<ref>
 CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin update codex@openai-codex
 ```
 
-`marketplace update` ではなく `rm` + `add` を使うのは、marketplace 登録がソース ref の独自コピーを `known_marketplaces.json` に保持し、`marketplace update` がその保存済み（stale な）登録から pull するためです。反映には、その後 Claude Code の再起動が必要です。
+`marketplace update` ではなく `marketplace add`（既登録を in-place で上書きします）を使うのは、marketplace 登録がソース ref の独自コピーを `known_marketplaces.json` に保持し、`marketplace update` がその保存済み（stale な）登録から pull するためです。先に `marketplace rm` はしないでください — その marketplace のプラグインをアンインストールしてしまいます。反映には、その後 Claude Code の再起動が必要です。
 
 ### codex:codex-rescue — 手動レスキュー専用
 

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -282,7 +282,7 @@ The Claude Code side reaches Codex through the `codex` plugin from the `openai-c
 
 The plugin setup script (`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`) converges the installed plugin to the pinned `ref` whenever the pin changes. The pin is part of the script's `run_onchange` key (via the rendered `extraKnownMarketplaces`), so **editing the `ref` re-runs the script on the next `chezmoi apply`, which reconciles both accounts (`~/.claude` and `~/.claude-r06`) automatically** — no manual plugin commands. (An apply that leaves the declaration unchanged does not re-run it.)
 
-It compares the pinned `ref` against the one the runtime recorded in `known_marketplaces.json`. When they differ it re-registers the marketplace at the new ref (`marketplace rm` + `add`, since `marketplace update` alone would re-pull the stale registered ref) and then runs `plugin update`. The reconcile is deliberately fail-safe:
+It compares the pinned `ref` against the one the runtime recorded in `known_marketplaces.json`. When they differ it re-registers the marketplace at the new ref with a plain `marketplace add`, which overwrites the registration in place (`marketplace update` alone would re-pull the stale registered ref, and `marketplace rm` would cascade-uninstall the plugin), and then runs `plugin update`. The reconcile is deliberately fail-safe:
 
 - **Post-verification, not silent success** — after converging it re-reads the registered ref; if it still lags (the CLI has been observed to ignore a ref on some paths) the script prints an explicit `WARNING` rather than reporting success.
 - **A convergence failure warns, it does not fail the apply** — `chezmoi apply` stays green so a ref the CLI refuses is surfaced once instead of retried on every apply. Only a *fresh* install (a plugin that is absent and cannot be installed) stays fatal, so chezmoi retries it.
@@ -292,17 +292,15 @@ It compares the pinned `ref` against the one the runtime recorded in `known_mark
 
 ```bash
 # default account (~/.claude)
-claude plugin marketplace rm openai-codex
 claude plugin marketplace add openai/codex-plugin-cc#<ref>
 claude plugin update codex@openai-codex
 
 # work account (~/.claude-r06)
-CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace rm openai-codex
 CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace add openai/codex-plugin-cc#<ref>
 CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin update codex@openai-codex
 ```
 
-Use `rm` + `add` rather than `marketplace update`: the marketplace registration keeps its own copy of the source ref in `known_marketplaces.json`, and `marketplace update` pulls from that stored (stale) registration. A Claude Code restart is required afterwards for the updated plugin to take effect.
+Use `marketplace add` (it overwrites an already-registered marketplace in place) rather than `marketplace update`: the registration keeps its own copy of the source ref in `known_marketplaces.json`, and `marketplace update` pulls from that stored (stale) registration. Do not `marketplace rm` first — that uninstalls the marketplace's plugins. A Claude Code restart is required afterwards for the updated plugin to take effect.
 
 ### codex:codex-rescue — manual rescue only
 

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -280,19 +280,29 @@ The Claude Code side reaches Codex through the `codex` plugin from the `openai-c
 
 ### Converging the installed version
 
-The plugin setup script (`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`) installs a plugin only when it is absent: its install loop skips on a plugin-name match alone, with no version comparison. Editing the `ref` pin therefore never converges an already-installed plugin — a known gap (implementing reconciliation in the script is deliberately deferred). Convergence is manual, run once per account (`CLAUDE_CONFIG_DIR`):
+The plugin setup script (`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`) converges the installed plugin to the pinned `ref` whenever the pin changes. The pin is part of the script's `run_onchange` key (via the rendered `extraKnownMarketplaces`), so **editing the `ref` re-runs the script on the next `chezmoi apply`, which reconciles both accounts (`~/.claude` and `~/.claude-r06`) automatically** — no manual plugin commands. (An apply that leaves the declaration unchanged does not re-run it.)
+
+It compares the pinned `ref` against the one the runtime recorded in `known_marketplaces.json`. When they differ it re-registers the marketplace at the new ref (`marketplace rm` + `add`, since `marketplace update` alone would re-pull the stale registered ref) and then runs `plugin update`. The reconcile is deliberately fail-safe:
+
+- **Post-verification, not silent success** — after converging it re-reads the registered ref; if it still lags (the CLI has been observed to ignore a ref on some paths) the script prints an explicit `WARNING` rather than reporting success.
+- **A convergence failure warns, it does not fail the apply** — `chezmoi apply` stays green so a ref the CLI refuses is surfaced once instead of retried on every apply. Only a *fresh* install (a plugin that is absent and cannot be installed) stays fatal, so chezmoi retries it.
+- **Restart notice** — when it updates a plugin the script reports that a Claude Code restart is required to apply (`claude plugin update` itself reports "restart required to apply").
+
+**Manual fallback** — only needed if the automated path warns it could not converge. Run once per account (`CLAUDE_CONFIG_DIR`), substituting the pinned tag for `<ref>`:
 
 ```bash
 # default account (~/.claude)
-claude plugin marketplace update openai-codex
+claude plugin marketplace rm openai-codex
+claude plugin marketplace add openai/codex-plugin-cc#<ref>
 claude plugin update codex@openai-codex
 
 # work account (~/.claude-r06)
-CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace update openai-codex
+CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace rm openai-codex
+CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin marketplace add openai/codex-plugin-cc#<ref>
 CLAUDE_CONFIG_DIR=~/.claude-r06 claude plugin update codex@openai-codex
 ```
 
-A Claude Code restart is required afterwards for the updated plugin to take effect (`claude plugin update` itself reports "restart required to apply"). One caveat for a future ref bump: the marketplace registration keeps its own copy of the source ref (in the runtime's `known_marketplaces.json`), and `marketplace update` pulls from that stored registration — so after changing the `settings.json` pin, verify the registered ref and re-register the marketplace (`claude plugin marketplace rm` + `add`) if it lags.
+Use `rm` + `add` rather than `marketplace update`: the marketplace registration keeps its own copy of the source ref in `known_marketplaces.json`, and `marketplace update` pulls from that stored (stale) registration. A Claude Code restart is required afterwards for the updated plugin to take effect.
 
 ### codex:codex-rescue — manual rescue only
 

--- a/home/run_onchange_after_17-setup-claude-plugins.sh.tmpl
+++ b/home/run_onchange_after_17-setup-claude-plugins.sh.tmpl
@@ -130,7 +130,37 @@ marketplace_source() {
   '
 }
 
+# The ref a marketplace is pinned to in settings.json (empty for the official marketplace, which has no
+# ref, or for an unpinned entry). This is the SSOT the runtime must converge to. Kept as a git ref
+# string ("v1.0.6"), the same shape known_marketplaces.json stores, so the two compare without any
+# version normalization.
+declared_ref() {
+  local name="$1"
+  if [ "$name" = "$OFFICIAL_MARKETPLACE" ]; then
+    printf ''
+    return 0
+  fi
+  # shellcheck disable=SC2016  # $m is a jq variable bound by --arg, not a shell expansion.
+  printf '%s' "$declaration_json" | "${jq_cmd[@]}" -r --arg m "$name" '.extraKnownMarketplaces[$m].source.ref // ""'
+}
+
+# The ref a marketplace is currently registered at, read from the account's known_marketplaces.json --
+# the file `marketplace add` writes and `marketplace update` follows. Empty when the marketplace is
+# unregistered or was registered without a ref. Comparing it against declared_ref() is how a pin bump
+# the runtime has not caught up to is detected. Always succeeds (empty on any read failure), so it is
+# safe under `set -e`.
+registered_ref() {
+  local file="$1" name="$2"
+  [ -f "$file" ] || {
+    printf ''
+    return 0
+  }
+  # shellcheck disable=SC2016  # $m is a jq variable bound by --arg, not a shell expansion.
+  "${jq_cmd[@]}" -r --arg m "$name" '.[$m].source.ref // ""' "$file" 2>/dev/null || printf ''
+}
+
 failed=0
+reconciled=0
 for config_dir in "${config_dirs[@]}"; do
   echo "==> Reconciling Claude Code plugins in ${config_dir}..."
   mkdir -p "$config_dir"
@@ -143,12 +173,30 @@ for config_dir in "${config_dirs[@]}"; do
 
   for plugin in "${plugins[@]}"; do
     marketplace="${plugin##*@}"
+    want_ref="$(declared_ref "$marketplace")"
 
-    # Presence is keyed on the marketplace name only: an entry already registered under a different
-    # source is trusted as-is. Rewriting it would need local write access to known_marketplaces.json,
-    # which already implies control of this machine.
+    # Presence is keyed on the marketplace name only. A registration under a different *repo* (same name)
+    # is trusted as-is -- only a lagging *ref* (handled just below) triggers a re-registration, not a repo
+    # swap. Rewriting an entry needs local write access to known_marketplaces.json, which already implies
+    # control of this machine.
+    is_registered=0
     # shellcheck disable=SC2016  # $m is a jq variable bound by --arg, not a shell expansion.
-    if [ ! -f "$known_marketplaces" ] || ! "${jq_cmd[@]}" -e --arg m "$marketplace" 'has($m)' "$known_marketplaces" >/dev/null 2>&1; then
+    if [ -f "$known_marketplaces" ] && "${jq_cmd[@]}" -e --arg m "$marketplace" 'has($m)' "$known_marketplaces" >/dev/null 2>&1; then
+      is_registered=1
+    fi
+
+    # A pin bump rewrites settings.json (and this script's run_onchange key), but the runtime keeps the
+    # old ref until the marketplace is re-registered: `marketplace add` skips an already-known name and
+    # `plugin install` skips an already-installed plugin. Detect the lag by comparing the pinned ref
+    # against the one recorded in known_marketplaces.json. Only a registered, ref-pinned marketplace can
+    # drift (the official one has no ref).
+    ref_drift=0
+    if [ "$is_registered" -eq 1 ] && [ -n "$want_ref" ] && [ "$(registered_ref "$known_marketplaces" "$marketplace")" != "$want_ref" ]; then
+      ref_drift=1
+    fi
+
+    if [ "$is_registered" -eq 0 ]; then
+      # First apply on this machine: register the marketplace. A failure here is fatal (see below).
       if ! source_spec="$(marketplace_source "$marketplace")"; then
         printf 'ERROR: cannot resolve a source for marketplace %s (needed by %s); declare it in settings.json extraKnownMarketplaces\n' "$marketplace" "$plugin" >&2
         failed=1
@@ -159,17 +207,68 @@ for config_dir in "${config_dirs[@]}"; do
         failed=1
         continue
       fi
+    elif [ "$ref_drift" -eq 1 ]; then
+      # The pin moved. `marketplace update` alone would re-pull the stale registered ref, so re-register
+      # from scratch (rm + add) to pick up the pinned ref. A convergence failure here is a WARNING, not
+      # fatal: the plugin stays usable at its old ref, and exiting non-zero would only make chezmoi retry
+      # a step the CLI has already refused -- endlessly -- instead of surfacing it once.
+      if ! source_spec="$(marketplace_source "$marketplace")"; then
+        printf 'WARNING: cannot resolve a source to converge marketplace %s (needed by %s) to %s; leaving the installed version in place\n' "$marketplace" "$plugin" "$want_ref" >&2
+        continue
+      fi
+      prev_ref="$(registered_ref "$known_marketplaces" "$marketplace")"
+      CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin marketplace remove "$marketplace" --scope user >/dev/null 2>&1 || true
+      if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin marketplace add "$source_spec" --scope user 2>&1)"; then
+        # The rm above already dropped the working registration. Restore it (best effort) so the still-
+        # installed plugin is not stranded with no marketplace: this run still exits 0, so an unregistered
+        # marketplace would not be retried until the pin changes again. Warn without failing the apply.
+        prev_spec="${source_spec%%#*}"
+        [ -n "$prev_ref" ] && prev_spec="${prev_spec}#${prev_ref}"
+        if CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin marketplace add "$prev_spec" --scope user >/dev/null 2>&1; then
+          printf 'WARNING: could not re-register marketplace %s in %s to converge to %s; kept the previous registration (%s)\n%s\n' "$marketplace" "$config_dir" "$want_ref" "$prev_ref" "$out" >&2
+        else
+          printf 'WARNING: could not re-register marketplace %s in %s to converge to %s, and could not restore the previous registration; re-run chezmoi apply, or use the manual fallback in docs/agents/codex.md\n%s\n' "$marketplace" "$config_dir" "$want_ref" "$out" >&2
+        fi
+        continue
+      fi
     fi
 
-    if printf '%s\n' "$installed" | grep -qxF "$plugin"; then
+    if ! printf '%s\n' "$installed" | grep -qxF "$plugin"; then
+      # Not installed yet: a failed install is fatal so chezmoi retries -- a fresh machine genuinely
+      # needs the plugin, and the failure is more likely transient than a ref the CLI refuses.
+      if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin install "$plugin" --scope user 2>&1)"; then
+        printf 'ERROR: failed to install plugin %s in %s\n%s\n' "$plugin" "$config_dir" "$out" >&2
+        failed=1
+      fi
       continue
     fi
-    if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin install "$plugin" --scope user 2>&1)"; then
-      printf 'ERROR: failed to install plugin %s in %s\n%s\n' "$plugin" "$config_dir" "$out" >&2
-      failed=1
+
+    # Already installed. Nothing to do unless the pin moved.
+    [ "$ref_drift" -eq 1 ] || continue
+
+    # Converge the installed plugin to the re-registered ref. `plugin update` reports "restart required
+    # to apply". A failed update is a WARNING, not fatal (same reasoning as the re-register above).
+    if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin update "$plugin" --scope user 2>&1)"; then
+      printf 'WARNING: failed to update plugin %s in %s to converge to %s; leaving the installed version in place\n%s\n' "$plugin" "$config_dir" "$want_ref" "$out" >&2
+      continue
+    fi
+    reconciled=1
+
+    # Post-verify against the marketplace registration -- the SSOT the CLI follows -- as a proxy for the
+    # plugin having converged (the installed plugin records a bare version, not the git ref, so it is not
+    # directly comparable). The CLI has been observed to ignore a ref on some paths; WARN -- without
+    # failing or looping -- if the registered ref still lags the pin, rather than reporting a false success.
+    got_ref="$(registered_ref "$known_marketplaces" "$marketplace")"
+    if [ "$got_ref" != "$want_ref" ]; then
+      printf 'WARNING: plugin %s in %s did not converge to %s (registered ref is now "%s"); a Claude Code restart or a manual re-register may be needed\n' "$plugin" "$config_dir" "$want_ref" "$got_ref" >&2
     fi
   done
 done
+
+if [ "$reconciled" -ne 0 ]; then
+  # `claude plugin update` takes effect on the next Claude Code start, not in the running session.
+  echo "==> Plugin version(s) converged to the pinned ref; restart Claude Code to apply (\"restart required to apply\")."
+fi
 
 if [ "$failed" -ne 0 ]; then
   # Exit non-zero so chezmoi does not record this run as successful and retries on the next apply,

--- a/home/run_onchange_after_17-setup-claude-plugins.sh.tmpl
+++ b/home/run_onchange_after_17-setup-claude-plugins.sh.tmpl
@@ -141,7 +141,9 @@ declared_ref() {
     return 0
   fi
   # shellcheck disable=SC2016  # $m is a jq variable bound by --arg, not a shell expansion.
-  printf '%s' "$declaration_json" | "${jq_cmd[@]}" -r --arg m "$name" '.extraKnownMarketplaces[$m].source.ref // ""'
+  # `|| printf ''` mirrors registered_ref(): the function always succeeds, so `want_ref="$(declared_ref)"`
+  # (an unguarded assignment) cannot trip `set -e` on a jq hiccup.
+  printf '%s' "$declaration_json" | "${jq_cmd[@]}" -r --arg m "$name" '.extraKnownMarketplaces[$m].source.ref // ""' 2>/dev/null || printf ''
 }
 
 # The ref a marketplace is currently registered at, read from the account's known_marketplaces.json --
@@ -170,15 +172,18 @@ for config_dir in "${config_dirs[@]}"; do
   # user-scoped one. The command is empty (and exits non-zero) before the plugin runtime exists, which
   # is the expected state on a first apply.
   installed="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin list --json 2>/dev/null | "${jq_cmd[@]}" -r '.[] | select(.scope == "user") | .id' || true)"
+  # Space-delimited set of ref-pinned marketplaces (re)registered to their pin this account this run.
+  # The update gate below keys on membership here rather than a per-plugin ref_drift flag.
+  converged_mkts=""
 
   for plugin in "${plugins[@]}"; do
     marketplace="${plugin##*@}"
     want_ref="$(declared_ref "$marketplace")"
 
-    # Presence is keyed on the marketplace name only. A registration under a different *repo* (same name)
-    # is trusted as-is -- only a lagging *ref* (handled just below) triggers a re-registration, not a repo
-    # swap. Rewriting an entry needs local write access to known_marketplaces.json, which already implies
-    # control of this machine.
+    # Presence is keyed on the marketplace name only. A lagging ref (detected just below) triggers a
+    # re-registration via `marketplace add`, which overwrites the entry in place and converges both the
+    # ref and the declared repo. An entry left as-is (no ref drift) under a different repo would need
+    # local write access to known_marketplaces.json, which already implies control of this machine.
     is_registered=0
     # shellcheck disable=SC2016  # $m is a jq variable bound by --arg, not a shell expansion.
     if [ -f "$known_marketplaces" ] && "${jq_cmd[@]}" -e --arg m "$marketplace" 'has($m)' "$known_marketplaces" >/dev/null 2>&1; then
@@ -186,10 +191,11 @@ for config_dir in "${config_dirs[@]}"; do
     fi
 
     # A pin bump rewrites settings.json (and this script's run_onchange key), but the runtime keeps the
-    # old ref until the marketplace is re-registered: `marketplace add` skips an already-known name and
-    # `plugin install` skips an already-installed plugin. Detect the lag by comparing the pinned ref
-    # against the one recorded in known_marketplaces.json. Only a registered, ref-pinned marketplace can
-    # drift (the official one has no ref).
+    # old ref until the marketplace is re-registered -- `plugin install` skips an already-installed
+    # plugin, and this loop registers a marketplace only when the name is absent. Detect the lag by
+    # comparing the pinned ref against the one recorded in known_marketplaces.json; the re-register below
+    # relies on `marketplace add` overwriting an already-known marketplace in place (verified against
+    # claude 2.1.220). Only a registered, ref-pinned marketplace can drift (the official one has no ref).
     ref_drift=0
     if [ "$is_registered" -eq 1 ] && [ -n "$want_ref" ] && [ "$(registered_ref "$known_marketplaces" "$marketplace")" != "$want_ref" ]; then
       ref_drift=1
@@ -207,30 +213,26 @@ for config_dir in "${config_dirs[@]}"; do
         failed=1
         continue
       fi
+      # Freshly registered to the pin. Record it so an already-installed plugin (a recovery apply where
+      # the registration was lost but the plugin stayed) is converged by the update gate below.
+      [ -n "$want_ref" ] && converged_mkts="$converged_mkts $marketplace"
     elif [ "$ref_drift" -eq 1 ]; then
-      # The pin moved. `marketplace update` alone would re-pull the stale registered ref, so re-register
-      # from scratch (rm + add) to pick up the pinned ref. A convergence failure here is a WARNING, not
-      # fatal: the plugin stays usable at its old ref, and exiting non-zero would only make chezmoi retry
-      # a step the CLI has already refused -- endlessly -- instead of surfacing it once.
+      # The pin moved. Re-register at the pinned ref with a plain `marketplace add`: it overwrites an
+      # already-known marketplace in place -- verified against claude 2.1.220, both the registered ref
+      # and the on-disk clone move to the new ref and the installed plugin is preserved -- so no `remove`
+      # is needed. `remove` must NOT be used here: it cascade-uninstalls the marketplace's plugins. A
+      # failure is a WARNING, not fatal: a failed `add` leaves the previous registration intact, so the
+      # plugin stays usable at its old ref, and exiting non-zero would only make chezmoi retry a ref the
+      # CLI has already refused -- endlessly -- instead of surfacing it once.
       if ! source_spec="$(marketplace_source "$marketplace")"; then
         printf 'WARNING: cannot resolve a source to converge marketplace %s (needed by %s) to %s; leaving the installed version in place\n' "$marketplace" "$plugin" "$want_ref" >&2
         continue
       fi
-      prev_ref="$(registered_ref "$known_marketplaces" "$marketplace")"
-      CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin marketplace remove "$marketplace" --scope user >/dev/null 2>&1 || true
       if ! out="$(CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin marketplace add "$source_spec" --scope user 2>&1)"; then
-        # The rm above already dropped the working registration. Restore it (best effort) so the still-
-        # installed plugin is not stranded with no marketplace: this run still exits 0, so an unregistered
-        # marketplace would not be retried until the pin changes again. Warn without failing the apply.
-        prev_spec="${source_spec%%#*}"
-        [ -n "$prev_ref" ] && prev_spec="${prev_spec}#${prev_ref}"
-        if CLAUDE_CONFIG_DIR="$config_dir" mise exec -- claude plugin marketplace add "$prev_spec" --scope user >/dev/null 2>&1; then
-          printf 'WARNING: could not re-register marketplace %s in %s to converge to %s; kept the previous registration (%s)\n%s\n' "$marketplace" "$config_dir" "$want_ref" "$prev_ref" "$out" >&2
-        else
-          printf 'WARNING: could not re-register marketplace %s in %s to converge to %s, and could not restore the previous registration; re-run chezmoi apply, or use the manual fallback in docs/agents/codex.md\n%s\n' "$marketplace" "$config_dir" "$want_ref" "$out" >&2
-        fi
+        printf 'WARNING: could not re-register marketplace %s (%s) in %s to converge to %s; the previous registration is left intact and the plugin stays at its old version\n%s\n' "$marketplace" "$source_spec" "$config_dir" "$want_ref" "$out" >&2
         continue
       fi
+      converged_mkts="$converged_mkts $marketplace"
     fi
 
     if ! printf '%s\n' "$installed" | grep -qxF "$plugin"; then
@@ -243,8 +245,14 @@ for config_dir in "${config_dirs[@]}"; do
       continue
     fi
 
-    # Already installed. Nothing to do unless the pin moved.
-    [ "$ref_drift" -eq 1 ] || continue
+    # Already installed. Converge it only if its ref-pinned marketplace was (re)registered to the pin
+    # this run -- the fresh registration or the ref-bump re-register above. Keying on the run's
+    # registration set (not this plugin's own ref_drift) also converges every installed plugin sharing a
+    # marketplace, not just the one whose iteration detected the drift.
+    case " $converged_mkts " in
+      *" $marketplace "*) ;;
+      *) continue ;;
+    esac
 
     # Converge the installed plugin to the re-registered ref. `plugin update` reports "restart required
     # to apply". A failed update is a WARNING, not fatal (same reasoning as the re-register above).
@@ -252,14 +260,16 @@ for config_dir in "${config_dirs[@]}"; do
       printf 'WARNING: failed to update plugin %s in %s to converge to %s; leaving the installed version in place\n%s\n' "$plugin" "$config_dir" "$want_ref" "$out" >&2
       continue
     fi
-    reconciled=1
 
     # Post-verify against the marketplace registration -- the SSOT the CLI follows -- as a proxy for the
     # plugin having converged (the installed plugin records a bare version, not the git ref, so it is not
-    # directly comparable). The CLI has been observed to ignore a ref on some paths; WARN -- without
-    # failing or looping -- if the registered ref still lags the pin, rather than reporting a false success.
+    # directly comparable). The CLI has been observed to ignore a ref on some paths. Only report success
+    # (reconciled) once the registered ref matches the pin; otherwise WARN -- without failing or looping --
+    # rather than claiming a convergence the run's restart banner would then contradict.
     got_ref="$(registered_ref "$known_marketplaces" "$marketplace")"
-    if [ "$got_ref" != "$want_ref" ]; then
+    if [ "$got_ref" = "$want_ref" ]; then
+      reconciled=1
+    else
       printf 'WARNING: plugin %s in %s did not converge to %s (registered ref is now "%s"); a Claude Code restart or a manual re-register may be needed\n' "$plugin" "$config_dir" "$want_ref" "$got_ref" >&2
     fi
   done

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -681,8 +681,8 @@ case "${1:-} ${2:-}" in
     case "$sub" in
       add)
         src="$4"
-        # FAKE_CLAUDE_ADD_FAILS=<ref> fails `marketplace add` for that specific ref only (not the restore
-        # add), reproducing a re-register whose clone fails after the rm already dropped the registration.
+        # FAKE_CLAUDE_ADD_FAILS=<ref> fails `marketplace add` for that specific ref, reproducing a
+        # re-register whose clone fails. It exits before writing, so the previous registration stays intact.
         if [ -n "${FAKE_CLAUDE_ADD_FAILS:-}" ] && [ "${src#*#}" = "${FAKE_CLAUDE_ADD_FAILS}" ]; then
           echo "boom-add ${src}" >&2
           exit 1
@@ -706,12 +706,8 @@ case "${1:-} ${2:-}" in
           "${cfg}/plugins/known_marketplaces.json" >"${cfg}/plugins/km.tmp"
         mv "${cfg}/plugins/km.tmp" "${cfg}/plugins/known_marketplaces.json"
         ;;
-      remove | rm)
-        name="$4"
-        echo "marketplace-remove ${cfg##*/} ${name}" >>"$log"
-        jq --arg k "$name" 'del(.[$k])' "${cfg}/plugins/known_marketplaces.json" >"${cfg}/plugins/km.tmp"
-        mv "${cfg}/plugins/km.tmp" "${cfg}/plugins/known_marketplaces.json"
-        ;;
+      # No `remove | rm` handler on purpose: the reconciler must never call `marketplace remove` (it
+      # cascade-uninstalls the plugin). The catch-all below fails the test if a regression reintroduces it.
       *) echo "unexpected fake marketplace subcommand: $*" >&2; exit 1 ;;
     esac
     ;;
@@ -822,12 +818,14 @@ FAKE_CLAUDE
     FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile-bumped.sh"
   [ "$status" -eq 0 ]
 
-  # The marketplace is re-registered at the bumped ref and the plugin updated -- in both accounts.
-  grep -qF 'marketplace-remove .claude openai-codex' "${sandbox}/calls.log"
+  # The marketplace is re-registered in place (a plain `marketplace add`, no rm) at the bumped ref and
+  # the plugin updated -- in both accounts.
   grep -qF 'marketplace-add .claude openai/codex-plugin-cc#v1.0.7' "${sandbox}/calls.log"
   grep -qF 'plugin-update .claude codex@openai-codex' "${sandbox}/calls.log"
   grep -qF 'marketplace-add .claude-r06 openai/codex-plugin-cc#v1.0.7' "${sandbox}/calls.log"
   grep -qF 'plugin-update .claude-r06 codex@openai-codex' "${sandbox}/calls.log"
+  # `marketplace remove` must never be used -- it cascade-uninstalls the plugin (claude 2.1.220).
+  ! grep -qF 'marketplace-remove' "${sandbox}/calls.log"
   # The unpinned official plugin has no ref, so it never drifts and is left untouched.
   ! grep -qF 'claude-code-setup' "${sandbox}/calls.log"
   # The "restart required to apply" notice is surfaced.
@@ -880,7 +878,7 @@ FAKE_CLAUDE
   rm -rf "$sandbox"
 }
 
-@test "claude plugin reconciler: a failed re-register restores the previous registration and does not strand the plugin" {
+@test "claude plugin reconciler: a failed re-register leaves the previous registration intact and does not fail the run" {
   command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
   command -v jq >/dev/null 2>&1 || skip "jq unavailable"
   local sandbox
@@ -892,16 +890,46 @@ FAKE_CLAUDE
   sed 's/v1\.0\.6/v1.0.7/g' "${sandbox}/reconcile.sh" >"${sandbox}/reconcile-bumped.sh"
   : >"${sandbox}/calls.log"
 
-  # The re-register's `add` for the bumped ref fails after the `rm` already dropped the registration. The
-  # script must restore the previous registration rather than strand the still-installed plugin with no
-  # marketplace, and warn without failing the apply (a non-zero exit would only be retried by chezmoi).
+  # The plain `marketplace add` for the bumped ref fails (no rm precedes it), so the previous registration
+  # is untouched and the plugin stays at its old version. Warn without failing the apply (a non-zero exit
+  # would only make chezmoi retry a ref the CLI has already refused).
   run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
     FAKE_CLAUDE_LOG="${sandbox}/calls.log" FAKE_CLAUDE_ADD_FAILS=v1.0.7 bash "${sandbox}/reconcile-bumped.sh"
   [ "$status" -eq 0 ]
-  echo "$output" | grep -qi 'kept the previous registration'
-  # The marketplace is not left unregistered -- the previous ref is restored in both accounts.
+  echo "$output" | grep -qi 'previous registration is left intact'
+  # The previous ref is preserved (not orphaned) in both accounts, and no rm was attempted.
   jq -e '.["openai-codex"].source.ref == "v1.0.6"' "${sandbox}/home/.claude/plugins/known_marketplaces.json"
   jq -e '.["openai-codex"].source.ref == "v1.0.6"' "${sandbox}/home/.claude-r06/plugins/known_marketplaces.json"
+  ! grep -qF 'marketplace-remove' "${sandbox}/calls.log"
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: a lost registration with the plugin still installed re-registers and updates it" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  # Fresh apply: marketplace registered, plugin installed.
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  # Drop the marketplace registration (e.g. a manual `marketplace rm`) while the plugin stays installed --
+  # the state the fresh path must recover from without leaving the installed plugin stale.
+  for acct in .claude .claude-r06; do
+    jq 'del(."openai-codex")' "${sandbox}/home/${acct}/plugins/known_marketplaces.json" >"${sandbox}/km.tmp"
+    mv "${sandbox}/km.tmp" "${sandbox}/home/${acct}/plugins/known_marketplaces.json"
+  done
+  : >"${sandbox}/calls.log"
+
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  [ "$status" -eq 0 ]
+  # The marketplace is re-added AND the already-installed plugin is updated (not silently left stale).
+  grep -qF 'marketplace-add .claude openai/codex-plugin-cc#v1.0.6' "${sandbox}/calls.log"
+  grep -qF 'plugin-update .claude codex@openai-codex' "${sandbox}/calls.log"
+  grep -qF 'plugin-update .claude-r06 codex@openai-codex' "${sandbox}/calls.log"
 
   rm -rf "$sandbox"
 }

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -675,17 +675,45 @@ case "${1:-} ${2:-}" in
     cat "${cfg}/plugins/installed.json"
     ;;
   "plugin marketplace")
-    src="$4"
-    echo "marketplace-add ${cfg##*/} ${src}" >>"$log"
-    case "$src" in
-      anthropics/claude-plugins-official*) key=claude-plugins-official ;;
-      openai/codex-plugin-cc*) key=openai-codex ;;
-      *) echo "unknown marketplace source: $src" >&2; exit 1 ;;
-    esac
+    sub="$3"
     mkdir -p "${cfg}/plugins"
     [ -f "${cfg}/plugins/known_marketplaces.json" ] || echo '{}' >"${cfg}/plugins/known_marketplaces.json"
-    jq --arg k "$key" '.[$k] = {}' "${cfg}/plugins/known_marketplaces.json" >"${cfg}/plugins/km.tmp"
-    mv "${cfg}/plugins/km.tmp" "${cfg}/plugins/known_marketplaces.json"
+    case "$sub" in
+      add)
+        src="$4"
+        # FAKE_CLAUDE_ADD_FAILS=<ref> fails `marketplace add` for that specific ref only (not the restore
+        # add), reproducing a re-register whose clone fails after the rm already dropped the registration.
+        if [ -n "${FAKE_CLAUDE_ADD_FAILS:-}" ] && [ "${src#*#}" = "${FAKE_CLAUDE_ADD_FAILS}" ]; then
+          echo "boom-add ${src}" >&2
+          exit 1
+        fi
+        echo "marketplace-add ${cfg##*/} ${src}" >>"$log"
+        repo="${src%%#*}"
+        case "$repo" in
+          anthropics/claude-plugins-official) key=claude-plugins-official ;;
+          openai/codex-plugin-cc) key=openai-codex ;;
+          *) echo "unknown marketplace source: $src" >&2; exit 1 ;;
+        esac
+        ref=""
+        [ "$src" != "$repo" ] && ref="${src#*#}"
+        # FAKE_CLAUDE_IGNORES_REF drops the stored ref to reproduce the CLI ignoring a ref on a path the
+        # reconciler must post-verify and warn about.
+        [ "${FAKE_CLAUDE_IGNORES_REF:-0}" = "1" ] && ref=""
+        # Mirror the real known_marketplaces.json shape (.<name>.source.{repo,ref}) so a later run can
+        # detect that the registration lags a bumped pin.
+        jq --arg k "$key" --arg repo "$repo" --arg ref "$ref" \
+          '.[$k] = {source: ({source: "github", repo: $repo} + (if $ref == "" then {} else {ref: $ref} end))}' \
+          "${cfg}/plugins/known_marketplaces.json" >"${cfg}/plugins/km.tmp"
+        mv "${cfg}/plugins/km.tmp" "${cfg}/plugins/known_marketplaces.json"
+        ;;
+      remove | rm)
+        name="$4"
+        echo "marketplace-remove ${cfg##*/} ${name}" >>"$log"
+        jq --arg k "$name" 'del(.[$k])' "${cfg}/plugins/known_marketplaces.json" >"${cfg}/plugins/km.tmp"
+        mv "${cfg}/plugins/km.tmp" "${cfg}/plugins/known_marketplaces.json"
+        ;;
+      *) echo "unexpected fake marketplace subcommand: $*" >&2; exit 1 ;;
+    esac
     ;;
   "plugin install")
     id="$3"
@@ -699,6 +727,11 @@ case "${1:-} ${2:-}" in
     # atomic rename, which clobbers the work account's symlink).
     jq 'del(.hooks.SessionStart[0].id, .hooks.SessionStart[0].description)' "${cfg}/settings.json" >"${cfg}/settings.tmp"
     mv "${cfg}/settings.tmp" "${cfg}/settings.json"
+    ;;
+  "plugin update")
+    id="$3"
+    [ "${FAKE_CLAUDE_UPDATE_FAILS:-0}" = "1" ] && { echo "boom-update" >&2; exit 1; }
+    echo "plugin-update ${cfg##*/} ${id}" >>"$log"
     ;;
   *) echo "unexpected fake claude invocation: $*" >&2; exit 1 ;;
 esac
@@ -766,6 +799,109 @@ FAKE_CLAUDE
   [ "$status" -ne 0 ]
   # A partially-reconciled run must still leave settings.json as chezmoi wrote it.
   jq -e '.hooks.SessionStart[0] | has("id")' "${sandbox}/home/.claude/settings.json"
+
+  rm -rf "$sandbox"
+}
+
+# Simulate a pin bump by rendering the reconciler once, then advancing the embedded ref. The ref string
+# (v1.0.6) appears only as the pinned ref in the embedded declaration, so a global sed replace is safe;
+# settings.json is the only place the ref lives, and the rendered script embeds the declaration verbatim.
+@test "claude plugin reconciler: a pin bump re-registers the marketplace and updates the plugin in both accounts" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  sed 's/v1\.0\.6/v1.0.7/g' "${sandbox}/reconcile.sh" >"${sandbox}/reconcile-bumped.sh"
+  : >"${sandbox}/calls.log"
+
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile-bumped.sh"
+  [ "$status" -eq 0 ]
+
+  # The marketplace is re-registered at the bumped ref and the plugin updated -- in both accounts.
+  grep -qF 'marketplace-remove .claude openai-codex' "${sandbox}/calls.log"
+  grep -qF 'marketplace-add .claude openai/codex-plugin-cc#v1.0.7' "${sandbox}/calls.log"
+  grep -qF 'plugin-update .claude codex@openai-codex' "${sandbox}/calls.log"
+  grep -qF 'marketplace-add .claude-r06 openai/codex-plugin-cc#v1.0.7' "${sandbox}/calls.log"
+  grep -qF 'plugin-update .claude-r06 codex@openai-codex' "${sandbox}/calls.log"
+  # The unpinned official plugin has no ref, so it never drifts and is left untouched.
+  ! grep -qF 'claude-code-setup' "${sandbox}/calls.log"
+  # The "restart required to apply" notice is surfaced.
+  echo "$output" | grep -qi 'restart Claude Code'
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: a ref the CLI ignores warns but does not fail the run" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  sed 's/v1\.0\.6/v1.0.7/g' "${sandbox}/reconcile.sh" >"${sandbox}/reconcile-bumped.sh"
+  : >"${sandbox}/calls.log"
+
+  # FAKE_CLAUDE_IGNORES_REF makes `marketplace add` drop the ref, so post-verify still sees a lag.
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" FAKE_CLAUDE_IGNORES_REF=1 bash "${sandbox}/reconcile-bumped.sh"
+  # Warn -- neither an endless-retry exit 1 nor a silent success.
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi 'did not converge'
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: a failed plugin update warns but does not fail the run" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  sed 's/v1\.0\.6/v1.0.7/g' "${sandbox}/reconcile.sh" >"${sandbox}/reconcile-bumped.sh"
+  : >"${sandbox}/calls.log"
+
+  # A convergence-step failure is best-effort: warn, but do not fail the apply (unlike the fresh-install
+  # path, which stays fatal so chezmoi retries).
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" FAKE_CLAUDE_UPDATE_FAILS=1 bash "${sandbox}/reconcile-bumped.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi 'failed to update plugin'
+
+  rm -rf "$sandbox"
+}
+
+@test "claude plugin reconciler: a failed re-register restores the previous registration and does not strand the plugin" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  local sandbox
+  sandbox="$(mktemp -d)"
+  _reconciler_sandbox "$sandbox"
+
+  env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" bash "${sandbox}/reconcile.sh"
+  sed 's/v1\.0\.6/v1.0.7/g' "${sandbox}/reconcile.sh" >"${sandbox}/reconcile-bumped.sh"
+  : >"${sandbox}/calls.log"
+
+  # The re-register's `add` for the bumped ref fails after the `rm` already dropped the registration. The
+  # script must restore the previous registration rather than strand the still-installed plugin with no
+  # marketplace, and warn without failing the apply (a non-zero exit would only be retried by chezmoi).
+  run env HOME="${sandbox}/home" PATH="${sandbox}/bin:${PATH}" \
+    FAKE_CLAUDE_LOG="${sandbox}/calls.log" FAKE_CLAUDE_ADD_FAILS=v1.0.7 bash "${sandbox}/reconcile-bumped.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi 'kept the previous registration'
+  # The marketplace is not left unregistered -- the previous ref is restored in both accounts.
+  jq -e '.["openai-codex"].source.ref == "v1.0.6"' "${sandbox}/home/.claude/plugins/known_marketplaces.json"
+  jq -e '.["openai-codex"].source.ref == "v1.0.6"' "${sandbox}/home/.claude-r06/plugins/known_marketplaces.json"
 
   rm -rf "$sandbox"
 }


### PR DESCRIPTION
## Summary

Automate codex-plugin version reconciliation at `chezmoi apply` time. Until now the plugin
setup script (`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`) installed a plugin
only when it was absent — its loop skipped on a plugin-name match, with no version comparison —
so editing the pinned `ref` never converged an already-installed plugin. Convergence was a
manual, per-account procedure. This change makes `chezmoi apply` converge the installed plugin
to the pinned `ref` on both accounts automatically, or print an explicit warning when it cannot.

`closes #342`

## What changed

- **`home/run_onchange_after_17-setup-claude-plugins.sh.tmpl`** — added a ref-drift path to the
  per-account loop:
  - New helpers `declared_ref()` (the `ref` pinned in `settings.json`) and `registered_ref()`
    (the `ref` the runtime recorded in `known_marketplaces.json`, the file `marketplace add`
    writes and `marketplace update` follows). Both stay a git-ref string (`vX.Y.Z`), so they
    compare without version normalization.
  - When they differ, re-register the marketplace at the pinned ref with a **plain
    `marketplace add`, which overwrites an already-known registration in place** (verified against
    claude 2.1.220: the registered ref and the on-disk clone move, and the installed plugin is
    preserved), then run `plugin update`. `marketplace remove` is deliberately **not** used — it
    cascade-uninstalls the marketplace's plugins.
  - **Run-scoped convergence gate**: a `plugin update` fires for any installed plugin whose
    ref-pinned marketplace was (re)registered to the pin this run — so several plugins sharing a
    marketplace, and an already-installed plugin whose registration was lost, all converge, not
    just the one whose iteration detected the drift.
  - **Fail-safe split**: a reconcile failure (re-register/update failure, or a post-verify ref
    that still lags — the CLI has been observed to ignore a ref on some paths) is a `WARNING` and
    `exit 0`, so `chezmoi apply` is not stuck in an endless retry, and a failed re-register leaves
    the previous registration intact. Only a *fresh* install failure stays fatal (`exit 1`), so
    chezmoi retries a genuinely missing plugin.
  - **Post-verify before claiming success**: the run reports "converged" (and the restart notice)
    only after the registered ref matches the pin; an ignored ref warns instead of a contradicting
    banner. The restart notice matches `claude plugin update`'s own "restart required to apply".
  - The fresh-install path, `settings.json` snapshot/restore, and official-marketplace handling
    are unchanged (byte-compatible for a first apply).
- **`tests/files.bats`** — made the fake `claude` faithful to the real CLI (`marketplace add`
  overwrites the stored `source.ref` in place; env knobs `FAKE_CLAUDE_IGNORES_REF` /
  `FAKE_CLAUDE_UPDATE_FAILS` / `FAKE_CLAUDE_ADD_FAILS`; the fake rejects `marketplace remove` as a
  regression guard). Reconciler tests cover: a pin bump re-registers in place + updates in both
  accounts + restart notice; a ref the CLI ignores warns without failing; a failed `plugin update`
  warns without failing; a failed re-register leaves the previous registration intact; a lost
  registration with the plugin still installed re-registers and updates it. The existing no-op and
  fresh-install/fatal tests still hold.
- **`docs/agents/codex.md` / `codex.ja.md`** — the "Converging the installed version" section now
  documents the automated path (post-verify / warn / restart semantics), keeping a manual fallback
  (plain `marketplace add` + `plugin update`, no `rm`). Both languages match.

## Why

The pin (`settings.json` `ref`) is the SSOT, but editing it changed nothing on the machine —
pin/installed drift is exactly the failure mode this reconciler exists to eliminate. Manual
per-account procedures do not scale and had already drifted out-of-band once.

## Testing

- `make lint` — pass (shellcheck + shfmt + zsh syntax).
- `make test` — pass (185 bats tests, including the reconciler suite).
- Rendered via `chezmoi execute-template` + `bash -n`.
- CLI behaviour confirmed against the mise-pinned `claude` (2.1.220): `marketplace add` overwrites a
  registration in place and preserves the installed plugin; `marketplace remove` cascade-uninstalls
  it; a failed `add` leaves the previous registration intact.
