### PR TITLE
feat: replace desktop-notify with a self-hosted ntfy notification system over Tailscale

### DIFF
--- a/.claude/prds/337-ntfy-tailscale.prd.md
+++ b/.claude/prds/337-ntfy-tailscale.prd.md
@@ -1,0 +1,263 @@
+---
+slug: 337-ntfy-tailscale
+feature: Self-hosted ntfy notification system over Tailscale (replaces ECC desktop-notify)
+created_at: 2026-07-26T13:01:43+09:00
+grill_session: 8ee99923-4cfa-42ba-b680-1d51dbb3ffce
+status: finalized
+---
+
+# PRD: Self-hosted ntfy notification system over Tailscale
+
+## Background
+
+Claude Code sessions currently notify only via the ECC `stop:desktop-notify` Stop hook
+(osascript, local-only, no history). GitHub Issue #337 requests replacing it with a
+notification system backed by a ntfy server self-hosted on the primary Mac, reached via
+Tailscale so tailnet devices (phone, tablet) can subscribe. Goals: richer notification
+timing (official hook events beyond Stop), persistent reviewable history (ntfy
+server-side cache), and structured attribution (session, repo, branch, account, event
+type) so history can be filtered.
+
+Primary-source facts constraining the design (verified against docs.ntfy.sh,
+code.claude.com/docs/en/hooks.md, tailscale.com/kb, and this machine during
+deliberation):
+
+- **The Homebrew `ntfy` formula builds macOS binaries with the `noserver` Go build tag:
+  `ntfy serve` does not exist in the Brewfile-provisioned binary** (verified via
+  `brew cat ntfy` and `ntfy --help` on this machine). ntfy server on macOS is
+  officially unsupported. The Brewfile does, however, already provision
+  `cask "docker-desktop"`, and ntfy publishes an official Docker image.
+- Message history requires `cache-file` (SQLite); default is in-memory 12h only.
+  `auth-file` must be set for auth to exist at all; `auth-default-access: deny-all` is
+  the documented recommendation for private instances.
+- `tailscale serve --bg` persists across reboots and tailscaled restarts (Tailscale KB
+  1242); without `--bg` the mapping dies with the terminal session.
+- iOS instant push requires `upstream-base-url` forwarding poll requests through
+  ntfy.sh/APNs; the device then fetches the message body from our server directly, so
+  tailnet reachability from the phone is required either way. Whether this works on a
+  Tailscale-only server is not documented (unverified). Android connects directly and
+  works regardless.
+- Claude Code `Notification` hook supports matcher-based routing across 8 types
+  (`permission_prompt`, `idle_prompt`, `auth_success`, `elicitation_dialog`,
+  `elicitation_complete`, `elicitation_response`, `agent_needs_input`,
+  `agent_completed`); `Stop` provides `last_assistant_message` on stdin; handlers can
+  be `command` (payload reshaping possible) or `http` (no reshaping, env-var headers
+  only). The documented Notification stdin schema guarantees only the common fields
+  (`session_id`, `cwd`, `hook_event_name`, ...) — no message body field is documented
+  for Notification events.
+- CI handles `onepasswordRead` templates by physically excluding them: the
+  `Exclude CI-incompatible files` step in `.github/workflows/setup-validation.yml`
+  `mv`s a hardcoded file list out of the source tree before `chezmoi apply`, in both
+  the macOS and Ubuntu jobs. There is no `.chezmoiignore`/template-guard precedent.
+
+## User Story
+
+As the owner of this dotfiles setup running long autonomous Claude Code sessions, I want
+permission prompts, input-needed events, completions, and session stops pushed to my
+tailnet devices with session/repo/event attribution and a persistent, filterable
+server-side history, so that I can react promptly while away from the Mac and audit
+"what asked for what, when" after the fact.
+
+## Design decisions (council-adjudicated, revised after adversarial review)
+
+- **D1 Runtime**: ntfy server runs as a Docker container using the official ntfy image
+  with a **pinned version tag** (Renovate-trackable via the docker-compose manager),
+  defined in a chezmoi-managed compose file (`home/dot_config/ntfy/compose.yaml.tmpl`)
+  with `restart: unless-stopped`. Docker Desktop is already Brewfile-provisioned; its
+  start-at-login setting is a documented runbook prerequisite. No launchd plist. The
+  original council pick (launchd + Homebrew binary) was invalidated by the verified
+  `noserver` build tag.
+- **D2 Reachability**: the container publishes its port as `127.0.0.1:<port>:80`
+  (loopback-only at the host). Tailnet exposure exclusively via `tailscale serve --bg`
+  (HTTPS on the ts.net MagicDNS name; TLS terminated by tailscaled). `tailscale
+  funnel` is prohibited; a funnel-absence check command is documented.
+- **D2' iOS instant push**: **enabled** (user-approved at the gate, overriding the
+  security-lens default): server config sets `upstream-base-url: https://ntfy.sh`,
+  accepting that poll requests (topic metadata, never message bodies) leave the
+  tailnet. Actual iOS instant delivery on a Tailscale-only server is unverified
+  upstream; the smoke test records the observed behavior in the notifications doc.
+  If it proves non-functional, iOS degrades to app-open fetch with no further change.
+- **D3 Event scope (v1)**: `Notification` hook matchers `permission_prompt`,
+  `idle_prompt`, `agent_needs_input` (attention class) and `agent_completed`
+  (completion class), plus the `Stop` event (completion class). `SubagentStop`,
+  `TaskCompleted`, `SessionEnd`, `auth_success`, and the three elicitation matchers
+  (`elicitation_dialog`, `elicitation_complete`, `elicitation_response`) are deferred
+  (noise control; opt-in later). Whether `agent_completed` and `Stop` double-fire for
+  the same completion is verified during implementation and matchers tuned if needed.
+  Known limitation: Notification-event stdin documents no message body, so
+  attention-class notifications carry attribution + event type only (best-effort body
+  if the payload turns out to include one).
+- **D4 Handler**: a single repo-owned shell wrapper (`command` hook type, async) that
+  reads hook stdin JSON, enriches it (repo, branch from `cwd` via git; account from
+  `CLAUDE_CONFIG_DIR`; short session id; event type), applies truncation/scrubbing
+  (D7'), and publishes JSON to ntfy via curl. The token is read at runtime from a 0600
+  chezmoi-deployed env file and passed via **`curl --config` (`-K`) with the
+  `Authorization` header written in the curl config file — never `-H` with shell
+  expansion (argv-visible), never logged; no `set -x`**. `curl --max-time` short, no
+  retries, fail-open. No debounce/rate limiting in v1 (accepted: async hooks +
+  max-time bound the blast radius; revisit if high-frequency sessions prove noisy).
+- **D5 Topics**: two fixed topics — `claude-attention` (actionable: permission/input
+  events, high priority) and `claude-done` (completions, default/low priority) — plus
+  `claude-test` for smoke tests. Attribution lives in tags/title (repo, branch,
+  account, event, short session id), not in topic names. ACL: publisher user
+  write-only on all three; subscriber user read-only.
+- **D6 Auth bootstrap**: one-time manual issuance (`ntfy user add`, `ntfy access`,
+  `ntfy token add` — executed inside the container via `docker compose exec`)
+  following a documented runbook; **both** tokens (publisher write-only, subscriber
+  read-only) stored in 1Password (`kryota.dev` vault). chezmoi deploys the publisher
+  token into the 0600 env file via `onepasswordRead`;
+  `run_once_after_11-validate-1password` ITEMS extended. The subscriber token is
+  entered on devices manually from 1Password (runbook). `auth.db` recovery = re-run
+  the runbook; the runbook states that re-issuance invalidates existing device tokens
+  and lists what must be re-entered where.
+- **D7 History retention**: `cache-duration` = **168h (7 days)** (user-confirmed at
+  the approval gate), value SSOT in `.chezmoidata.toml`.
+- **D7' Content scrubbing**: truncation (default 200 chars) is the **primary** defense
+  for `last_assistant_message`-derived bodies. As a secondary, best-effort layer the
+  wrapper scrubs client identifiers using the regex embedded in the chezmoi-deployed
+  `~/.config/git/gitleaks-own.toml` (extracted with a fixed-format-assuming `sed`;
+  extraction failure ⇒ fall back to truncation-only). This layer is explicitly **not**
+  a secret/PII detector — the pattern is a client/employer name list — and the PRD
+  makes no stronger claim. Strength user-confirmed at the approval gate: truncated
+  (200 chars) + client-identifier scrub.
+- **D8 Migration/fallback**: `stop:desktop-notify` disabled by appending to
+  `env.ECC_DISABLED_HOOKS` in `home/dot_claude/settings.json` (existing SSOT). No dual
+  notification channel; on publish failure the wrapper logs and plays a content-free
+  local alert sound (silent-drop prevention). Known accepted window: settings.json
+  (files phase) activates the new hooks before `run_onchange_after_31` (after phase)
+  has started the server on a fresh apply — fail-open covers it. Rollback = remove
+  the env entry **and** the new hook entries together (documented as one step) to
+  avoid double notification.
+- **D9 Placement**: compose file + server config `home/dot_config/ntfy/*.tmpl`;
+  secrets env `home/dot_config/ntfy/private_*-env.tmpl` (0600, **added to the CI
+  exclude list in `.github/workflows/setup-validation.yml`, both jobs**); assertion
+  script `home/run_onchange_after_31-setup-ntfy.sh.tmpl` (embedded-hash, CI guard,
+  darwin-only; asserts `docker compose up -d` and the `tailscale serve --bg` mapping;
+  warns instead of hard-failing when Docker Desktop is not running — documented
+  deviation from the launchctl exit-1 convention so a closed Docker Desktop never
+  blocks `chezmoi apply`); wrapper under `home/dot_claude/`; runtime state
+  (`auth.db`, `cache.db`) bind-mounted from `~/Library/Application Support/ntfy/`
+  (0700/0600), outside the chezmoi target tree. Non-darwin machines: full no-op via
+  OS guards and `.chezmoiignore`.
+
+## Acceptance Criteria
+
+Integration-level criteria (verified once via a documented manual smoke-test runbook;
+CI cannot start services or reach the network):
+
+- AC-001: Events `permission_prompt`, `idle_prompt`, `agent_needs_input`,
+  `agent_completed` (Notification hook) and `Stop` are published to the self-hosted
+  ntfy server; each notification carries repo, branch, account (default/r06), short
+  session id, and event type in title/tags. Verified by the documented smoke test.
+- AC-002: History is persisted via `cache-file` with `cache-duration` set from a single
+  SSOT value in `.chezmoidata.toml`; docs include `poll=1&since=` query examples
+  filtering by session/repo/type, each verified once manually before documenting.
+- AC-003: The container port is published on `127.0.0.1` only; tailnet exposure is via
+  `tailscale serve --bg` (HTTPS); `tailscale funnel` is prohibited and a
+  funnel-absence verification command is documented.
+- AC-014: `upstream-base-url` is set to `https://ntfy.sh` in the server config; the
+  smoke test records whether iOS instant delivery works on the tailnet-only setup.
+- AC-004: Auth is enabled (`auth-file`, `auth-default-access: deny-all`); publishing
+  uses a write-only token, subscribing a read-only token; the smoke-test runbook
+  includes anonymous-access denial **and** a read-only-token publish attempt being
+  rejected.
+
+Machine-verifiable criteria (bats/CI):
+
+- AC-005: The publisher token comes from a new 1Password item via `onepasswordRead`
+  into a 0600 file; validate-1password ITEMS and the `onepassword-vault-item-count`
+  FACT marker are updated; the new template is added to the CI exclude list in
+  `.github/workflows/setup-validation.yml` (both jobs); gitleaks stays clean.
+- AC-006: The wrapper is fail-open: on unreachable server it exits within its curl
+  timeout, logs the failure, plays a content-free local alert, and never blocks the
+  session. The token never appears in argv/stdout/stderr/logs: the header travels via
+  `curl -K`, and bats asserts the wrapper contains no `-H`-with-expansion pattern.
+- AC-007: Published bodies never contain raw `last_assistant_message`: truncation
+  (default 200 chars) always applies; the client-identifier scrub layer's TOML regex
+  extraction is a separable function unit-tested in bats against a fixture TOML,
+  with extraction failure falling back to truncation-only.
+- AC-008: `stop:desktop-notify` is appended to `env.ECC_DISABLED_HOOKS` in
+  `home/dot_claude/settings.json`; the existing bats jq assertion is updated; the new
+  Notification/Stop hook entries follow the existing settings.json hook structure
+  (id/async/timeout).
+- AC-009: The compose file pins an exact ntfy image version (no `latest`), sets
+  `restart: unless-stopped`, and publishes only `127.0.0.1:<port>:80`; bats asserts
+  all three. The assertion script carries the embedded-hash and CI-guard strings
+  (bats-checked, morning-radar assertions untouched); Renovate tracks the image tag.
+- AC-010: `auth.db`/`cache.db` live outside the chezmoi target tree with 0700 dir
+  permissions; bats asserts no runtime-state paths exist inside the chezmoi source.
+- AC-011: CI (macOS + Ubuntu) completes `chezmoi apply` + bats with no service start
+  and no network access; non-darwin machines are a full no-op.
+- AC-012: `make lint` and `make test` pass; new bats coverage exists for the wrapper
+  (mocked stdin/curl: payload construction, enrichment, truncation/scrub fallback,
+  fail-open, token hygiene, missing-env-file no-op).
+- AC-013: Docs: a notifications architecture page (EN + JA mirror), lifecycle-scripts
+  table update, mobile (iOS/Android) subscription runbook incl. token entry from
+  1Password, and troubleshooting (Docker Desktop not running, boot/login race,
+  meaning of the local fallback alert, cache expiry, funnel check).
+
+## Considered Alternatives / Rejection Rationale
+
+- **launchd + Homebrew `ntfy` binary** (original council pick, D1): invalidated —
+  the macOS formula builds with the `noserver` tag; `ntfy serve` does not exist in
+  the installed binary (verified on this machine). Kept here as the decision-log
+  record of why a unanimous council pick was reversed.
+- **Source build via go (mise-managed) + launchd** (rejected, D1): adds a Go
+  toolchain dependency (absent today) and per-upgrade build maintenance for a
+  configuration that upstream does not support on macOS anyway; Docker Desktop is
+  already provisioned and the official image is the supported artifact.
+- **Direct bind to the Tailscale 100.x IP** (rejected, D2): races the tailscale0
+  interface at boot, plain HTTP end-to-end, per-IP templating churn. `tailscale
+  serve --bg` decouples ntfy's lifecycle from network state and provides managed TLS,
+  which the ntfy mobile apps prefer.
+- **`http` hook handler type** (rejected, D4): cannot reshape the payload (no
+  repo/branch/account enrichment, no scrubbing), requires the token as a long-lived
+  env var (`allowedEnvVars`), and embeds untestable logic in settings.json.
+- **Per-repo/per-session/per-account topics** (rejected, D5): unbounded topic growth
+  breaks deny-all ACL management and mobile subscription UX; urgency-based topics map
+  directly to per-topic sound/mute on devices, and tags cover attribution.
+- **Automated token provisioning script** (rejected, D6): a rare one-time operation;
+  automation would route freshly minted secrets through scripts/temp files. Manual
+  runbook + 1Password matches the existing audited secrets path; ops' self-healing
+  concern is addressed by the recovery runbook and the idempotent assertion script.
+- **Full dual-channel fallback (auto-revert to ECC desktop-notify)** (rejected, D8):
+  would resurrect the rich local channel this issue retires; a content-free local
+  alert covers the "Mac awake but server down" gap without content-leak risk.
+- **JS wrapper in `hooks-fork/`** (rejected, D4/D9): `hooks-fork/` precedent is for
+  forking ECC-runtime JS hooks; this is a standalone curl/jq one-shot, which the
+  repo's shell toolchain (shellcheck/shfmt/bats) already covers end-to-end.
+- **Staged migration (run both channels for a while)** (rejected, D8): the switch is
+  a single settings.json edit with a documented one-step rollback; parallel channels
+  add duplicate notifications for marginal safety.
+
+## Out of Scope
+
+- `tailscale funnel` / any public-internet exposure (explicitly prohibited; the
+  user-approved `upstream-base-url` metadata egress in D2' is the sole exception).
+- SubagentStop / TaskCompleted / SessionEnd / auth_success / elicitation event
+  coverage (future opt-in; elicitation = 3 individual matcher values, no wildcard).
+- General secret/PII detection in published bodies (truncation + client-identifier
+  scrub only; see D7').
+- Automated token rotation; ntfy uptime monitoring beyond the local alert; log
+  aggregation dashboards; publish debounce/rate limiting.
+- Tailnet ACL / device-sharing review (assumption documented: the tailnet contains
+  only the owner's personal devices).
+- ntfy servers on other machines / HA; per-repo topic provisioning; custom history UI.
+
+## Open Questions
+
+Resolved at the user approval gate (2026-07-26): iOS instant push **enabled** (D2');
+`cache-duration` **168h**; body strength **200-char truncation + client-identifier
+scrub** (D7').
+
+Resolved during implementation (verification tasks, not user decisions):
+
+1. `agent_completed` vs `Stop` double-fire behavior for the same completion.
+2. Exact Authorization header format for token publish (verify against
+   docs.ntfy.sh/publish before wiring the curl config file).
+3. Whether Notification-event stdin carries any usable message body beyond the
+   documented common fields.
+4. Docker Desktop start-at-login + `restart: unless-stopped` behavior across reboot
+   (smoke-tested once, documented in the runbook).
+5. Actual iOS instant delivery through the upstream relay on the Tailscale-only
+   setup (smoke test; outcome recorded in the notifications doc).

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -114,9 +114,9 @@
         '/home/dot_config/ntfy/compose\\.yaml\\.tmpl$/',
       ],
       matchStrings: [
-        'image: binary/ntfy:(?<currentValue>v[0-9.]+)',
+        'image: binwiederhier/ntfy:(?<currentValue>v[0-9.]+)@(?<currentDigest>sha256:[a-f0-9]+)',
       ],
-      depNameTemplate: 'binary/ntfy',
+      depNameTemplate: 'binwiederhier/ntfy',
       datasourceTemplate: 'docker',
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -105,6 +105,20 @@
       datasourceTemplate: 'github-tags',
       extractVersionTemplate: '^v(?<version>.+)$',
     },
+    {
+      // Self-hosted ntfy server image (#337). The tag is pinned literally in the
+      // compose template (chezmoi .tmpl files are invisible to the built-in
+      // docker-compose manager), so track it with a regex manager instead.
+      customType: 'regex',
+      managerFilePatterns: [
+        '/home/dot_config/ntfy/compose\\.yaml\\.tmpl$/',
+      ],
+      matchStrings: [
+        'image: binary/ntfy:(?<currentValue>v[0-9.]+)',
+      ],
+      depNameTemplate: 'binary/ntfy',
+      datasourceTemplate: 'docker',
+    },
   ],
   mise: {
     managerFilePatterns: [

--- a/.github/workflows/setup-validation.yml
+++ b/.github/workflows/setup-validation.yml
@@ -70,7 +70,9 @@ jobs:
             home/run_once_after_11-validate-1password.sh.tmpl \
             home/run_once_after_30-setup-fonts.sh.tmpl \
             home/run_once_after_90-other-apps.sh.tmpl \
-            home/dot_config/git/private_gitleaks-own.toml.tmpl; do
+            home/dot_config/git/private_gitleaks-own.toml.tmpl \
+            home/dot_config/ntfy/private_server.yml.tmpl \
+            home/dot_config/ntfy/private_notify-env.tmpl; do
             if [ -f "$f" ]; then
               mv "$f" /tmp/chezmoi-excluded/
               echo "Excluded: $f"
@@ -293,7 +295,9 @@ jobs:
             home/run_once_before_00-install-prerequisites.sh.tmpl \
             home/run_onchange_before_10-brew-bundle.sh.tmpl \
             home/run_once_after_11-validate-1password.sh.tmpl \
-            home/dot_config/git/private_gitleaks-own.toml.tmpl; do
+            home/dot_config/git/private_gitleaks-own.toml.tmpl \
+            home/dot_config/ntfy/private_server.yml.tmpl \
+            home/dot_config/ntfy/private_notify-env.tmpl; do
             if [ -f "$f" ]; then
               mv "$f" /tmp/chezmoi-excluded/
               echo "Excluded: $f"

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -28,6 +28,7 @@
 | [ライフサイクルスクリプト: 順序とトリガーモデル](architecture/lifecycle-scripts.ja.md) | before/after 二フェーズモデル、完全な適用タイムライン（00→90）、`run_once` vs `run_onchange` のセマンティクス、埋め込みハッシュのトリック |
 | [zsh 起動・プロンプト・シェルモジュール](architecture/shell-environment.ja.md) | `.zprofile` → `.zshrc` → sheldon 遅延ローディング、新しい `.zsh` モジュールの追加方法 |
 | [開発ツールチェーン: mise・Brewfile・git](architecture/dev-tooling.ja.md) | mise バージョンピン、`Brewfile` + `.brewfile-linux-exclude`、git 1Password 署名、グローバル gitleaks フック |
+| [Notifications: 自己ホスト ntfy over Tailscale](architecture/notifications.ja.md) | Claude Code フックイベント → ntfy サーバー（Docker、loopback のみ）→ tailnet デバイス。トピック、認証/ACL、セットアップとリカバリの手順 |
 
 ### エージェント
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ This repo (`kryota-dev/dotfiles`) is a chezmoi-managed macOS-first dotfiles set 
 | [Lifecycle scripts: ordering & trigger model](architecture/lifecycle-scripts.md) | The two-phase before/after model, the full apply timeline (00→90), `run_once` vs `run_onchange` semantics, and the embedded-hash trick |
 | [zsh startup, prompt & shell modules](architecture/shell-environment.md) | `.zprofile` → `.zshrc` → sheldon deferred loading; how to add a new `.zsh` module |
 | [Developer toolchain: mise, Brewfile & git](architecture/dev-tooling.md) | mise version pins, `Brewfile` + `.brewfile-linux-exclude`, git 1Password signing, global gitleaks hook |
+| [Notifications: self-hosted ntfy over Tailscale](architecture/notifications.md) | Claude Code hook events → ntfy server (Docker, loopback-only) → tailnet devices; topics, auth/ACL, setup & recovery runbooks |
 
 ### Agents
 

--- a/docs/agents/claude-code.ja.md
+++ b/docs/agents/claude-code.ja.md
@@ -19,6 +19,7 @@
   - [PreToolUse](#pretooluse)
   - [PostToolUse](#posttooluse)
   - [PostToolUseFailure](#posttoolusefailure)
+  - [Notification](#notification)
   - [Stop](#stop)
 - [ECC ランチャー — ecc-hook.sh](#ecc-ランチャー--ecc-hooksh)
 - [ECC フック fork (hooks-fork/)](#ecc-フック-fork-hooks-fork)
@@ -163,11 +164,14 @@ flowchart TD
     PoTU --> PoTU9[design-quality-check\nEdit Write MultiEdit]
     PoTU --> PoTU10[console-warn\nEdit]
 
+    NTF[Notification] --> NTF1[ntfy-notify async\npermission_prompt idle_prompt\nagent_needs_input agent_completed]
+
     STP[Stop] --> STP1[session-end async]
     STP --> STP2[cost-tracker async]
-    STP --> STP3[desktop-notify async]
-    STP --> STP4[format-typecheck async]
-    STP --> STP5[check-console-log sync]
+    STP --> STP3[desktop-notify async\nDISABLED via ECC_DISABLED_HOOKS]
+    STP --> STP4[ntfy-notify async]
+    STP --> STP5[format-typecheck async]
+    STP --> STP6[check-console-log sync]
 ```
 
 ### SessionStart
@@ -234,13 +238,20 @@ flowchart TD
 |---|---|
 | `post:mcp-health-check` | 失敗した MCP ツール呼び出しを追跡し、不健全なサーバーをマーク、再接続を試みる。Claude Code はこの env var をエクスポートしないため、`CLAUDE_HOOK_EVENT_NAME=PostToolUseFailure` を明示的に設定している。 |
 
+### Notification
+
+| フック ID | マッチャー | Async | 説明 |
+|---|---|---|---|
+| `notification:ntfy-notify` | `permission_prompt\|idle_prompt\|agent_needs_input\|agent_completed` | Yes | repo/branch/account/session の帰属情報付きで、attention/completion 通知を Tailscale 経由の自己ホスト ntfy サーバーへ publish する（#337; [Notifications](../architecture/notifications.ja.md) 参照）。フェイルオープン: `~/.config/ntfy/notify-env` が無ければサイレント no-op |
+
 ### Stop
 
 | フック ID | Async | 説明 |
 |---|---|---|
 | `stop:session-end` | Yes | 各レスポンス後にセッション状態を永続化 |
 | `stop:cost-tracker` | Yes | セッションごとのトークンとコストメトリクスを追跡 |
-| `stop:desktop-notify` | Yes | タスクサマリー付きの macOS/WSL デスクトップ通知を送信 |
+| `stop:desktop-notify` | Yes | **Disabled**（`env.ECC_DISABLED_HOOKS` により）— `stop:ntfy-notify` に置き換え（#337）。ドキュメント化された 1 ステップロールバック（ここで再有効化 + ntfy エントリを一緒に削除）のため配線は維持 |
+| `stop:ntfy-notify` | Yes | セッション停止通知（切り詰め + client-identifier スクラブ済みサマリー）を自己ホスト ntfy サーバーへ publish する（#337） |
 | `stop:format-typecheck` | Yes | 今セッションで編集した JS/TS ファイルを一括フォーマット・型チェック (`tsc --noEmit`、タイムアウト 300 秒) |
 | `stop:check-console-log` | No | git 変更のある全 JS/TS ファイルで `console.log` 警告を集計 |
 

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -19,6 +19,7 @@ This document covers the Claude Code harness configuration deployed by this dotf
   - [PreToolUse](#pretooluse)
   - [PostToolUse](#posttooluse)
   - [PostToolUseFailure](#posttoolusefailure)
+  - [Notification](#notification)
   - [Stop](#stop)
 - [ECC launcher — ecc-hook.sh](#ecc-launcher--ecc-hooksh)
 - [ECC hook forks (hooks-fork/)](#ecc-hook-forks-hooks-fork)
@@ -165,11 +166,14 @@ flowchart TD
     PoTU --> PoTU9[design-quality-check\nEdit Write MultiEdit]
     PoTU --> PoTU10[console-warn\nEdit]
 
+    NTF[Notification] --> NTF1[ntfy-notify async\npermission_prompt idle_prompt\nagent_needs_input agent_completed]
+
     STP[Stop] --> STP1[session-end async]
     STP --> STP2[cost-tracker async]
-    STP --> STP3[desktop-notify async]
-    STP --> STP4[format-typecheck async]
-    STP --> STP5[check-console-log sync]
+    STP --> STP3[desktop-notify async\nDISABLED via ECC_DISABLED_HOOKS]
+    STP --> STP4[ntfy-notify async]
+    STP --> STP5[format-typecheck async]
+    STP --> STP6[check-console-log sync]
 ```
 
 ### SessionStart
@@ -236,13 +240,20 @@ This regex is the SSOT shared with the Codex gateguard (see [codex.md](codex.md#
 |---|---|
 | `post:mcp-health-check` | Tracks failed MCP tool calls, marks unhealthy servers, attempts reconnect. `CLAUDE_HOOK_EVENT_NAME=PostToolUseFailure` is set explicitly because Claude Code does not export it and `mcp-health-check.js` selects its handler from that env var. |
 
+### Notification
+
+| Hook ID | Matcher | Async | Description |
+|---|---|---|---|
+| `notification:ntfy-notify` | `permission_prompt\|idle_prompt\|agent_needs_input\|agent_completed` | Yes | Publishes attention/completion notifications to the self-hosted ntfy server over Tailscale with repo/branch/account/session attribution (#337; see [Notifications](../architecture/notifications.md)). Fail-open: silent no-op without `~/.config/ntfy/notify-env` |
+
 ### Stop
 
 | Hook ID | Async | Description |
 |---|---|---|
 | `stop:session-end` | Yes | Persists session state after each response |
 | `stop:cost-tracker` | Yes | Tracks token and cost metrics per session |
-| `stop:desktop-notify` | Yes | Sends macOS/WSL desktop notification with task summary |
+| `stop:desktop-notify` | Yes | **Disabled** via `env.ECC_DISABLED_HOOKS` — replaced by `stop:ntfy-notify` (#337). Wiring kept for the documented one-step rollback (re-enable here + remove the ntfy entries together) |
+| `stop:ntfy-notify` | Yes | Publishes a session-stop notification (truncated + client-identifier-scrubbed summary) to the self-hosted ntfy server (#337) |
 | `stop:format-typecheck` | Yes | Batch-formats and typechecks (`tsc --noEmit`) JS/TS files edited this session (timeout 300 s) |
 | `stop:check-console-log` | No | Aggregates `console.log` warnings across all git-modified JS/TS files |
 

--- a/docs/architecture/dev-tooling.ja.md
+++ b/docs/architecture/dev-tooling.ja.md
@@ -53,6 +53,7 @@ ruby.compile = false
 制約:
 - Brewfile に `brew "chezmoi"` を追加しないでください。chezmoi 自体はスタンドアロンの `curl get.chezmoi.io` ブートストラップでインストールされます（PR #22）。Brewfile に追加すると mise 管理バージョンと競合します。
 - Brewfile の変更は `run_onchange_before_10-brew-bundle.sh.tmpl` の埋め込み sha256 を通じて次回の `chezmoi apply` で自動適用されます。
+- `cask "docker-desktop"` は場当たり的なコンテナ作業にとどまらず load-bearing です: 自己ホストの ntfy 通知サーバーがこの上で動作しており、`run_onchange_after_31-setup-ntfy` は apply 時に Docker Desktop が起動していることに依存します（起動していない場合は warn-and-skip。サインイン時起動はランブックの前提条件です — [notifications.ja.md](notifications.ja.md) 参照）。
 
 ### `.brewfile-linux-exclude`
 

--- a/docs/architecture/dev-tooling.md
+++ b/docs/architecture/dev-tooling.md
@@ -53,6 +53,7 @@ ruby.compile = false
 Constraints:
 - Do not add `brew "chezmoi"` to the Brewfile. chezmoi itself is installed via the standalone `curl get.chezmoi.io` bootstrap (PR #22); adding it to the Brewfile would conflict with the mise-managed version.
 - Brewfile changes are auto-applied on the next `chezmoi apply` via the embedded sha256 in `run_onchange_before_10-brew-bundle.sh.tmpl`.
+- `cask "docker-desktop"` is load-bearing beyond ad-hoc container work: the self-hosted ntfy notification server runs under it, and `run_onchange_after_31-setup-ntfy` depends on Docker Desktop being running at apply time (warn-and-skip otherwise; start-at-login is a runbook prerequisite — see [notifications.md](notifications.md)).
 
 ### `.brewfile-linux-exclude`
 

--- a/docs/architecture/lifecycle-scripts.ja.md
+++ b/docs/architecture/lifecycle-scripts.ja.md
@@ -42,7 +42,8 @@ flowchart TD
         H2 --> I["18 setup-agent-browser\nrun_onchange\n(mise exec 経由で agent-browser install)"]
         I --> J["20 macos-defaults\nrun_onchange · macOS のみ\n(defaults write + killall Dock/Finder)"]
         J --> J2["30 register-launchd-agents\nrun_onchange · macOS のみ\n(repo 管理 LaunchAgent の launchctl bootstrap\nCI ではスキップ)"]
-        J2 --> K["40 setup-sheldon\nrun_onchange\n(sheldon lock)"]
+        J2 --> J3["31 setup-ntfy\nrun_onchange · macOS のみ\n(ntfy サーバー用の docker compose up +\ntailscale serve; CI ではスキップ)"]
+        J3 --> K["40 setup-sheldon\nrun_onchange\n(sheldon lock)"]
         K --> L["50 set-login-shell\nrun_once · Linux のみ\n(chsh -s zsh, sudo 失敗時は graceful)"]
         L --> M["90 other-apps\nrun_once · macOS のみ\n(Logi Options+ / Google IME ダウンロードプロンプト)\n(非 TTY は即時スキップ)"]
     end
@@ -79,6 +80,7 @@ flowchart TD
 | `17-setup-claude-plugins` | `dot_claude/settings.json` |
 | `18-setup-agent-browser` | `dot_config/mise/config.toml` |
 | `30-register-launchd-agents` | `Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl` |
+| `31-setup-ntfy` | `dot_config/ntfy/compose.yaml.tmpl` + `dot_config/ntfy/private_server.yml.tmpl` |
 | `40-setup-sheldon` | `dot_config/sheldon/plugins.toml` |
 | `20-macos-defaults` | 自分自身のソースファイル（任意の編集で再トリガー） |
 
@@ -110,6 +112,7 @@ quoted heredoc の中に埋め込みます。これにより単一ソースを�
 | `18-setup-agent-browser` | 両対応 | `{{ if linux }}` で `--with-deps` を追加 |
 | `20-macos-defaults` | **macOS のみ** | 本文全体が `{{ if darwin }}` 内。Linux ではほぼ空にレンダリング |
 | `30-register-launchd-agents` | **macOS のみ** | 本文全体が `{{ if darwin }}` 内。Linux ではほぼ空にレンダリング |
+| `31-setup-ntfy` | **macOS のみ** | 本文全体が `{{ if darwin }}` 内。Linux ではほぼ空にレンダリング |
 | `40-setup-sheldon` | 両対応 | OS ガードなし |
 | `50-set-login-shell` | **Linux のみ** | 本文全体が `{{ if linux }}` 内。macOS ではほぼ空にレンダリング |
 | `90-other-apps` | **macOS のみ** | 本文全体が `{{ if darwin }}` 内。Linux ではほぼ空にレンダリング |
@@ -128,12 +131,14 @@ Xcode CLI ツール（macOS、`xcode-select -p` が成功するまでポーリ�
 
 ### 11 — validate-1password (`run_once`、after、macOS のみ)
 
-ハードゲートです。`op` がインストール済みかつ認証済みであることを確認し、<!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> つの必須 vault 参照に対して `op read` を呼び出します。
+ハードゲートです。`op` がインストール済みかつ認証済みであることを確認し、<!-- FACT:onepassword-vault-item-count -->6<!-- /FACT --> つの必須 vault 参照に対して `op read` を呼び出します。
 
 - `op://kryota.dev/Dotfiles - AWS Config/notesPlain`
 - `op://kryota.dev/Dotfiles - Exa API/credential`
 - `op://kryota.dev/Dotfiles - Firecrawl API/credential`
 - `op://kryota.dev/Dotfiles - Redact Patterns/pattern`
+- `op://kryota.dev/Dotfiles - ntfy/base-url`
+- `op://kryota.dev/Dotfiles - ntfy/credential`
 
 `Dotfiles - Redact Patterns` アイテムについては単純な存在確認にとどまらず、パターンが非空であること、`private_gitleaks-own.toml.tmpl` の TOML 生文字列リテラルを破壊する `'''` を含まないこと、有効な正規表現としてコンパイルできることも検証します。破損したパターンは自社名前空間リポジトリのすべてのコミットでクライアント識別子ルールをサイレントに無効化してしまいます。
 
@@ -169,6 +174,10 @@ Xcode CLI ツール（macOS、`xcode-select -p` が成功するまでポーリ�
 
 repo 管理の launchd LaunchAgent（現在は平日朝ブリーフを発火する `dev.kryota.morning-radar` の 1 つ、kryota-dev/dotfiles#257。Claude Code ハーネスドキュメントの [朝次レーダーのスケジュール実行](../agents/claude-code.ja.md) 参照）を登録します。`launchctl bootout || true` → `launchctl bootstrap gui/$UID` の順で実行するため、plist の変更は冪等に再読み込みされます。再トリガーのキーは plist テンプレートの埋め込みハッシュです（wrapper script の編集は再登録不要 — launchd は発火のたびに現行ファイルを exec します）。`$CI` 設定時は登録をスキップします。headless runner には gui launchd domain が存在せず、in-script ガードならワークフローでファイルを除外する方式と異なり、レンダリング / apply パスが CI 検証対象に残ります。CI 外では bootstrap 失敗をハードフェイルとし、次回 apply で chezmoi がリトライします（規約 #6）。
 
+### 31 — setup-ntfy (`run_onchange`、after、macOS のみ)
+
+自己ホスト ntfy 通知サーバー（kryota-dev/dotfiles#337; [Notifications](notifications.ja.md) 参照）を起動します。ランタイム状態ディレクトリ（`~/Library/Application Support/ntfy`、0700、chezmoi のターゲットツリー外）を作成し、`~/.config/ntfy/compose.yaml` に対して `docker compose up -d` を実行し、`tailscale serve --bg` のマッピングを検証してサーバーが tailnet 全体から HTTPS で到達可能な状態を保ちます。compose テンプレートとサーバー設定の埋め込みハッシュで再トリガーされます。CI ではスキップします（サービスもネットワークもないため）。**規約 #6 からの意図的な逸脱**: Docker Desktop が起動していない（または tailscale CLI が存在しない）場合、ハードフェイルせず警告を出して exit 0 します——通知はセットアップクリティカルではなく、`chezmoi apply` をブロックしてはならないためです。各スキップパスは手動リカバリ手順を出力します。
+
 ### 40 — setup-sheldon (`run_onchange`、after)
 
 `.zshrc` が利用する zsh プラグインロックファイルを `sheldon lock` で再生成します。`plugins.toml` のハッシュで再トリガーされます。`sheldon` が未インストールの場合は警告を出して exit 0 します。
@@ -202,7 +211,7 @@ brew (00) → Homebrew パッケージ（mise, sheldon を含む）(10)
 
 ## スクリプト追加時の規約
 
-1. 順序付きタイムラインに自然に収まるプレフィックスを選ぶ。現在の空きスロット: `…15…17…19…31-39…`（40 より前）、`…41-49…`（sheldon とログインシェルの間）。
+1. 順序付きタイムラインに自然に収まるプレフィックスを選ぶ。現在の空きスロット: `…15…17…19…32-39…`（40 より前）、`…41-49…`（sheldon とログインシェルの間）。
 2. 高コスト・不可逆な操作には `run_once_`、冪等な同期ステップには `run_onchange_` を使用する。
 3. 外部ファイルへの変化で `run_onchange_` を再トリガーするには、先頭コメントに `{{ include "<path>" | sha256sum }}` を埋め込む。
 4. すべてのスクリプトを `#!/bin/bash` と `set -euo pipefail` で始める。ただし、スクリプト全体が OS 固有の場合は shebang を OS テンプレートガードの内側に置く。

--- a/docs/architecture/lifecycle-scripts.md
+++ b/docs/architecture/lifecycle-scripts.md
@@ -42,7 +42,8 @@ flowchart TD
         H2 --> I["18 setup-agent-browser\nrun_onchange\n(agent-browser install via mise exec)"]
         I --> J["20 macos-defaults\nrun_onchange · macOS only\n(defaults write + killall Dock/Finder)"]
         J --> J2["30 register-launchd-agents\nrun_onchange · macOS only\n(launchctl bootstrap of repo-managed\nLaunchAgents; skipped in CI)"]
-        J2 --> K["40 setup-sheldon\nrun_onchange\n(sheldon lock)"]
+        J2 --> J3["31 setup-ntfy\nrun_onchange · macOS only\n(docker compose up + tailscale serve\nfor the ntfy server; skipped in CI)"]
+        J3 --> K["40 setup-sheldon\nrun_onchange\n(sheldon lock)"]
         K --> L["50 set-login-shell\nrun_once · Linux only\n(chsh -s zsh, graceful on sudo fail)"]
         L --> M["90 other-apps\nrun_once · macOS only\n(Logi Options+ / Google IME download prompts)\n(non-TTY short-circuits immediately)"]
     end
@@ -79,6 +80,7 @@ When `dot_Brewfile` changes, the rendered comment line changes, the script body 
 | `17-setup-claude-plugins` | `dot_claude/settings.json` |
 | `18-setup-agent-browser` | `dot_config/mise/config.toml` |
 | `30-register-launchd-agents` | `Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl` |
+| `31-setup-ntfy` | `dot_config/ntfy/compose.yaml.tmpl` + `dot_config/ntfy/private_server.yml.tmpl` |
 | `40-setup-sheldon` | `dot_config/sheldon/plugins.toml` |
 | `20-macos-defaults` | its own source file (any edit re-triggers) |
 
@@ -111,6 +113,7 @@ Scripts use chezmoi template guards to select the appropriate behavior per OS.
 | `18-setup-agent-browser` | dual | `{{ if linux }}` adds `--with-deps` |
 | `20-macos-defaults` | **macOS only** | Entire body inside `{{ if darwin }}`; renders near-empty on Linux |
 | `30-register-launchd-agents` | **macOS only** | Entire body inside `{{ if darwin }}`; renders near-empty on Linux |
+| `31-setup-ntfy` | **macOS only** | Entire body inside `{{ if darwin }}`; renders near-empty on Linux |
 | `40-setup-sheldon` | both | No OS guard |
 | `50-set-login-shell` | **Linux only** | Entire body inside `{{ if linux }}`; renders near-empty on macOS |
 | `90-other-apps` | **macOS only** | Entire body inside `{{ if darwin }}`; renders near-empty on Linux |
@@ -129,12 +132,14 @@ Runs `brew bundle --no-upgrade` against `dot_Brewfile`. On Linux, filters the Br
 
 ### 11 — validate-1password (`run_once`, after, macOS only)
 
-Hard gate. Verifies `op` is installed and authenticated, then calls `op read` on each of the <!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> required vault references:
+Hard gate. Verifies `op` is installed and authenticated, then calls `op read` on each of the <!-- FACT:onepassword-vault-item-count -->6<!-- /FACT --> required vault references:
 
 - `op://kryota.dev/Dotfiles - AWS Config/notesPlain`
 - `op://kryota.dev/Dotfiles - Exa API/credential`
 - `op://kryota.dev/Dotfiles - Firecrawl API/credential`
 - `op://kryota.dev/Dotfiles - Redact Patterns/pattern`
+- `op://kryota.dev/Dotfiles - ntfy/base-url`
+- `op://kryota.dev/Dotfiles - ntfy/credential`
 
 For the `Dotfiles - Redact Patterns` item the script goes further than a simple existence check: it also verifies the pattern is non-empty, contains no `'''` (which would break the TOML raw-string literal in `private_gitleaks-own.toml.tmpl`), and compiles as a valid regex. A broken pattern would otherwise allow `chezmoi apply` to succeed while silently disabling the client-identifier gitleaks rule on every commit in own-namespace repos.
 
@@ -170,6 +175,19 @@ Applies `defaults write` for keyboard, Finder, Dock, DesktopServices, clock, and
 
 Registers the repo-managed launchd LaunchAgents — currently one, `dev.kryota.morning-radar`, which fires the weekday-morning brief (kryota-dev/dotfiles#257; see [Scheduled morning radar](../agents/claude-code.md) in the Claude Code harness doc). Performs `launchctl bootout || true` then `launchctl bootstrap gui/$UID` so a changed plist is reloaded idempotently; the plist template's embedded hash is the re-trigger key (wrapper-script edits need no re-registration — launchd execs the current file on every fire). Skips registration when `$CI` is set: headless runners have no gui launchd domain, and the in-script guard keeps the render/apply path CI-validated (unlike excluding the file in the workflow). Outside CI a bootstrap failure hard-fails so chezmoi retries on the next apply (convention #6).
 
+### 31 — setup-ntfy (`run_onchange`, after, macOS only)
+
+Starts the self-hosted ntfy notification server (kryota-dev/dotfiles#337; see
+[Notifications](notifications.md)): creates the runtime-state dir
+(`~/Library/Application Support/ntfy`, 0700, outside the chezmoi target tree), runs
+`docker compose up -d` on `~/.config/ntfy/compose.yaml`, and asserts the
+`tailscale serve --bg` mapping so the server stays reachable tailnet-wide over HTTPS.
+Re-triggered by the embedded hashes of the compose template and the server config.
+Skips in CI (no services, no network). **Intentional deviation from convention #6**:
+when Docker Desktop is not running (or the tailscale CLI is missing) it warns and
+exits 0 instead of hard-failing — notifications are not setup-critical and must never
+block `chezmoi apply`; each skip path prints its manual recovery command.
+
 ### 40 — setup-sheldon (`run_onchange`, after)
 
 Runs `sheldon lock` to regenerate the zsh plugin lockfile consumed by `.zshrc`. Re-triggered by the `plugins.toml` hash. Exits 0 with a warning when `sheldon` is not yet installed.
@@ -203,7 +221,7 @@ Scripts 13 and 14 invoke tools through `mise exec --` rather than via PATH becau
 
 ## Conventions for adding scripts
 
-1. Choose a prefix that slots naturally into the ordered timeline. Current slots with gaps: `…15…17…19…31-39…` (before 40), `…41-49…` (between sheldon and login-shell).
+1. Choose a prefix that slots naturally into the ordered timeline. Current slots with gaps: `…15…17…19…32-39…` (before 40), `…41-49…` (between sheldon and login-shell).
 2. Use `run_once_` for expensive/irreversible operations; `run_onchange_` for idempotent sync.
 3. For `run_onchange_` scripts that must react to an external file, embed `{{ include "<path>" | sha256sum }}` in a leading comment.
 4. Start every script with `#!/bin/bash` and `set -euo pipefail` — or place the shebang inside the OS template guard if the entire script is OS-specific.

--- a/docs/architecture/notifications.ja.md
+++ b/docs/architecture/notifications.ja.md
@@ -10,6 +10,13 @@ tailnet 上のデバイスから subscribe されます（kryota-dev/dotfiles#33
 リモートから subscribe 可能な通知に置き換えます。最終決定の記録は
 `.claude/prds/337-ntfy-tailscale.prd.md` にあります。
 
+**スコープの境界**: このページが扱うのは Claude Code の `Notification`/`Stop` フックから
+ntfy への経路のみです。リポジトリには、本システムが意図的に手を付けていない独立した
+ローカル限定の通知経路が他に3つあります: `clv2-session-notify.sh`（SessionStart、
+instinct クラスターのレビュー促し）、`morning-radar.sh`（launchd、osascript による
+朝ブリーフ）、`notify` zsh エイリアス（可聴チャイム。本システムの wrapper も失敗時の
+アラート音として再利用しています）。
+
 ## アーキテクチャ
 
 ```
@@ -21,7 +28,7 @@ Claude Code hooks (settings.json)
 ~/.claude/ntfy-notify.sh ──── enrich (repo/branch/account/session/event)
         │ curl -K, Bearer write-only token, --max-time 3
         ▼
-http://127.0.0.1:2586 ── docker: binary/ntfy (restart: unless-stopped)
+http://127.0.0.1:2586 ── docker: binwiederhier/ntfy (restart: unless-stopped)
         ▲                        └─ state: ~/Library/Application Support/ntfy/
 tailscale serve --bg (HTTPS, MagicDNS)          (user.db, cache.db — outside chezmoi)
         ▲
@@ -29,17 +36,19 @@ phones/tablets on the tailnet (read-only token)
 ```
 
 - **サーバーランタイム**: Homebrew の `ntfy` formula は `noserver` タグ付きで macOS バイナリを
-  ビルドするため（`ntfy serve` は存在しない）、サーバーは公式の `binary/ntfy` Docker イメージとして
+  ビルドするため（`ntfy serve` は存在しない）、サーバーは公式の `binwiederhier/ntfy` Docker イメージとして
   Docker Desktop 上で動作します。イメージタグは `home/dot_config/ntfy/compose.yaml.tmpl` にピン留めされ、
   Renovate が追跡します。
 - **ネットワーク境界**: コンテナは `127.0.0.1` にのみバインドします。tailnet への公開は
   `tailscale serve --bg`（再起動をまたいで永続化）を通じてのみ行われます。`tailscale
   funnel` は禁止です — 疑わしい場合は `tailscale funnel status`（何も serve していないことを期待）で
   確認してください。
-- **iOS の即時 push**: `upstream-base-url: https://ntfy.sh` がポーリングリクエスト
-  （トピックのメタデータのみ、メッセージ本文は含まない）を ntfy.sh/APNs 経由でリレーします — これが
-  唯一の承認済みメタデータ egress です。デバイス自体は本文をこのサーバーから tailnet 経由で取得します。
-  実機の iOS 挙動を観測後、ここに記録してください:
+- **iOS の即時 push**: `upstream-base-url: https://ntfy.sh` は、**受信メッセージすべて**について
+  ntfy.sh へポーリングリクエストを送ります — iOS デバイスが購読しているかどうかに関係なく
+  （トピックのメタデータのみで、メッセージ本文は含みません）— これが APNs に即時配信の材料を渡します。
+  これが唯一の承認済みメタデータ egress です。デバイス自体は本文をこのサーバーから tailnet 経由で
+  取得します。smoke test で tailnet-only では即時 push が機能しないと判明した場合は、この key を
+  削除して egress をゼロにしてください。実機の iOS 挙動を観測後、ここに記録してください:
   _observed: (pending first smoke test)_.
 - **トピック**（固定、緊急度ベース; SSOT は `home/.chezmoidata.toml` の `[ntfy]`）:
 
@@ -81,23 +90,33 @@ phones/tablets on the tailnet (read-only token)
    docker compose exec ntfy ntfy token add --label devices subscriber
    ```
 
-   publisher トークンをアイテムの `credential` フィールドに、subscriber トークンを別のフィールドに
-   （各デバイスへ手動で入力するため）保存し、`chezmoi apply` を再実行します。
+   publisher トークンをアイテムの `credential` フィールドに、subscriber トークンを
+   `subscriber-token` フィールドに（各デバイスへ手動で入力するため）保存し、`chezmoi apply`
+   を再実行します。
+   注: `ntfy token add` はトークンを端末の scrollback にそのまま出力します — 値を保存したら
+   scrollback をクリアしてください。
 5. **デバイスの subscribe** — ntfy アプリ（iOS/Android）→ *別のサーバーを使う* で `base-url`
    エンドポイント、1Password の subscriber トークン、2つのトピックを設定します。
 
 ## Smoke test
 
+トークンをコマンドラインに乗せることは決してしません（`-H` だと `ps` やシェル履歴に露出します —
+wrapper が課しているのと同じルールです）。代わりに process substitution で curl に header 設定を
+渡します:
+
 ```bash
+BASE="$(op read 'op://kryota.dev/Dotfiles - ntfy/base-url')"
+ro() { printf 'header = "Authorization: Bearer %s"\n' "$(op read 'op://kryota.dev/Dotfiles - ntfy/subscriber-token')"; }
+wo() { printf 'header = "Authorization: Bearer %s"\n' "$(op read 'op://kryota.dev/Dotfiles - ntfy/credential')"; }
 # anonymous publish must be denied (401/403)
-curl -s -o /dev/null -w '%{http_code}\n' -d test "$(op read 'op://kryota.dev/Dotfiles - ntfy/base-url')/claude-test"
+curl -s -o /dev/null -w '%{http_code}\n' -d test "$BASE/claude-test"
 # read-only token must be denied for publish (403)
-curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer <subscriber-token>" -d test ".../claude-test"
+curl -s -o /dev/null -w '%{http_code}\n' -K <(ro) -d test "$BASE/claude-test"
 # publisher token succeeds (200); phones should receive it
-curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer <publisher-token>" -d test ".../claude-test"
+curl -s -o /dev/null -w '%{http_code}\n' -K <(wo) -d test "$BASE/claude-test"
 # history retrieval + filtering examples (verify once, then rely on them)
-curl -s -H "Authorization: Bearer <subscriber-token>" ".../claude-done/json?poll=1&since=24h" | jq 'select(.tags | index("dotfiles"))'
-curl -s -H "Authorization: Bearer <subscriber-token>" ".../claude-attention/json?poll=1&since=all" | jq 'select(.tags | index("permission_prompt"))'
+curl -s -K <(ro) "$BASE/claude-done/json?poll=1&since=24h" | jq 'select(.tags | index("dotfiles"))'
+curl -s -K <(ro) "$BASE/claude-attention/json?poll=1&since=all" | jq 'select(.tags | index("permission_prompt"))'
 ```
 
 アプリを閉じた状態で iOS が即時配信するかどうかも記録してください（tailnet 限定サーバー上での
@@ -109,12 +128,12 @@ upstream リレーは upstream 側で未検証です — PRD 参照）。
 |---------|-------------|
 | Local alert sound, no phone notification | Wrapper publish failed — server down. Check `~/Library/Logs/ntfy-notify.log`, then `docker compose -f ~/.config/ntfy/compose.yaml up -d` |
 | No notifications right after login | Docker Desktop still starting; the fail-open window is expected. Enable start-at-login (runbook step 2) |
-| `chezmoi apply` prints `[ntfy] Docker Desktop is not running` | Intentional warn-and-skip (deviation from lifecycle convention #6): notifications must not block apply. Start Docker Desktop, re-run apply or the printed compose command |
+| `chezmoi apply` prints `[ntfy] Docker Desktop is not running` | Intentional warn-and-skip (deviation from lifecycle convention #6): notifications must not block apply. **復旧は印字された `docker compose up -d` コマンドで行う** — `chezmoi apply` の再実行だけでは再試行されない（exit 0 で `run_onchange` の state が記録され、compose/server テンプレートが変更されたときのみ再発火する） |
 | Phone can't reach the server | Device off the tailnet, or `tailscale serve` mapping lost — re-run `tailscale serve --bg http://127.0.0.1:2586` (also asserted by every re-triggered apply) |
 | Old messages missing | `cache-duration` (168h, `[ntfy]` in `.chezmoidata.toml`) elapsed |
 | Notifications on the wrong account badge | `CLAUDE_CONFIG_DIR` unset in that session; account falls back to `default` |
 
-## リカバリ: auth.db の消失・破損
+## リカバリ: user.db (auth) の消失・破損
 
 破損している場合は `~/Library/Application Support/ntfy/user.db` を削除し、セットアップ手順の
 4 を再実行してください。**トークンを再発行するとすべての既存トークンが無効化されます**: 1Password の

--- a/docs/architecture/notifications.ja.md
+++ b/docs/architecture/notifications.ja.md
@@ -1,0 +1,130 @@
+# Notifications: 自己ホスト ntfy over Tailscale
+
+🌐 English (canonical): [notifications.md](notifications.md)
+
+← [ドキュメント目次](../README.ja.md)
+
+Claude Code のセッションイベントは、この Mac 上に自己ホストした ntfy サーバーへ push され、
+tailnet 上のデバイスから subscribe されます（kryota-dev/dotfiles#337）。これにより ECC の
+`stop:desktop-notify` Stop フック（ローカル osascript、履歴なし）を、帰属情報付きで永続化され、
+リモートから subscribe 可能な通知に置き換えます。最終決定の記録は
+`.claude/prds/337-ntfy-tailscale.prd.md` にあります。
+
+## アーキテクチャ
+
+```
+Claude Code hooks (settings.json)
+  Notification: permission_prompt | idle_prompt | agent_needs_input | agent_completed
+  Stop
+        │ stdin JSON (async, fail-open)
+        ▼
+~/.claude/ntfy-notify.sh ──── enrich (repo/branch/account/session/event)
+        │ curl -K, Bearer write-only token, --max-time 3
+        ▼
+http://127.0.0.1:2586 ── docker: binary/ntfy (restart: unless-stopped)
+        ▲                        └─ state: ~/Library/Application Support/ntfy/
+tailscale serve --bg (HTTPS, MagicDNS)          (user.db, cache.db — outside chezmoi)
+        ▲
+phones/tablets on the tailnet (read-only token)
+```
+
+- **サーバーランタイム**: Homebrew の `ntfy` formula は `noserver` タグ付きで macOS バイナリを
+  ビルドするため（`ntfy serve` は存在しない）、サーバーは公式の `binary/ntfy` Docker イメージとして
+  Docker Desktop 上で動作します。イメージタグは `home/dot_config/ntfy/compose.yaml.tmpl` にピン留めされ、
+  Renovate が追跡します。
+- **ネットワーク境界**: コンテナは `127.0.0.1` にのみバインドします。tailnet への公開は
+  `tailscale serve --bg`（再起動をまたいで永続化）を通じてのみ行われます。`tailscale
+  funnel` は禁止です — 疑わしい場合は `tailscale funnel status`（何も serve していないことを期待）で
+  確認してください。
+- **iOS の即時 push**: `upstream-base-url: https://ntfy.sh` がポーリングリクエスト
+  （トピックのメタデータのみ、メッセージ本文は含まない）を ntfy.sh/APNs 経由でリレーします — これが
+  唯一の承認済みメタデータ egress です。デバイス自体は本文をこのサーバーから tailnet 経由で取得します。
+  実機の iOS 挙動を観測後、ここに記録してください:
+  _observed: (pending first smoke test)_.
+- **トピック**（固定、緊急度ベース; SSOT は `home/.chezmoidata.toml` の `[ntfy]`）:
+
+| Topic | Events | Priority | Intended device setting |
+|-------|--------|----------|------------------------|
+| `claude-attention` | permission_prompt, idle_prompt, agent_needs_input | high (4) | sound/vibrate on |
+| `claude-done` | agent_completed, Stop | default (3) | silent delivery |
+| `claude-test` | manual smoke tests | — | mute after testing |
+
+帰属情報（repo、branch、account `default`/`r06`、8文字のセッション id、イベント種別）はタイトルと
+タグに乗り、トピック名には決して含まれません。Stop の本文は 200 文字に切り詰められ、
+`~/.config/git/gitleaks-own.toml` のクライアント識別子パターンでスクラブされます（ベストエフォートの
+名前スクラブであり、**secret/PII 検出器ではありません** — 切り詰めが主たる防御手段です）。
+許容済み残存リスク（#337 PRD）: プロンプトインジェクションを受けたアシスタントメッセージが
+200 文字の窓内に短い secret 断片を含む可能性は残ります — 汎用 secret 検出は明示的にスコープ外です。
+
+## セットアップ手順（初回のみ）
+
+1. **1Password アイテム** — `kryota.dev` Vault に `Dotfiles - ntfy` を作成し、フィールド
+   `base-url`（serve エンドポイント、`https://<host>.<tailnet>.ts.net`）と
+   `credential`（手順4まではプレースホルダー）を設定します。
+   [secrets-1password](../getting-started/secrets-1password.ja.md) を参照してください。
+2. **Docker Desktop** — *サインイン時に Docker Desktop を起動する*（設定 →
+   一般）を有効化します。これにより compose の `restart: unless-stopped` ポリシーが、
+   再起動のたびにサーバーを復帰させます。
+3. **Apply** — `chezmoi apply` が設定をレンダリングし、コンテナを起動し
+   （`run_onchange_after_31-setup-ntfy`）、`tailscale serve --bg` のマッピングを検証します。
+4. **認証情報のプロビジョニング**（コンテナ内で実行; 認証はランタイム状態であり chezmoi 管理外です）:
+
+   ```bash
+   cd ~/.config/ntfy
+   docker compose exec ntfy ntfy user add publisher     # publisher, write-only
+   docker compose exec ntfy ntfy user add subscriber    # devices, read-only
+   for t in claude-attention claude-done claude-test; do
+     docker compose exec ntfy ntfy access publisher "$t" write-only
+     docker compose exec ntfy ntfy access subscriber "$t" read-only
+   done
+   docker compose exec ntfy ntfy token add --label chezmoi publisher
+   docker compose exec ntfy ntfy token add --label devices subscriber
+   ```
+
+   publisher トークンをアイテムの `credential` フィールドに、subscriber トークンを別のフィールドに
+   （各デバイスへ手動で入力するため）保存し、`chezmoi apply` を再実行します。
+5. **デバイスの subscribe** — ntfy アプリ（iOS/Android）→ *別のサーバーを使う* で `base-url`
+   エンドポイント、1Password の subscriber トークン、2つのトピックを設定します。
+
+## Smoke test
+
+```bash
+# anonymous publish must be denied (401/403)
+curl -s -o /dev/null -w '%{http_code}\n' -d test "$(op read 'op://kryota.dev/Dotfiles - ntfy/base-url')/claude-test"
+# read-only token must be denied for publish (403)
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer <subscriber-token>" -d test ".../claude-test"
+# publisher token succeeds (200); phones should receive it
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer <publisher-token>" -d test ".../claude-test"
+# history retrieval + filtering examples (verify once, then rely on them)
+curl -s -H "Authorization: Bearer <subscriber-token>" ".../claude-done/json?poll=1&since=24h" | jq 'select(.tags | index("dotfiles"))'
+curl -s -H "Authorization: Bearer <subscriber-token>" ".../claude-attention/json?poll=1&since=all" | jq 'select(.tags | index("permission_prompt"))'
+```
+
+アプリを閉じた状態で iOS が即時配信するかどうかも記録してください（tailnet 限定サーバー上での
+upstream リレーは upstream 側で未検証です — PRD 参照）。
+
+## 障害モードとトラブルシューティング
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| Local alert sound, no phone notification | Wrapper publish failed — server down. Check `~/Library/Logs/ntfy-notify.log`, then `docker compose -f ~/.config/ntfy/compose.yaml up -d` |
+| No notifications right after login | Docker Desktop still starting; the fail-open window is expected. Enable start-at-login (runbook step 2) |
+| `chezmoi apply` prints `[ntfy] Docker Desktop is not running` | Intentional warn-and-skip (deviation from lifecycle convention #6): notifications must not block apply. Start Docker Desktop, re-run apply or the printed compose command |
+| Phone can't reach the server | Device off the tailnet, or `tailscale serve` mapping lost — re-run `tailscale serve --bg http://127.0.0.1:2586` (also asserted by every re-triggered apply) |
+| Old messages missing | `cache-duration` (168h, `[ntfy]` in `.chezmoidata.toml`) elapsed |
+| Notifications on the wrong account badge | `CLAUDE_CONFIG_DIR` unset in that session; account falls back to `default` |
+
+## リカバリ: auth.db の消失・破損
+
+破損している場合は `~/Library/Application Support/ntfy/user.db` を削除し、セットアップ手順の
+4 を再実行してください。**トークンを再発行するとすべての既存トークンが無効化されます**: 1Password の
+`credential` フィールドを更新し、`chezmoi apply` を再実行し、subscribe している全デバイスで
+subscriber トークンを再入力してください。
+
+## ロールバック（1ステップ）
+
+settings.json の2つの変更をまとめて revert してください — `env.ECC_DISABLED_HOOKS` から
+`stop:desktop-notify` を削除し、**かつ** `notification:ntfy-notify` / `stop:ntfy-notify` の
+フックエントリを削除した上で `chezmoi apply` を実行します。片方だけ行うと、通知が来なくなるか
+二重通知になります。サーバーの停止（任意）:
+`docker compose -f ~/.config/ntfy/compose.yaml down` と `tailscale serve --https=443 off`。

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -1,0 +1,130 @@
+# Notifications: self-hosted ntfy over Tailscale
+
+[日本語版](notifications.ja.md)
+
+Claude Code session events are pushed to a ntfy server self-hosted on this Mac and
+subscribed from tailnet devices (kryota-dev/dotfiles#337). This replaces the ECC
+`stop:desktop-notify` Stop hook (local osascript, no history) with attributable,
+persistent, remotely subscribable notifications. The finalized decision record lives
+in `.claude/prds/337-ntfy-tailscale.prd.md`.
+
+## Architecture
+
+```
+Claude Code hooks (settings.json)
+  Notification: permission_prompt | idle_prompt | agent_needs_input | agent_completed
+  Stop
+        │ stdin JSON (async, fail-open)
+        ▼
+~/.claude/ntfy-notify.sh ──── enrich (repo/branch/account/session/event)
+        │ curl -K, Bearer write-only token, --max-time 3
+        ▼
+http://127.0.0.1:2586 ── docker: binary/ntfy (restart: unless-stopped)
+        ▲                        └─ state: ~/Library/Application Support/ntfy/
+tailscale serve --bg (HTTPS, MagicDNS)          (user.db, cache.db — outside chezmoi)
+        ▲
+phones/tablets on the tailnet (read-only token)
+```
+
+- **Server runtime**: the Homebrew `ntfy` formula builds macOS binaries with the
+  `noserver` tag (`ntfy serve` does not exist), so the server runs as the official
+  `binary/ntfy` Docker image under Docker Desktop. The image tag is pinned in
+  `home/dot_config/ntfy/compose.yaml.tmpl` and tracked by Renovate.
+- **Network boundary**: the container binds `127.0.0.1` only; tailnet exposure goes
+  exclusively through `tailscale serve --bg` (persists across reboots). `tailscale
+  funnel` is prohibited — verify with `tailscale funnel status` (expect nothing
+  served) whenever in doubt.
+- **iOS instant push**: `upstream-base-url: https://ntfy.sh` relays poll requests
+  (topic metadata only, never message bodies) through ntfy.sh/APNs — the sole
+  approved metadata egress. The device still fetches bodies from this server over
+  the tailnet. Record the observed iOS behavior here after the smoke test:
+  _observed: (pending first smoke test)_.
+- **Topics** (fixed, urgency-based; SSOT in `home/.chezmoidata.toml` `[ntfy]`):
+
+| Topic | Events | Priority | Intended device setting |
+|-------|--------|----------|------------------------|
+| `claude-attention` | permission_prompt, idle_prompt, agent_needs_input | high (4) | sound/vibrate on |
+| `claude-done` | agent_completed, Stop | default (3) | silent delivery |
+| `claude-test` | manual smoke tests | — | mute after testing |
+
+Attribution (repo, branch, account `default`/`r06`, 8-char session id, event type)
+travels in titles and tags, never in topic names. Stop bodies are truncated to 200
+chars and scrubbed with the client-identifier pattern from
+`~/.config/git/gitleaks-own.toml` (best-effort name scrub — **not** a secret/PII
+detector; truncation is the primary defense). Accepted residual risk (#337 PRD): a
+prompt-injected assistant message could still surface short secret fragments within
+the 200-char window — general secret detection is explicitly out of scope.
+
+## Setup runbook (one-time)
+
+1. **1Password item** — create `Dotfiles - ntfy` in the `kryota.dev` vault with
+   fields `base-url` (the serve endpoint, `https://<host>.<tailnet>.ts.net`) and
+   `credential` (placeholder until step 4). See
+   [secrets-1password](../getting-started/secrets-1password.md).
+2. **Docker Desktop** — enable *Start Docker Desktop when you sign in* (Settings →
+   General); the compose `restart: unless-stopped` policy then revives the server
+   after every reboot.
+3. **Apply** — `chezmoi apply` renders the config, starts the container
+   (`run_onchange_after_31-setup-ntfy`), and asserts the `tailscale serve --bg`
+   mapping.
+4. **Provision auth** (inside the container; auth is runtime state, never chezmoi-managed):
+
+   ```bash
+   cd ~/.config/ntfy
+   docker compose exec ntfy ntfy user add publisher     # publisher, write-only
+   docker compose exec ntfy ntfy user add subscriber    # devices, read-only
+   for t in claude-attention claude-done claude-test; do
+     docker compose exec ntfy ntfy access publisher "$t" write-only
+     docker compose exec ntfy ntfy access subscriber "$t" read-only
+   done
+   docker compose exec ntfy ntfy token add --label chezmoi publisher
+   docker compose exec ntfy ntfy token add --label devices subscriber
+   ```
+
+   Store the publisher token in the item's `credential` field, the subscriber token
+   in a separate field (entered on devices manually), then re-run `chezmoi apply`.
+5. **Subscribe devices** — ntfy app (iOS/Android) → *Use another server* with the
+   `base-url` endpoint, the subscriber token from 1Password, and the two topics.
+
+## Smoke test
+
+```bash
+# anonymous publish must be denied (401/403)
+curl -s -o /dev/null -w '%{http_code}\n' -d test "$(op read 'op://kryota.dev/Dotfiles - ntfy/base-url')/claude-test"
+# read-only token must be denied for publish (403)
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer <subscriber-token>" -d test ".../claude-test"
+# publisher token succeeds (200); phones should receive it
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer <publisher-token>" -d test ".../claude-test"
+# history retrieval + filtering examples (verify once, then rely on them)
+curl -s -H "Authorization: Bearer <subscriber-token>" ".../claude-done/json?poll=1&since=24h" | jq 'select(.tags | index("dotfiles"))'
+curl -s -H "Authorization: Bearer <subscriber-token>" ".../claude-attention/json?poll=1&since=all" | jq 'select(.tags | index("permission_prompt"))'
+```
+
+Also record whether iOS delivers instantly with the app closed (upstream relay on a
+tailnet-only server is unverified upstream — see the PRD).
+
+## Failure modes & troubleshooting
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| Local alert sound, no phone notification | Wrapper publish failed — server down. Check `~/Library/Logs/ntfy-notify.log`, then `docker compose -f ~/.config/ntfy/compose.yaml up -d` |
+| No notifications right after login | Docker Desktop still starting; the fail-open window is expected. Enable start-at-login (runbook step 2) |
+| `chezmoi apply` prints `[ntfy] Docker Desktop is not running` | Intentional warn-and-skip (deviation from lifecycle convention #6): notifications must not block apply. Start Docker Desktop, re-run apply or the printed compose command |
+| Phone can't reach the server | Device off the tailnet, or `tailscale serve` mapping lost — re-run `tailscale serve --bg http://127.0.0.1:2586` (also asserted by every re-triggered apply) |
+| Old messages missing | `cache-duration` (168h, `[ntfy]` in `.chezmoidata.toml`) elapsed |
+| Notifications on the wrong account badge | `CLAUDE_CONFIG_DIR` unset in that session; account falls back to `default` |
+
+## Recovery: auth.db lost or corrupted
+
+Delete `~/Library/Application Support/ntfy/user.db` if corrupted, then re-run
+runbook step 4. **Re-issuing tokens invalidates every existing token**: update the
+1Password `credential` field, re-run `chezmoi apply`, and re-enter the subscriber
+token on every subscribed device.
+
+## Rollback (one step)
+
+Revert the two settings.json changes together — remove `stop:desktop-notify` from
+`env.ECC_DISABLED_HOOKS` **and** delete the `notification:ntfy-notify` /
+`stop:ntfy-notify` hook entries — then `chezmoi apply`. Doing only one half either
+leaves you notification-less or double-notifies. Server teardown (optional):
+`docker compose -f ~/.config/ntfy/compose.yaml down` and `tailscale serve --https=443 off`.

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -8,6 +8,13 @@ subscribed from tailnet devices (kryota-dev/dotfiles#337). This replaces the ECC
 persistent, remotely subscribable notifications. The finalized decision record lives
 in `.claude/prds/337-ntfy-tailscale.prd.md`.
 
+**Scope boundary**: this page covers only the Claude Code `Notification`/`Stop`
+hook → ntfy path. The repo has three other, independent local-only notification
+paths that this system deliberately does not touch: `clv2-session-notify.sh`
+(SessionStart, instinct-cluster review nudge), `morning-radar.sh` (launchd,
+osascript morning brief), and the `notify` zsh alias (audible chime, also reused
+by this system's wrapper as its failure alert sound).
+
 ## Architecture
 
 ```
@@ -19,7 +26,7 @@ Claude Code hooks (settings.json)
 ~/.claude/ntfy-notify.sh ──── enrich (repo/branch/account/session/event)
         │ curl -K, Bearer write-only token, --max-time 3
         ▼
-http://127.0.0.1:2586 ── docker: binary/ntfy (restart: unless-stopped)
+http://127.0.0.1:2586 ── docker: binwiederhier/ntfy (restart: unless-stopped)
         ▲                        └─ state: ~/Library/Application Support/ntfy/
 tailscale serve --bg (HTTPS, MagicDNS)          (user.db, cache.db — outside chezmoi)
         ▲
@@ -28,16 +35,19 @@ phones/tablets on the tailnet (read-only token)
 
 - **Server runtime**: the Homebrew `ntfy` formula builds macOS binaries with the
   `noserver` tag (`ntfy serve` does not exist), so the server runs as the official
-  `binary/ntfy` Docker image under Docker Desktop. The image tag is pinned in
+  `binwiederhier/ntfy` Docker image under Docker Desktop. The image tag is pinned in
   `home/dot_config/ntfy/compose.yaml.tmpl` and tracked by Renovate.
 - **Network boundary**: the container binds `127.0.0.1` only; tailnet exposure goes
   exclusively through `tailscale serve --bg` (persists across reboots). `tailscale
   funnel` is prohibited — verify with `tailscale funnel status` (expect nothing
   served) whenever in doubt.
-- **iOS instant push**: `upstream-base-url: https://ntfy.sh` relays poll requests
-  (topic metadata only, never message bodies) through ntfy.sh/APNs — the sole
-  approved metadata egress. The device still fetches bodies from this server over
-  the tailnet. Record the observed iOS behavior here after the smoke test:
+- **iOS instant push**: `upstream-base-url: https://ntfy.sh` publishes a poll
+  request to ntfy.sh for **every incoming message** — regardless of whether any
+  iOS device subscribes (topic metadata only, never message bodies) — feeding
+  APNs for instant delivery. This is the sole approved metadata egress. The
+  device still fetches bodies from this server over the tailnet. If the smoke
+  test shows instant push does not work tailnet-only, remove the key to bring
+  egress to zero. Record the observed iOS behavior here after the smoke test:
   _observed: (pending first smoke test)_.
 - **Topics** (fixed, urgency-based; SSOT in `home/.chezmoidata.toml` `[ntfy]`):
 
@@ -82,22 +92,32 @@ the 200-char window — general secret detection is explicitly out of scope.
    ```
 
    Store the publisher token in the item's `credential` field, the subscriber token
-   in a separate field (entered on devices manually), then re-run `chezmoi apply`.
+   in a `subscriber-token` field (entered on devices manually), then re-run
+   `chezmoi apply`.
+   Note: `ntfy token add` echoes tokens into terminal scrollback — clear it after
+   storing the values.
 5. **Subscribe devices** — ntfy app (iOS/Android) → *Use another server* with the
    `base-url` endpoint, the subscriber token from 1Password, and the two topics.
 
 ## Smoke test
 
+Tokens never go on the command line (`-H` would expose them in `ps` and shell
+history — the same rule the wrapper enforces); feed curl a header config via
+process substitution instead:
+
 ```bash
+BASE="$(op read 'op://kryota.dev/Dotfiles - ntfy/base-url')"
+ro() { printf 'header = "Authorization: Bearer %s"\n' "$(op read 'op://kryota.dev/Dotfiles - ntfy/subscriber-token')"; }
+wo() { printf 'header = "Authorization: Bearer %s"\n' "$(op read 'op://kryota.dev/Dotfiles - ntfy/credential')"; }
 # anonymous publish must be denied (401/403)
-curl -s -o /dev/null -w '%{http_code}\n' -d test "$(op read 'op://kryota.dev/Dotfiles - ntfy/base-url')/claude-test"
+curl -s -o /dev/null -w '%{http_code}\n' -d test "$BASE/claude-test"
 # read-only token must be denied for publish (403)
-curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer <subscriber-token>" -d test ".../claude-test"
+curl -s -o /dev/null -w '%{http_code}\n' -K <(ro) -d test "$BASE/claude-test"
 # publisher token succeeds (200); phones should receive it
-curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer <publisher-token>" -d test ".../claude-test"
+curl -s -o /dev/null -w '%{http_code}\n' -K <(wo) -d test "$BASE/claude-test"
 # history retrieval + filtering examples (verify once, then rely on them)
-curl -s -H "Authorization: Bearer <subscriber-token>" ".../claude-done/json?poll=1&since=24h" | jq 'select(.tags | index("dotfiles"))'
-curl -s -H "Authorization: Bearer <subscriber-token>" ".../claude-attention/json?poll=1&since=all" | jq 'select(.tags | index("permission_prompt"))'
+curl -s -K <(ro) "$BASE/claude-done/json?poll=1&since=24h" | jq 'select(.tags | index("dotfiles"))'
+curl -s -K <(ro) "$BASE/claude-attention/json?poll=1&since=all" | jq 'select(.tags | index("permission_prompt"))'
 ```
 
 Also record whether iOS delivers instantly with the app closed (upstream relay on a
@@ -109,12 +129,12 @@ tailnet-only server is unverified upstream — see the PRD).
 |---------|-------------|
 | Local alert sound, no phone notification | Wrapper publish failed — server down. Check `~/Library/Logs/ntfy-notify.log`, then `docker compose -f ~/.config/ntfy/compose.yaml up -d` |
 | No notifications right after login | Docker Desktop still starting; the fail-open window is expected. Enable start-at-login (runbook step 2) |
-| `chezmoi apply` prints `[ntfy] Docker Desktop is not running` | Intentional warn-and-skip (deviation from lifecycle convention #6): notifications must not block apply. Start Docker Desktop, re-run apply or the printed compose command |
+| `chezmoi apply` prints `[ntfy] Docker Desktop is not running` | Intentional warn-and-skip (deviation from lifecycle convention #6): notifications must not block apply. **Recover with the printed `docker compose up -d` command** — re-running `chezmoi apply` alone does NOT retry (the exit-0 run records the `run_onchange` state; the script only re-fires when the compose/server templates change) |
 | Phone can't reach the server | Device off the tailnet, or `tailscale serve` mapping lost — re-run `tailscale serve --bg http://127.0.0.1:2586` (also asserted by every re-triggered apply) |
 | Old messages missing | `cache-duration` (168h, `[ntfy]` in `.chezmoidata.toml`) elapsed |
 | Notifications on the wrong account badge | `CLAUDE_CONFIG_DIR` unset in that session; account falls back to `default` |
 
-## Recovery: auth.db lost or corrupted
+## Recovery: user.db (auth) lost or corrupted
 
 Delete `~/Library/Application Support/ntfy/user.db` if corrupted, then re-run
 runbook step 4. **Re-issuing tokens invalidates every existing token**: update the

--- a/docs/architecture/overview.ja.md
+++ b/docs/architecture/overview.ja.md
@@ -45,6 +45,7 @@ flowchart TD
 | ライフサイクルスクリプト | 2 フェーズ（before/after）順序（00→90）、`run_once` vs `run_onchange`、1Password ゲート | [lifecycle-scripts.ja.md](lifecycle-scripts.ja.md) |
 | シェル環境 | `.zshrc` ロード順序、sheldon 遅延ロード、starship、per-account zsh エイリアス | [shell-environment.ja.md](shell-environment.ja.md) |
 | 開発ツールチェーン | mise バージョンピン、`Brewfile` + `.brewfile-linux-exclude`、git 1Password 署名、gitleaks | [dev-tooling.ja.md](dev-tooling.ja.md) |
+| Notifications | Claude Code フックイベント → 自己ホスト ntfy（Docker、loopback のみ）→ tailnet デバイス。トピック、認証/ACL、ランブック | [notifications.ja.md](notifications.ja.md) |
 | AI エージェント層（概要） | デュアルハーネス × デュアルアカウントマトリクス、SSOT スキルライブラリ、共有ルール層 | [agents/overview.ja.md](../agents/overview.ja.md) |
 | アカウント分離 | per-account 環境変数、`_claude_with_home`、Codex `CODEX_HOME` | [agents/account-isolation.ja.md](../agents/account-isolation.ja.md) |
 | Claude Code ハーネス | `settings.json`、ECC フック、CLV2 オブザーバー、statusline、レビューサブエージェント | [agents/claude-code.ja.md](../agents/claude-code.ja.md) |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -45,6 +45,7 @@ flowchart TD
 | Lifecycle scripts | Two-phase (before/after) ordering (00→90); `run_once` vs `run_onchange`; 1Password gate | [lifecycle-scripts.md](lifecycle-scripts.md) |
 | Shell environment | `.zshrc` load order; sheldon deferred loading; starship; per-account zsh aliases | [shell-environment.md](shell-environment.md) |
 | Developer tooling | mise version pins; `Brewfile` + `.brewfile-linux-exclude`; git 1Password signing; gitleaks | [dev-tooling.md](dev-tooling.md) |
+| Notifications | Claude Code hook events → self-hosted ntfy (Docker, loopback-only) → tailnet devices; topics, auth/ACL, runbooks | [notifications.md](notifications.md) |
 | AI-agent layer (overview) | Dual-harness × dual-account matrix; SSOT skill library; shared rule layer | [agents/overview.md](../agents/overview.md) |
 | Account isolation | Per-account env vars; `_claude_with_home`; Codex `CODEX_HOME` | [agents/account-isolation.md](../agents/account-isolation.md) |
 | Claude Code harness | `settings.json`; ECC hooks; CLV2 observer; statusline; review subagents | [agents/claude-code.md](../agents/claude-code.md) |

--- a/docs/contributing/ci-and-tests.ja.md
+++ b/docs/contributing/ci-and-tests.ja.md
@@ -105,7 +105,7 @@ awk パーサーは `[ecc]` テーブルの `skills` 配列のみにスコープ
 
 `chezmoi apply` の前に、両ジョブは CI 環境では `op` の呼び出しやインタラクティブ/インストールステップの実行を試みないよう、一連のファイルを `/tmp/chezmoi-excluded/` に移動します。各ファイルは `for f in …; do if [ -f "$f" ]; then mv …; fi; done` ループ内で移動されるため、エントリが見つからなくてもステップは中断されません。
 
-**両ジョブ**で除外されるファイル（<!-- FACT:ci-both-exclusion-count -->6<!-- /FACT --> ファイル）：
+**両ジョブ**で除外されるファイル（<!-- FACT:ci-both-exclusion-count -->8<!-- /FACT --> ファイル）：
 
 - `home/private_dot_aws/config.tmpl`
 - `home/dot_config/zsh/private_claude-secrets.zsh.tmpl`
@@ -113,6 +113,8 @@ awk パーサーは `[ecc]` テーブルの `skills` 配列のみにスコープ
 - `home/run_onchange_before_10-brew-bundle.sh.tmpl`
 - `home/run_once_after_11-validate-1password.sh.tmpl`
 - `home/dot_config/git/private_gitleaks-own.toml.tmpl`
+- `home/dot_config/ntfy/private_server.yml.tmpl`
+- `home/dot_config/ntfy/private_notify-env.tmpl`
 
 **macOS ジョブのみ**で除外されるファイル：
 

--- a/docs/contributing/ci-and-tests.md
+++ b/docs/contributing/ci-and-tests.md
@@ -105,7 +105,7 @@ This workflow runs a real `chezmoi init --apply` on two platforms and asserts th
 
 Before `chezmoi apply`, both jobs move a set of files to `/tmp/chezmoi-excluded/` so that apply never attempts to call `op` or run interactive/install steps in the CI environment. Each file is moved inside a `for f in …; do if [ -f "$f" ]; then mv …; fi; done` loop so that a missing entry does not abort the step.
 
-Files excluded by **both** jobs (<!-- FACT:ci-both-exclusion-count -->6<!-- /FACT --> files):
+Files excluded by **both** jobs (<!-- FACT:ci-both-exclusion-count -->8<!-- /FACT --> files):
 
 - `home/private_dot_aws/config.tmpl`
 - `home/dot_config/zsh/private_claude-secrets.zsh.tmpl`
@@ -113,6 +113,8 @@ Files excluded by **both** jobs (<!-- FACT:ci-both-exclusion-count -->6<!-- /FAC
 - `home/run_onchange_before_10-brew-bundle.sh.tmpl`
 - `home/run_once_after_11-validate-1password.sh.tmpl`
 - `home/dot_config/git/private_gitleaks-own.toml.tmpl`
+- `home/dot_config/ntfy/private_server.yml.tmpl`
+- `home/dot_config/ntfy/private_notify-env.tmpl`
 
 Files excluded by the **macOS job only**:
 

--- a/docs/explanation/secrets-and-isolation.ja.md
+++ b/docs/explanation/secrets-and-isolation.ja.md
@@ -44,12 +44,14 @@
 
 ### Apply-strict: `run_once_after_11-validate-1password.sh.tmpl`
 
-このライフサイクルスクリプトは macOS 上で一度だけ実行され、<!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> つの必要な 1Password アイテムのいずれかが見つからないか到達不能な場合、ゼロ以外の終了コードで `chezmoi apply` を中断します。確認されるアイテムは以下のとおりです:
+このライフサイクルスクリプトは macOS 上で一度だけ実行され、<!-- FACT:onepassword-vault-item-count -->6<!-- /FACT --> つの必要な 1Password アイテム参照のいずれかが見つからないか到達不能な場合、ゼロ以外の終了コードで `chezmoi apply` を中断します。確認される参照は以下のとおりです:
 
 - `op://kryota.dev/Dotfiles - AWS Config/notesPlain`
 - `op://kryota.dev/Dotfiles - Exa API/credential`
 - `op://kryota.dev/Dotfiles - Firecrawl API/credential`
 - `op://kryota.dev/Dotfiles - Redact Patterns/pattern`
+- `op://kryota.dev/Dotfiles - ntfy/base-url`
+- `op://kryota.dev/Dotfiles - ntfy/credential`
 
 `op` がインストールされていない、認証されていない、またはアイテムが読み取れない場合、`chezmoi apply` はフェイルファストします。注意点として、`run_once_after_11` は AFTER フェーズのスクリプトであり、実行時点ではホームディレクトリはすでに変更されています。実際のフェイルファストパスは次の 2 つです: (1) `.tmpl` ファイル内の `onepasswordRead` がテンプレートレンダリング中に apply を中断する（当該ファイルが書き込まれる前）; (2) `run_once_after_11` が後続の重い after フェーズプロビジョニング（mise、MCP、CLV2 等）の前のフェイルファストゲートとして機能する。シークレットが欠落した状態で途中までプロビジョニングされたマシンは、これらいずれかの時点でのクリーンな中断よりも悪い結果をもたらすという考えに基づいています。スクリプトは macOS のみです（`{{ if ne .chezmoi.os "darwin" }}` で早期終了）。CI は 1Password インストールなしで Ubuntu 上で実行されるためです。
 

--- a/docs/explanation/secrets-and-isolation.md
+++ b/docs/explanation/secrets-and-isolation.md
@@ -44,12 +44,14 @@ The system draws a hard line between apply-time and runtime behavior:
 
 ### Apply-strict: `run_once_after_11-validate-1password.sh.tmpl`
 
-This lifecycle script runs once on macOS and aborts `chezmoi apply` with a non-zero exit if any of the <!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> required 1Password items is missing or unreachable. The checked items are:
+This lifecycle script runs once on macOS and aborts `chezmoi apply` with a non-zero exit if any of the <!-- FACT:onepassword-vault-item-count -->6<!-- /FACT --> required 1Password item references is missing or unreachable. The checked references are:
 
 - `op://kryota.dev/Dotfiles - AWS Config/notesPlain`
 - `op://kryota.dev/Dotfiles - Exa API/credential`
 - `op://kryota.dev/Dotfiles - Firecrawl API/credential`
 - `op://kryota.dev/Dotfiles - Redact Patterns/pattern`
+- `op://kryota.dev/Dotfiles - ntfy/base-url`
+- `op://kryota.dev/Dotfiles - ntfy/credential`
 
 If `op` is not installed, not authenticated, or an item cannot be read, `chezmoi apply` fails fast. Note that `run_once_after_11` is an AFTER-phase script — home has already been mutated by the time it runs. The actual fail-fast paths are: (1) `onepasswordRead` inside `.tmpl` files aborts apply during template render, before those files are written; and (2) `run_once_after_11` acts as a fail-fast gate before the heavier after-phase provisioning (mise, MCP, CLV2, etc.). The intent is that a partially-provisioned machine with missing secrets is worse than a clean abort at either of those points. The script is macOS-only (`{{ if ne .chezmoi.os "darwin" }}` exits early) because CI runs on Ubuntu without a 1Password installation.
 

--- a/docs/getting-started/secrets-1password.ja.md
+++ b/docs/getting-started/secrets-1password.ja.md
@@ -44,7 +44,7 @@ macOS で `chezmoi apply` を実行する前に:
 1. **1Password デスクトップアプリ**がインストールされ、サインイン済みであること。
 2. **CLI 統合が有効**: 1Password → 設定 → デベロッパー → "1Password CLI と統合"。
 3. **1Password CLI（`op`）**がインストール済み: `brew install --cask 1password-cli`。
-4. 以下に示す <!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> つの Vault アイテムすべてが `kryota.dev` Vault に存在すること。
+4. 以下に示す <!-- FACT:onepassword-vault-item-count -->6<!-- /FACT --> つの Vault アイテム参照すべてが `kryota.dev` Vault に存在すること。
 
 ---
 
@@ -104,6 +104,19 @@ macOS で `chezmoi apply` を実行する前に:
 
 クライアント/勤務先の識別子パターンを `name1|name2|...` の交替形式で保存します（必要に応じて regex エスケープ済み; `'''` と改行は不可）。chezmoi は apply 時にこれを自社名前空間リポジトリ用の gitleaks 設定にレンダリングします。`run_once_after_11` スクリプトはさらにこの値をスモークテストします——パターンが非空であること、TOML 生文字列リテラルを破壊する `'''` を含まないこと、有効な正規表現としてコンパイルできることを検証します。破損したパターンは自社名前空間リポジトリのすべてのコミットでクライアント識別子ルールをサイレントに無効化してしまいます。
 
+### 5. `Dotfiles - ntfy`
+
+| 属性 | 値 |
+|-----|---|
+| Vault | `kryota.dev` |
+| アイテムタイトル | `Dotfiles - ntfy` |
+| フィールド参照 | `base-url`, `credential` |
+| op:// URI | `op://kryota.dev/Dotfiles - ntfy/base-url`, `op://kryota.dev/Dotfiles - ntfy/credential` |
+| レンダリング先 | `~/.config/ntfy/server.yml`（`base-url`）と `~/.config/ntfy/notify-env`（`credential`） |
+| ファイルモード | `0600`（`private_` プレフィックスによる） |
+
+自己ホスト ntfy 通知サーバー（#337; [Notifications](../architecture/notifications.ja.md) 参照）用に、1 アイテムで 2 つのフィールドを検証します。`base-url` は `tailscale serve` の HTTPS エンドポイント（`https://<host>.<tailnet>.ts.net`）です——tailnet の MagicDNS 名がこの公開リポジトリに残らないよう 1Password に保存しています。`credential` は `ntfy token add` で発行される**書き込み専用**の publisher トークンです（notifications のセットアップ手順を参照）。読み取り専用の subscriber トークンも同じアイテムに保存しますが、各デバイスへ手動で入力するため検証ゲートはチェックしません。
+
 ---
 
 ## アイテムが欠落またはリネームされた場合の影響
@@ -114,8 +127,9 @@ macOS で `chezmoi apply` を実行する前に:
 | `Dotfiles - Exa API` | 検証ゲートで `chezmoi apply` が exit 1 | `claude-secrets.zsh` がレンダリングされない、exa MCP サーバーが認証失敗 |
 | `Dotfiles - Firecrawl API` | 検証ゲートで `chezmoi apply` が exit 1 | `claude-secrets.zsh` がレンダリングされない、firecrawl MCP サーバーが認証失敗 |
 | `Dotfiles - Redact Patterns` | 検証ゲートで `chezmoi apply` が exit 1 | `gitleaks-own.toml` がレンダリングされない、自社名前空間リポジトリでクライアント識別子 gitleaks ルールが無効化 |
+| `Dotfiles - ntfy` | 検証ゲートで `chezmoi apply` が exit 1 | `~/.config/ntfy/server.yml` / `notify-env` がレンダリングされない、ntfy サーバーが未設定のままフックラッパーが no-op のまま |
 
-ゲートはすべての 4 アイテムを成功前にチェックするため、1 つのアイテムが欠落するだけでライフサイクルスクリプトの after フェーズ全体がブロックされます。
+ゲートはすべての 6 参照を成功前にチェックするため、1 つのアイテムが欠落するだけでライフサイクルスクリプトの after フェーズ全体がブロックされます。
 
 ---
 

--- a/docs/getting-started/secrets-1password.md
+++ b/docs/getting-started/secrets-1password.md
@@ -44,7 +44,7 @@ Before running `chezmoi apply` on macOS:
 1. **1Password desktop app** installed and signed in.
 2. **CLI integration enabled**: 1Password → Settings → Developer → "Integrate with 1Password CLI".
 3. **1Password CLI (`op`)** installed: `brew install --cask 1password-cli`.
-4. All <!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> vault items listed below exist in the `kryota.dev` vault.
+4. All <!-- FACT:onepassword-vault-item-count -->6<!-- /FACT --> vault item references listed below exist in the `kryota.dev` vault.
 
 ---
 
@@ -104,6 +104,19 @@ Used by the `firecrawl` user-scope Claude Code MCP server. Sets `FIRECRAWL_API_K
 
 Store the client/employer identifier pattern as a `name1|name2|...` alternation (regex-escaped where needed; no `'''`, no newlines). chezmoi renders it into the owner-scoped gitleaks config at apply time. The `run_once_after_11` script additionally smoke-tests this value — it verifies the pattern is non-empty, contains no `'''` (which would break the TOML raw-string literal), and compiles as a valid regex. A broken pattern would silently disable the client-identifier rule on every commit in own-namespace repos.
 
+### 5. `Dotfiles - ntfy`
+
+| Attribute | Value |
+|-----------|-------|
+| Vault | `kryota.dev` |
+| Item title | `Dotfiles - ntfy` |
+| Field references | `base-url`, `credential` |
+| op:// URIs | `op://kryota.dev/Dotfiles - ntfy/base-url`, `op://kryota.dev/Dotfiles - ntfy/credential` |
+| Rendered to | `~/.config/ntfy/server.yml` (`base-url`) and `~/.config/ntfy/notify-env` (`credential`) |
+| File mode | `0600` (via `private_` prefix) |
+
+One item, two validated fields, for the self-hosted ntfy notification server (#337; see [Notifications](../architecture/notifications.md)). `base-url` is the `tailscale serve` HTTPS endpoint (`https://<host>.<tailnet>.ts.net`) — stored in 1Password so the tailnet's MagicDNS name never lands in this public repo. `credential` is the **write-only** publisher token issued by `ntfy token add` (see the notifications setup runbook). The read-only subscriber token also lives in this item but is entered on devices manually, so the validation gate does not check it.
+
 ---
 
 ## What breaks when an item is missing or renamed
@@ -114,8 +127,9 @@ Store the client/employer identifier pattern as a `name1|name2|...` alternation 
 | `Dotfiles - Exa API` | `chezmoi apply` exits 1 at the validation gate | `claude-secrets.zsh` not rendered; exa MCP server starts but fails to authenticate |
 | `Dotfiles - Firecrawl API` | `chezmoi apply` exits 1 at the validation gate | `claude-secrets.zsh` not rendered; firecrawl MCP server starts but fails to authenticate |
 | `Dotfiles - Redact Patterns` | `chezmoi apply` exits 1 at the validation gate | `gitleaks-own.toml` not rendered; client-identifier gitleaks rule inactive in own-namespace repos |
+| `Dotfiles - ntfy` | `chezmoi apply` exits 1 at the validation gate | `~/.config/ntfy/server.yml` / `notify-env` not rendered; ntfy server unconfigured and the hook wrapper stays a no-op |
 
-Because the gate checks all four items before any succeeds, a single missing item blocks the entire after-phase of lifecycle scripts.
+Because the gate checks all six references before any succeeds, a single missing item blocks the entire after-phase of lifecycle scripts.
 
 ---
 

--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -162,3 +162,18 @@ ghq_user = "kryota-dev"
     "verification-loop",
     "vite-patterns",
   ]
+
+[ntfy]
+  # Self-hosted ntfy notification server (kryota-dev/dotfiles#337).
+  # SSOT for every ntfy constant except the Docker image tag, which lives
+  # literally in home/dot_config/ntfy/compose.yaml.tmpl so Renovate's regex
+  # manager can track it (drift is caught by tests/files.bats).
+  port = 2586
+  # Server-side history retention (cache-duration). User-approved trade-off:
+  # 7 days of reviewable history vs. plaintext SQLite residency on disk.
+  cache_duration = "168h"
+  # Fixed urgency-based topics; attribution (repo/branch/account/session/event)
+  # travels in tags and titles, never in topic names.
+  topic_attention = "claude-attention"
+  topic_done = "claude-done"
+  topic_test = "claude-test"

--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -173,7 +173,9 @@ ghq_user = "kryota-dev"
   # 7 days of reviewable history vs. plaintext SQLite residency on disk.
   cache_duration = "168h"
   # Fixed urgency-based topics; attribution (repo/branch/account/session/event)
-  # travels in tags and titles, never in topic names.
+  # travels in tags and titles, never in topic names. The ad-hoc smoke-test
+  # topic (claude-test) is a runbook-only convention in
+  # docs/architecture/notifications.md, not rendered config, so it is
+  # intentionally not declared here.
   topic_attention = "claude-attention"
   topic_done = "claude-done"
-  topic_test = "claude-test"

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -119,6 +119,10 @@
 .aws/sso
 
 # macOS-only: VS Code settings (on Linux, VS Code Server uses ~/.vscode-server/)
+# and the self-hosted ntfy server config (#337; the server only runs on this Mac —
+# the ~/.claude/ntfy-notify.sh hook wrapper still deploys everywhere and no-ops
+# without ~/.config/ntfy/notify-env)
 {{ if ne .chezmoi.os "darwin" }}
 Library/
+.config/ntfy
 {{ end }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -119,9 +119,9 @@
 .aws/sso
 
 # macOS-only: VS Code settings (on Linux, VS Code Server uses ~/.vscode-server/)
-# and the self-hosted ntfy server config (#337; the server only runs on this Mac —
-# the ~/.claude/ntfy-notify.sh hook wrapper still deploys everywhere and no-ops
-# without ~/.config/ntfy/notify-env)
+# macOS-only: self-hosted ntfy server config (#337; the server only runs on this
+# Mac — the ~/.claude/ntfy-notify.sh hook wrapper still deploys everywhere and
+# no-ops without ~/.config/ntfy/notify-env)
 {{ if ne .chezmoi.os "darwin" }}
 Library/
 .config/ntfy

--- a/home/dot_claude/executable_ntfy-notify.sh
+++ b/home/dot_claude/executable_ntfy-notify.sh
@@ -56,7 +56,7 @@ scrub_body() {
     printf '%s' "$body"
     return 0
   fi
-  if scrubbed="$(printf '%s' "$body" | NTFY_REDACT_PATTERN="$pattern" perl -pe 's/$ENV{NTFY_REDACT_PATTERN}/[redacted]/gi' 2>/dev/null)"; then
+  if scrubbed="$(printf '%s' "$body" | NTFY_REDACT_PATTERN="$pattern" perl -pe 'BEGIN { $SIG{ALRM} = sub { die }; alarm 2 } s/$ENV{NTFY_REDACT_PATTERN}/[redacted]/gi' 2>/dev/null)"; then
     printf '%s' "$scrubbed"
   else
     printf '%s' "$body"
@@ -71,8 +71,9 @@ truncate_body() {
   printf '%s' "$1" | tr '\n' ' ' | jq -Rrs --argjson n "$BODY_LIMIT" '.[0:$n]'
 }
 
-# CLAUDE_CONFIG_DIR -> account slug (same derivation as statusline.sh):
-# ~/.claude -> default, ~/.claude-r06 -> r06.
+# CLAUDE_CONFIG_DIR -> account slug: ~/.claude -> default, ~/.claude-r06 -> r06.
+# Intentionally self-contained (hook scripts stay dependency-free); statusline.sh
+# derives the same slug for display — keep the two in sync on changes.
 account_slug() {
   local base="${CLAUDE_CONFIG_DIR:-}"
   base="${base##*/}"
@@ -106,6 +107,17 @@ main() {
   # No env file / no jq -> silent no-op (unprovisioned machine or Linux).
   [ -f "$ENV_FILE" ] || exit 0
   command -v jq >/dev/null 2>&1 || exit 0
+  # Sourcing is code execution: only accept a file we own with no group/other
+  # permissions (the chezmoi-deployed private_ file is 0600). Anything else —
+  # including an env-var override pointing at hostile content — fails open.
+  [ -O "$ENV_FILE" ] || exit 0
+  local env_mode
+  if stat --version >/dev/null 2>&1; then
+    env_mode="$(stat -c '%a' "$ENV_FILE" 2>/dev/null || true)"
+  else
+    env_mode="$(stat -f '%Lp' "$ENV_FILE" 2>/dev/null || true)"
+  fi
+  case "$env_mode" in 600 | 400) ;; *) exit 0 ;; esac
   # shellcheck source=/dev/null
   . "$ENV_FILE"
   { [ -n "${NTFY_URL:-}" ] && [ -n "${NTFY_TOKEN:-}" ]; } || exit 0
@@ -153,11 +165,20 @@ main() {
   repo="$(repo_name "$cwd")"
   branch="$(branch_name "$cwd")"
 
+  # Attribution fields go through the client-identifier scrub too: repo and
+  # branch names are where client names are most likely to appear, and on
+  # Notification events they are the only published content.
+  repo="$(scrub_body "$repo")"
+  branch="$(scrub_body "$branch")"
   title="[${account}] ${repo}@${branch} — ${event}"
   body=""
   if [ "$event" = "Stop" ]; then
     body="$(printf '%s' "$input" | jq -r '.last_assistant_message // empty' 2>/dev/null || true)"
-    body="$(scrub_body "$(truncate_body "$body")")"
+    # Scrub BEFORE truncating so an identifier straddling the 200-char boundary
+    # cannot survive with its tail cut off; the byte pre-cap bounds the perl
+    # input so pathological messages cannot stall the hook.
+    body="$(printf '%s' "$body" | head -c 8192)"
+    body="$(truncate_body "$(scrub_body "$body")")"
   fi
 
   payload="$(jq -n \
@@ -176,8 +197,9 @@ main() {
   # Token travels via a 0600 curl config file, never argv.
   umask 077
   curl_cfg="$(mktemp "${TMPDIR:-/tmp}/ntfy-notify.XXXXXX")"
-  # shellcheck disable=SC2064
-  trap "rm -f '$curl_cfg'" EXIT
+  # EXIT alone misses signal deaths (the hook runs under a 10s timeout that
+  # may kill us) — cover the catchable signals so the token file never lingers.
+  trap 'rm -f "$curl_cfg"' EXIT INT TERM HUP
   printf 'header = "Authorization: Bearer %s"\n' "$NTFY_TOKEN" >"$curl_cfg"
 
   if ! printf '%s' "$payload" | curl -fs -K "$curl_cfg" --max-time 3 \

--- a/home/dot_claude/executable_ntfy-notify.sh
+++ b/home/dot_claude/executable_ntfy-notify.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# Claude Code hook -> ntfy publisher (kryota-dev/dotfiles#337).
+#
+# Wired in settings.json for the Notification event (permission_prompt,
+# idle_prompt, agent_needs_input, agent_completed) and the Stop event. Reads
+# the hook payload on stdin, enriches it with repo/branch/account/session
+# attribution, and publishes JSON to the local ntfy server.
+#
+# Fail-open contract (async hook, timeout 10): every exit path is 0. When the
+# server is unreachable the failure is logged and a content-free local alert
+# sound plays; the session is never blocked. Deployed on every OS: with no
+# env file (Linux, unprovisioned machines) the script is a silent no-op.
+#
+# Token hygiene: the write-only publisher token is sourced from a 0600 env
+# file and reaches curl through a temporary `curl -K` config file. It must
+# never appear in argv (`-H` with expansion is forbidden; bats asserts this),
+# stdout, stderr, logs, or `set -x` traces (never enable tracing here).
+set -euo pipefail
+
+ENV_FILE="${NTFY_NOTIFY_ENV_FILE:-$HOME/.config/ntfy/notify-env}"
+LOG_FILE="${NTFY_NOTIFY_LOG_FILE:-$HOME/Library/Logs/ntfy-notify.log}"
+REDACT_TOML="${NTFY_NOTIFY_REDACT_TOML:-$HOME/.config/git/gitleaks-own.toml}"
+ALERT_SOUND="${NTFY_NOTIFY_ALERT_SOUND:-/System/Library/PrivateFrameworks/ToneLibrary.framework/Versions/A/Resources/AlertTones/Classic/Glass.m4r}"
+BODY_LIMIT=200
+
+log_failure() {
+  mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || return 0
+  printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$1" >>"$LOG_FILE" 2>/dev/null || true
+}
+
+# Content-free local alert: signals "a notification was dropped" without
+# resurrecting the rich local channel this system replaces.
+local_alert() {
+  if command -v afplay >/dev/null 2>&1 && [ -f "$ALERT_SOUND" ]; then
+    afplay "$ALERT_SOUND" >/dev/null 2>&1 || true
+  fi
+}
+
+# Extract the client-identifier alternation from the deployed gitleaks-own
+# config. The file has exactly one fixed-format line:
+#   regex = '''(?i)(name1|name2)'''
+# Anything else (missing file, format drift) yields empty output and the
+# caller falls back to truncation-only scrubbing.
+extract_redact_pattern() {
+  [ -f "$REDACT_TOML" ] || return 0
+  sed -n "s/^regex = '''(?i)(\(.*\))'''\$/\1/p" "$REDACT_TOML" | head -n 1
+}
+
+# Best-effort client-identifier scrub (NOT a secret/PII detector — see the
+# #337 PRD). The pattern reaches perl via the environment, never via code
+# interpolation. Any failure returns the input unchanged.
+scrub_body() {
+  local body="$1" pattern scrubbed
+  pattern="$(extract_redact_pattern 2>/dev/null || true)"
+  if [ -z "$pattern" ]; then
+    printf '%s' "$body"
+    return 0
+  fi
+  if scrubbed="$(printf '%s' "$body" | NTFY_REDACT_PATTERN="$pattern" perl -pe 's/$ENV{NTFY_REDACT_PATTERN}/[redacted]/gi' 2>/dev/null)"; then
+    printf '%s' "$scrubbed"
+  else
+    printf '%s' "$body"
+  fi
+}
+
+# Flatten to one line and hard-cap at BODY_LIMIT characters. jq slices by
+# codepoint regardless of locale, so multibyte text is never cut mid-character
+# (`cut -c` corrupts UTF-8 under LANG=C). Truncation is the primary defense
+# for last_assistant_message-derived content.
+truncate_body() {
+  printf '%s' "$1" | tr '\n' ' ' | jq -Rrs --argjson n "$BODY_LIMIT" '.[0:$n]'
+}
+
+# CLAUDE_CONFIG_DIR -> account slug (same derivation as statusline.sh):
+# ~/.claude -> default, ~/.claude-r06 -> r06.
+account_slug() {
+  local base="${CLAUDE_CONFIG_DIR:-}"
+  base="${base##*/}"
+  case "$base" in
+    "" | .claude) printf 'default' ;;
+    .claude-*) printf '%s' "${base#.claude-}" ;;
+    *) printf '%s' "$base" ;;
+  esac
+}
+
+repo_name() {
+  local cwd="$1" top
+  if top="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)"; then
+    basename "$top"
+  else
+    printf -- '-'
+  fi
+}
+
+branch_name() {
+  local cwd="$1" branch
+  branch="$(git -C "$cwd" branch --show-current 2>/dev/null || true)"
+  [ -n "$branch" ] && printf '%s' "$branch" || printf -- '-'
+}
+
+main() {
+  local input event_name event topic priority emoji
+  local session_id sid cwd account repo branch title body payload
+  local curl_cfg
+
+  # No env file / no jq -> silent no-op (unprovisioned machine or Linux).
+  [ -f "$ENV_FILE" ] || exit 0
+  command -v jq >/dev/null 2>&1 || exit 0
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  { [ -n "${NTFY_URL:-}" ] && [ -n "${NTFY_TOKEN:-}" ]; } || exit 0
+
+  input="$(cat)"
+  event_name="$(printf '%s' "$input" | jq -r '.hook_event_name // empty' 2>/dev/null || true)"
+  if [ "$event_name" = "Notification" ]; then
+    event="$(printf '%s' "$input" | jq -r '.notification_type // empty' 2>/dev/null || true)"
+  else
+    event="$event_name"
+  fi
+
+  # Topic names come exclusively from the env file (rendered from the [ntfy]
+  # SSOT in .chezmoidata.toml) — no hardcoded fallbacks that could drift.
+  case "$event" in
+    permission_prompt | idle_prompt | agent_needs_input)
+      topic="${NTFY_TOPIC_ATTENTION:-}"
+      priority=4
+      emoji="rotating_light"
+      ;;
+    agent_completed)
+      topic="${NTFY_TOPIC_DONE:-}"
+      priority=3
+      emoji="white_check_mark"
+      ;;
+    Stop)
+      topic="${NTFY_TOPIC_DONE:-}"
+      priority=3
+      emoji="checkered_flag"
+      ;;
+    *)
+      # Unknown/unsubscribed event: ignore quietly.
+      exit 0
+      ;;
+  esac
+  # Broken/partial env file: fail open rather than publish to a bogus topic.
+  [ -n "$topic" ] || exit 0
+
+  session_id="$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null || true)"
+  sid="$(printf '%.8s' "$session_id")"
+  [ -n "$sid" ] || sid='-'
+  cwd="$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null || true)"
+  [ -n "$cwd" ] || cwd="$PWD"
+  account="$(account_slug)"
+  repo="$(repo_name "$cwd")"
+  branch="$(branch_name "$cwd")"
+
+  title="[${account}] ${repo}@${branch} — ${event}"
+  body=""
+  if [ "$event" = "Stop" ]; then
+    body="$(printf '%s' "$input" | jq -r '.last_assistant_message // empty' 2>/dev/null || true)"
+    body="$(scrub_body "$(truncate_body "$body")")"
+  fi
+
+  payload="$(jq -n \
+    --arg topic "$topic" \
+    --arg title "$title" \
+    --arg message "$body" \
+    --arg emoji "$emoji" \
+    --arg event "$event" \
+    --arg repo "$repo" \
+    --arg account "$account" \
+    --arg sid "$sid" \
+    --argjson priority "$priority" \
+    '{topic: $topic, title: $title, message: $message, priority: $priority,
+      tags: [$emoji, $event, $repo, $account, $sid]}')"
+
+  # Token travels via a 0600 curl config file, never argv.
+  umask 077
+  curl_cfg="$(mktemp "${TMPDIR:-/tmp}/ntfy-notify.XXXXXX")"
+  # shellcheck disable=SC2064
+  trap "rm -f '$curl_cfg'" EXIT
+  printf 'header = "Authorization: Bearer %s"\n' "$NTFY_TOKEN" >"$curl_cfg"
+
+  if ! printf '%s' "$payload" | curl -fs -K "$curl_cfg" --max-time 3 \
+    -o /dev/null -d @- "$NTFY_URL" 2>/dev/null; then
+    log_failure "publish failed: event=${event} topic=${topic} url=${NTFY_URL}"
+    local_alert
+  fi
+  exit 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -18,7 +18,7 @@
     "MAX_THINKING_TOKENS": "127999",
     "ECC_GOVERNANCE_CAPTURE": "1",
     "ECC_HOOK_PROFILE": "strict",
-    "ECC_DISABLED_HOOKS": "post:bash:command-log-audit,post:bash:command-log-cost,post:bash:build-complete,pre:edit-write:gateguard-fact-force",
+    "ECC_DISABLED_HOOKS": "post:bash:command-log-audit,post:bash:command-log-cost,post:bash:build-complete,pre:edit-write:gateguard-fact-force,stop:desktop-notify",
     "ECC_QUALITY_GATE_FIX": "true",
     "GATEGUARD_BASH_EXTRA_DESTRUCTIVE": "\\b(?:chezmoi\\s+(?:destroy|forget|purge)\\b|terraform\\s+(?:destroy|state\\s+rm|workspace\\s+delete|force-unlock)\\b|terraform\\s+apply\\s+(?:[^&|;]*\\s)?-{1,2}auto-approve\\b|kubectl\\s+delete\\b|helm\\s+(?:uninstall|delete)\\b|docker\\s+(?:system\\s+prune|volume\\s+(?:rm|prune)|image\\s+prune|container\\s+prune|network\\s+prune)\\b|docker\\s+(?:rm|rmi)\\b(?=[^&|;]*\\s(?:--force\\b|-[a-zA-Z]*f\\b))|brew\\s+(?:uninstall|autoremove|untap)\\b|mas\\s+uninstall\\b|mise\\s+(?:uninstall|implode|prune)\\b|aqua\\s+(?:rm|prune)\\b|gh\\s+(?:repo\\s+delete|release\\s+delete|secret\\s+(?:delete|remove)|cache\\s+delete|run\\s+delete)\\b|aws\\s+s3\\s+r[mb]\\b|aws\\s+(?:ec2\\s+terminate-instances|iam\\s+delete-|dynamodb\\s+delete-table|rds\\s+delete-)|aws\\s+\\S+\\s+delete-|gcloud\\s+(?:\\S+\\s+){1,5}delete\\b|supabase\\s+db\\s+reset\\b|supabase\\s+projects\\s+delete\\b|pnpm\\s+(?:purge|store\\s+prune)\\b|npm\\s+(?:unpublish|publish)\\b|yarn\\s+(?:unpublish|publish)\\b|defaults\\s+delete\\b|git\\s+filter-(?:repo|branch)\\b)"
   },
@@ -396,6 +396,21 @@
         "id": "post:mcp-health-check"
       }
     ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt|idle_prompt|agent_needs_input|agent_completed",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ntfy-notify.sh",
+            "async": true,
+            "timeout": 10
+          }
+        ],
+        "description": "Publish attention/completion notifications to the self-hosted ntfy server over Tailscale with repo/branch/account/session attribution (#337). Fail-open: no-op without ~/.config/ntfy/notify-env.",
+        "id": "notification:ntfy-notify"
+      }
+    ],
     "Stop": [
       {
         "matcher": "*",
@@ -433,8 +448,21 @@
             "timeout": 10
           }
         ],
-        "description": "Send desktop notification (macOS/WSL) with task summary when Claude responds",
+        "description": "Send desktop notification (macOS/WSL) with task summary when Claude responds. DISABLED via env.ECC_DISABLED_HOOKS — replaced by stop:ntfy-notify (#337); wiring kept for the documented one-step rollback (re-enable here + remove the ntfy entries together to avoid double notification).",
         "id": "stop:desktop-notify"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/ntfy-notify.sh",
+            "async": true,
+            "timeout": 10
+          }
+        ],
+        "description": "Publish a session-stop notification (truncated + client-identifier-scrubbed summary) to the self-hosted ntfy server (#337). Replaces stop:desktop-notify.",
+        "id": "stop:ntfy-notify"
       },
       {
         "matcher": "*",

--- a/home/dot_config/ntfy/compose.yaml.tmpl
+++ b/home/dot_config/ntfy/compose.yaml.tmpl
@@ -1,0 +1,24 @@
+# Self-hosted ntfy server (kryota-dev/dotfiles#337).
+# Runs under Docker Desktop (Brewfile-provisioned) because the Homebrew ntfy
+# formula builds macOS binaries with the `noserver` tag — `ntfy serve` does not
+# exist outside containers/Linux. Managed by run_onchange_after_31-setup-ntfy.
+#
+# The image line below is intentionally literal (no template variables): the
+# Renovate regex manager in .github/renovate.json5 tracks the pinned tag, and
+# tests/files.bats asserts the pin format. Everything else templated here comes
+# from the [ntfy] SSOT block in home/.chezmoidata.toml.
+services:
+  ntfy:
+    image: binary/ntfy:v2.26.0
+    command: serve
+    restart: unless-stopped
+    ports:
+      # Loopback-only on the host; tailnet exposure happens exclusively via
+      # `tailscale serve` (TLS terminated by tailscaled). Never bind all
+      # interfaces (tests/files.bats rejects a wildcard address here).
+      - "127.0.0.1:{{ .ntfy.port }}:80"
+    volumes:
+      - "{{ .chezmoi.homeDir }}/.config/ntfy/server.yml:/etc/ntfy/server.yml:ro"
+      # Runtime state (auth user.db, message cache.db) lives outside the
+      # chezmoi target tree, same principle as the CLV2 homunculus move.
+      - "{{ .chezmoi.homeDir }}/Library/Application Support/ntfy:/var/lib/ntfy"

--- a/home/dot_config/ntfy/compose.yaml.tmpl
+++ b/home/dot_config/ntfy/compose.yaml.tmpl
@@ -7,9 +7,12 @@
 # Renovate regex manager in .github/renovate.json5 tracks the pinned tag, and
 # tests/files.bats asserts the pin format. Everything else templated here comes
 # from the [ntfy] SSOT block in home/.chezmoidata.toml.
+# Explicit project name so `--remove-orphans` can never touch containers from
+# another compose project that happens to share the default (dirname) name.
+name: ntfy-dotfiles
 services:
   ntfy:
-    image: binary/ntfy:v2.26.0
+    image: binwiederhier/ntfy:v2.26.0@sha256:a6d335064ae927c4dbef118e1fa39656b3d2e01472b2a82af5915d5cebfe815f
     command: serve
     restart: unless-stopped
     ports:

--- a/home/dot_config/ntfy/private_notify-env.tmpl
+++ b/home/dot_config/ntfy/private_notify-env.tmpl
@@ -1,0 +1,12 @@
+# ntfy publisher credentials for the Claude Code hook wrapper
+# (~/.claude/ntfy-notify.sh, kryota-dev/dotfiles#337). Deployed 0600; sourced —
+# never exported — by the wrapper at publish time so the token only ever lives
+# in that process. CI never renders this file (setup-validation.yml exclude list).
+#
+# The wrapper publishes to the local loopback listener directly: it must keep
+# working even if the `tailscale serve` front is down.
+NTFY_URL='http://127.0.0.1:{{ .ntfy.port }}'
+# Write-only publisher token (least privilege: cannot read history if leaked).
+NTFY_TOKEN={{ onepasswordRead "op://kryota.dev/Dotfiles - ntfy/credential" | squote }}
+NTFY_TOPIC_ATTENTION='{{ .ntfy.topic_attention }}'
+NTFY_TOPIC_DONE='{{ .ntfy.topic_done }}'

--- a/home/dot_config/ntfy/private_server.yml.tmpl
+++ b/home/dot_config/ntfy/private_server.yml.tmpl
@@ -8,9 +8,12 @@
 # lands in this public repo.
 base-url: "{{ onepasswordRead "op://kryota.dev/Dotfiles - ntfy/base-url" | trim }}"
 
-# iOS instant push relay (user-approved at the #337 PRD gate): forwards poll
-# requests (topic metadata only, never message bodies) through ntfy.sh/APNs.
-# The sole approved metadata egress beyond the tailnet.
+# iOS instant push relay (user-approved at the #337 PRD gate). NOTE: per
+# docs.ntfy.sh/config this publishes a poll request to ntfy.sh for EVERY
+# incoming message (topic metadata only, never message bodies), regardless of
+# whether any iOS device subscribes. The sole approved metadata egress beyond
+# the tailnet; remove this key to bring egress to zero if the smoke test shows
+# iOS instant push does not work on the tailnet-only setup.
 upstream-base-url: "https://ntfy.sh"
 
 # Container-internal listener; host exposure is limited to 127.0.0.1 by the

--- a/home/dot_config/ntfy/private_server.yml.tmpl
+++ b/home/dot_config/ntfy/private_server.yml.tmpl
@@ -1,0 +1,32 @@
+# ntfy server configuration (kryota-dev/dotfiles#337). Deployed 0600; mounted
+# read-only into the ntfy container at /etc/ntfy/server.yml (paths below are
+# container paths). CI never renders this file — it is on the
+# "Exclude CI-incompatible files" list in setup-validation.yml (onepasswordRead).
+
+# Public URL of this server as seen by subscribers (the `tailscale serve`
+# HTTPS endpoint). Stored in 1Password so the tailnet's MagicDNS name never
+# lands in this public repo.
+base-url: "{{ onepasswordRead "op://kryota.dev/Dotfiles - ntfy/base-url" | trim }}"
+
+# iOS instant push relay (user-approved at the #337 PRD gate): forwards poll
+# requests (topic metadata only, never message bodies) through ntfy.sh/APNs.
+# The sole approved metadata egress beyond the tailnet.
+upstream-base-url: "https://ntfy.sh"
+
+# Container-internal listener; host exposure is limited to 127.0.0.1 by the
+# compose port mapping.
+listen-http: ":80"
+
+# Persistent message history (AC-002). Retention is the [ntfy] SSOT value in
+# home/.chezmoidata.toml.
+cache-file: /var/lib/ntfy/cache.db
+cache-duration: "{{ .ntfy.cache_duration }}"
+
+# Auth: private instance, deny-all by default. Users/tokens are provisioned
+# once manually via `docker compose exec` (see docs/architecture/notifications.md);
+# user.db is runtime state, never chezmoi-managed.
+auth-file: /var/lib/ntfy/user.db
+auth-default-access: "deny-all"
+
+# tailscale serve fronts this server as a reverse proxy.
+behind-proxy: true

--- a/home/run_once_after_11-validate-1password.sh.tmpl
+++ b/home/run_once_after_11-validate-1password.sh.tmpl
@@ -36,6 +36,15 @@ ITEMS=(
   # pre-commit hook for own-namespace repos only). Create as a Secure Note
   # exposing a `pattern` field holding a single `name1|name2|...` alternation.
   "op://kryota.dev/Dotfiles - Redact Patterns/pattern"
+  # Self-hosted ntfy notification server (#337). Create one item exposing:
+  #   base-url   — the `tailscale serve` HTTPS endpoint (https://<host>.<tailnet>.ts.net),
+  #                kept out of this public repo (rendered into ~/.config/ntfy/server.yml)
+  #   credential — the write-only publisher token from `ntfy token add`
+  #                (rendered into the 0600 ~/.config/ntfy/notify-env)
+  # The read-only subscriber token also lives in this item but is entered on
+  # devices manually from 1Password, so it is not validated here.
+  "op://kryota.dev/Dotfiles - ntfy/base-url"
+  "op://kryota.dev/Dotfiles - ntfy/credential"
 )
 
 for item in "${ITEMS[@]}"; do

--- a/home/run_once_after_11-validate-1password.sh.tmpl
+++ b/home/run_once_after_11-validate-1password.sh.tmpl
@@ -78,4 +78,37 @@ if command -v python3 &>/dev/null; then
   fi
 fi
 
+# Content validation for the ntfy fields, mirroring the Redact Patterns
+# precedent above. A quote/newline in base-url would escape the YAML scalar in
+# server.yml (config-key injection); a single quote in the token would break
+# the squote wrapping that the hook wrapper sources.
+ntfy_url="$(op read "op://kryota.dev/Dotfiles - ntfy/base-url" 2>/dev/null || true)"
+case "$ntfy_url" in
+  https://*.ts.net) ;;
+  *)
+    echo "ERROR: ntfy base-url must be an https://<host>.<tailnet>.ts.net endpoint."
+    exit 1
+    ;;
+esac
+case "$ntfy_url" in
+  *['"'$'\n''']*)
+    echo "ERROR: ntfy base-url contains a quote or newline (breaks the YAML scalar in server.yml)."
+    exit 1
+    ;;
+esac
+ntfy_tok="$(op read "op://kryota.dev/Dotfiles - ntfy/credential" 2>/dev/null || true)"
+case "$ntfy_tok" in
+  tk_*) ;;
+  *)
+    echo "ERROR: ntfy credential does not look like a tk_ access token."
+    exit 1
+    ;;
+esac
+case "$ntfy_tok" in
+  *"'"*)
+    echo "ERROR: ntfy credential contains a single quote (breaks squote in notify-env)."
+    exit 1
+    ;;
+esac
+
 echo "==> All 1Password items verified successfully."

--- a/home/run_onchange_after_31-setup-ntfy.sh.tmpl
+++ b/home/run_onchange_after_31-setup-ntfy.sh.tmpl
@@ -1,0 +1,61 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+# Start the self-hosted ntfy server and assert its tailnet front
+# (kryota-dev/dotfiles#337). Re-runs whenever the compose file or server
+# config changes (embedded hashes below).
+# compose hash: {{ include "dot_config/ntfy/compose.yaml.tmpl" | sha256sum }}
+# server.yml hash: {{ include "dot_config/ntfy/private_server.yml.tmpl" | sha256sum }}
+set -euo pipefail
+
+# CI runners must never start services or touch the network from this script.
+# Skip inside CI only — the render/apply path stays CI-validated.
+if [ -n "${CI:-}" ]; then
+  echo "[ntfy] CI detected; skipping ntfy setup."
+  exit 0
+fi
+
+# Template values live on assignment-only lines: the lint pipeline strips every
+# `{{` line before shellcheck/shfmt, so control flow must never carry them.
+# References use ${var:-} so the stripped body still lints clean.
+serve_target="http://127.0.0.1:{{ .ntfy.port }}"
+
+# Runtime state (auth user.db, message cache.db) lives outside the chezmoi
+# target tree; owner-only.
+state_dir="$HOME/Library/Application Support/ntfy"
+mkdir -p "$state_dir"
+chmod 700 "$state_dir"
+
+# Intentional deviation from the launchctl exit-1 convention (lifecycle
+# convention #6): a closed Docker Desktop must not block `chezmoi apply` —
+# notifications are not setup-critical. Recovery: start Docker Desktop and
+# re-run `chezmoi apply`, or run the compose command below manually.
+if ! docker info >/dev/null 2>&1; then
+  echo "[ntfy] Docker Desktop is not running; skipping server start." >&2
+  echo "[ntfy] Recover with: docker compose -f ~/.config/ntfy/compose.yaml up -d" >&2
+  exit 0
+fi
+
+echo "[ntfy] starting ntfy server (docker compose up -d)..."
+docker compose -f "$HOME/.config/ntfy/compose.yaml" up -d --remove-orphans
+
+# Assert the tailnet HTTPS front. `--bg` persists the mapping across reboots
+# and tailscaled restarts (tailscale.com/kb/1242); re-running is idempotent.
+# NEVER use `tailscale funnel` here — the server must stay tailnet-only.
+tailscale_bin="$(command -v tailscale || true)"
+if [ -z "$tailscale_bin" ] && [ -x "/Applications/Tailscale.app/Contents/MacOS/Tailscale" ]; then
+  tailscale_bin="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+fi
+if [ -z "$tailscale_bin" ]; then
+  echo "[ntfy] tailscale CLI not found; skipping serve assertion." >&2
+  echo "[ntfy] Recover with: tailscale serve --bg ${serve_target:-}" >&2
+  exit 0
+fi
+
+echo "[ntfy] asserting tailscale serve mapping..."
+if ! "$tailscale_bin" serve --bg "${serve_target:-}"; then
+  echo "[ntfy] tailscale serve failed (tailscaled down or not logged in)." >&2
+  echo "[ntfy] Recover with: tailscale serve --bg ${serve_target:-}" >&2
+  exit 0
+fi
+echo "[ntfy] ntfy server up at ${serve_target:-} behind tailscale serve."
+{{ end -}}

--- a/home/run_onchange_after_31-setup-ntfy.sh.tmpl
+++ b/home/run_onchange_after_31-setup-ntfy.sh.tmpl
@@ -26,9 +26,16 @@ mkdir -p "$state_dir"
 chmod 700 "$state_dir"
 
 # Intentional deviation from the launchctl exit-1 convention (lifecycle
-# convention #6): a closed Docker Desktop must not block `chezmoi apply` —
-# notifications are not setup-critical. Recovery: start Docker Desktop and
-# re-run `chezmoi apply`, or run the compose command below manually.
+# convention #6): notification setup must never block `chezmoi apply` —
+# notifications are not setup-critical. NOTE the run_onchange consequence:
+# exit 0 records this script as done, so re-running `chezmoi apply` does NOT
+# retry until the compose/server templates change. The printed manual command
+# is the recovery path that actually works.
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[ntfy] docker CLI not found; skipping server start." >&2
+  echo "[ntfy] Recover with: docker compose -f ~/.config/ntfy/compose.yaml up -d" >&2
+  exit 0
+fi
 if ! docker info >/dev/null 2>&1; then
   echo "[ntfy] Docker Desktop is not running; skipping server start." >&2
   echo "[ntfy] Recover with: docker compose -f ~/.config/ntfy/compose.yaml up -d" >&2
@@ -36,7 +43,11 @@ if ! docker info >/dev/null 2>&1; then
 fi
 
 echo "[ntfy] starting ntfy server (docker compose up -d)..."
-docker compose -f "$HOME/.config/ntfy/compose.yaml" up -d --remove-orphans
+if ! docker compose -f "$HOME/.config/ntfy/compose.yaml" up -d --remove-orphans; then
+  echo "[ntfy] docker compose up failed; notifications will fail open." >&2
+  echo "[ntfy] Recover with: docker compose -f ~/.config/ntfy/compose.yaml up -d" >&2
+  exit 0
+fi
 
 # Assert the tailnet HTTPS front. `--bg` persists the mapping across reboots
 # and tailscaled restarts (tailscale.com/kb/1242); re-running is idempotent.

--- a/tests/docs_facts.bats
+++ b/tests/docs_facts.bats
@@ -196,11 +196,12 @@ load helpers/setup
 }
 
 @test "docs_facts: every <!-- FACT:ci-both-exclusion-count --> marker matches the Ubuntu job exclusion count" {
-  # SSOT: .github/workflows/setup-validation.yml lines 290-296 (Ubuntu job's
-  # "Exclude CI-incompatible files" step for f in \...; do block). Count is 6 as of
-  # PR #271 — PR #248 added home/dot_config/git/private_gitleaks-own.toml.tmpl.
+  # SSOT: .github/workflows/setup-validation.yml (Ubuntu job's
+  # "Exclude CI-incompatible files" step for f in \...; do block). Count is 8 as of
+  # #337, which added the two home/dot_config/ntfy/private_*.tmpl entries
+  # (PR #248 added private_gitleaks-own.toml.tmpl for the earlier count of 6).
   # Update this constant AND every marker in docs/ when entries are added or removed.
-  local expected=6
+  local expected=8
   local found=0 f val
   while IFS= read -r f; do
     while IFS= read -r val; do

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1652,3 +1652,115 @@ _gate_decision() {
   grep -q 'instinct-cli.py' "$sk"
   grep -q 'clv2-session-notify' "$sk"
 }
+
+# --- Self-hosted ntfy notification system (#337) ---
+
+@test "ntfy compose pins an exact image tag, stays loopback-only, and restarts" {
+  local c="${HOME_DIR}/dot_config/ntfy/compose.yaml.tmpl"
+  [ -f "$c" ]
+  # Exact version pin — Renovate's regex manager tracks this line; `latest`
+  # (or any non-vX.Y.Z tag) would make the deployment unauditable.
+  grep -qE '^    image: binary/ntfy:v[0-9]+\.[0-9]+\.[0-9]+$' "$c"
+  ! grep -q 'image:.*latest' "$c"
+  grep -q 'restart: unless-stopped' "$c"
+  # Host exposure must be loopback-only; tailnet access goes through
+  # `tailscale serve`, never a direct bind.
+  grep -qF '"127.0.0.1:{{ .ntfy.port }}:80"' "$c"
+  ! grep -q '0\.0\.0\.0' "$c"
+}
+
+@test "ntfy server config enforces deny-all auth and persistent cache" {
+  local y="${HOME_DIR}/dot_config/ntfy/private_server.yml.tmpl"
+  [ -f "$y" ]
+  grep -q 'auth-default-access: "deny-all"' "$y"
+  grep -q 'auth-file:' "$y"
+  grep -q 'cache-file:' "$y"
+  grep -qF 'cache-duration: "{{ .ntfy.cache_duration }}"' "$y"
+  # iOS instant-push relay, the sole user-approved metadata egress (#337 PRD D2').
+  grep -qF 'upstream-base-url: "https://ntfy.sh"' "$y"
+  # tailscale funnel must never appear anywhere in the ntfy config assets.
+  ! grep -ri 'funnel' "${HOME_DIR}/dot_config/ntfy"
+}
+
+@test "ntfy setup script carries the embedded hashes and CI guard" {
+  local s="${HOME_DIR}/run_onchange_after_31-setup-ntfy.sh.tmpl"
+  [ -f "$s" ]
+  # embedded-hash trick: re-runs only when the compose file or server config changes
+  grep -qF 'include "dot_config/ntfy/compose.yaml.tmpl" | sha256sum' "$s"
+  grep -qF 'include "dot_config/ntfy/private_server.yml.tmpl" | sha256sum' "$s"
+  # CI must never start services from lifecycle scripts
+  grep -qF 'if [ -n "${CI:-}" ]; then' "$s"
+  # darwin-only: the whole body is inside the OS guard
+  head -1 "$s" | grep -qF '{{ if eq .chezmoi.os "darwin" -}}'
+  # template-stripped body must still parse
+  sed '/{{/d' "$s" | bash -n
+  # tailscale serve with --bg (persists across reboots); funnel is forbidden
+  grep -qF 'serve --bg' "$s"
+  ! grep -qE '^[^#]*tailscale.*funnel' "$s"
+}
+
+@test "settings.json disables stop:desktop-notify and wires the ntfy hooks (#337)" {
+  local s="${HOME_DIR}/dot_claude/settings.json"
+  [ -f "$s" ]
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
+  jq -e '
+    (.env.ECC_DISABLED_HOOKS | split(",")) as $ids
+    | ($ids | index("stop:desktop-notify")) != null
+  ' "$s" >/dev/null
+  # Notification hook entry: the four subscribed matchers, async command wrapper
+  jq -e '
+    .hooks.Notification[] | select(.id=="notification:ntfy-notify")
+    | .matcher=="permission_prompt|idle_prompt|agent_needs_input|agent_completed"
+      and .hooks[0].type=="command"
+      and .hooks[0].command=="$HOME/.claude/ntfy-notify.sh"
+      and .hooks[0].async==true
+      and .hooks[0].timeout==10
+  ' "$s" >/dev/null
+  # Stop hook entry replacing desktop-notify (same structural bar as Notification)
+  jq -e '
+    .hooks.Stop[] | select(.id=="stop:ntfy-notify")
+    | .hooks[0].type=="command"
+      and .hooks[0].command=="$HOME/.claude/ntfy-notify.sh"
+      and .hooks[0].async==true
+      and .hooks[0].timeout==10
+  ' "$s" >/dev/null
+}
+
+@test "CI excludes the ntfy onepasswordRead templates in both jobs" {
+  local w="${REPO_ROOT}/.github/workflows/setup-validation.yml"
+  [ -f "$w" ]
+  # The CI precedent is the hardcoded mv list (NOT .chezmoiignore): each
+  # onepasswordRead template must appear once per job (macOS + Ubuntu).
+  [ "$(grep -cF 'home/dot_config/ntfy/private_server.yml.tmpl' "$w")" -eq 2 ]
+  [ "$(grep -cF 'home/dot_config/ntfy/private_notify-env.tmpl' "$w")" -eq 2 ]
+}
+
+@test "renovate tracks the ntfy image tag via the compose regex manager" {
+  local r="${REPO_ROOT}/.github/renovate.json5"
+  grep -qF 'binary/ntfy' "$r"
+  grep -qF "compose\\\\.yaml\\\\.tmpl" "$r"
+}
+
+@test "1password ITEMS covers the ntfy item fields" {
+  _onepassword_item_list | grep -qF 'op://kryota.dev/Dotfiles - ntfy/base-url'
+  _onepassword_item_list | grep -qF 'op://kryota.dev/Dotfiles - ntfy/credential'
+  # The templates must consume exactly the URIs the gate validates — a typo on
+  # either side would otherwise pass both checks independently.
+  grep -qF 'onepasswordRead "op://kryota.dev/Dotfiles - ntfy/credential"' \
+    "${HOME_DIR}/dot_config/ntfy/private_notify-env.tmpl"
+  grep -qF 'onepasswordRead "op://kryota.dev/Dotfiles - ntfy/base-url"' \
+    "${HOME_DIR}/dot_config/ntfy/private_server.yml.tmpl"
+}
+
+@test "ntfy runtime state never lands in the chezmoi source tree" {
+  # user.db / cache.db are runtime state under ~/Library/Application Support/ntfy.
+  # Structural check first: chezmoi must not manage that target dir (the sibling
+  # Application Support/Code entry for VS Code is unrelated and stays).
+  [ ! -e "${HOME_DIR}/Library/Application Support/ntfy" ]
+  run find "${HOME_DIR}" -name 'user.db*' -o -name 'cache.db*'
+  [ -z "$output" ]
+}
+
+@test "chezmoiignore excludes the ntfy config dir on non-darwin" {
+  grep -qF '.config/ntfy' "${HOME_DIR}/.chezmoiignore"
+}

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1658,10 +1658,14 @@ _gate_decision() {
 @test "ntfy compose pins an exact image tag, stays loopback-only, and restarts" {
   local c="${HOME_DIR}/dot_config/ntfy/compose.yaml.tmpl"
   [ -f "$c" ]
-  # Exact version pin — Renovate's regex manager tracks this line; `latest`
-  # (or any non-vX.Y.Z tag) would make the deployment unauditable.
-  grep -qE '^    image: binary/ntfy:v[0-9]+\.[0-9]+\.[0-9]+$' "$c"
+  # Exact version pin + digest — Renovate's regex manager tracks this line;
+  # `latest` (or any non-vX.Y.Z tag) would make the deployment unauditable.
+  # The namespace is asserted literally: `binwiederhier` is the official ntfy
+  # publisher (a wrong namespace once shipped as `binary/ntfy`, which does not
+  # exist upstream and would trust an unrelated Docker Hub account).
+  grep -qE '^    image: binwiederhier/ntfy:v[0-9]+\.[0-9]+\.[0-9]+@sha256:[a-f0-9]{64}$' "$c"
   ! grep -q 'image:.*latest' "$c"
+  ! grep -q 'binary/ntfy' "$c"
   grep -q 'restart: unless-stopped' "$c"
   # Host exposure must be loopback-only; tailnet access goes through
   # `tailscale serve`, never a direct bind.
@@ -1737,7 +1741,7 @@ _gate_decision() {
 
 @test "renovate tracks the ntfy image tag via the compose regex manager" {
   local r="${REPO_ROOT}/.github/renovate.json5"
-  grep -qF 'binary/ntfy' "$r"
+  grep -qF 'binwiederhier/ntfy' "$r"
   grep -qF "compose\\\\.yaml\\\\.tmpl" "$r"
 }
 

--- a/tests/ntfy_notify.bats
+++ b/tests/ntfy_notify.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+
+# ntfy hook wrapper (home/dot_claude/executable_ntfy-notify.sh, #337).
+# Runs the wrapper against fixture hook payloads with curl stubbed out on
+# PATH; no network, no server, CI-safe. Covers the fail-open contract,
+# payload construction, truncation/scrubbing, and token hygiene (AC-006/007).
+
+load helpers/setup
+
+WRAPPER="${HOME_DIR}/dot_claude/executable_ntfy-notify.sh"
+
+setup() {
+  STUB_DIR="${BATS_TEST_TMPDIR}/stub"
+  mkdir -p "$STUB_DIR"
+  cat >"${STUB_DIR}/curl" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >"${NTFY_TEST_STUB_DIR}/curl_args"
+cat >"${NTFY_TEST_STUB_DIR}/curl_stdin"
+exit "${NTFY_TEST_CURL_EXIT:-0}"
+EOF
+  chmod +x "${STUB_DIR}/curl"
+
+  ENV_FILE="${BATS_TEST_TMPDIR}/notify-env"
+  cat >"$ENV_FILE" <<'EOF'
+NTFY_URL='http://127.0.0.1:9'
+NTFY_TOKEN='tk_bats_secret'
+NTFY_TOPIC_ATTENTION='claude-attention'
+NTFY_TOPIC_DONE='claude-done'
+EOF
+
+  LOG_FILE="${BATS_TEST_TMPDIR}/ntfy-notify.log"
+  REDACT_TOML="${BATS_TEST_TMPDIR}/gitleaks-own.toml"
+}
+
+# Run the wrapper with the stubbed PATH and fixture env; stdin comes from $1.
+run_wrapper() {
+  run env \
+    PATH="${STUB_DIR}:${PATH}" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" \
+    NTFY_TEST_CURL_EXIT="${NTFY_TEST_CURL_EXIT:-0}" \
+    NTFY_NOTIFY_ENV_FILE="$ENV_FILE" \
+    NTFY_NOTIFY_LOG_FILE="$LOG_FILE" \
+    NTFY_NOTIFY_REDACT_TOML="$REDACT_TOML" \
+    NTFY_NOTIFY_ALERT_SOUND="${BATS_TEST_TMPDIR}/nonexistent.m4r" \
+    bash -c "printf '%s' \"\$1\" | bash \"$WRAPPER\"" _ "$1"
+}
+
+@test "ntfy-notify.sh exists and passes bash -n" {
+  [ -f "$WRAPPER" ]
+  bash -n "$WRAPPER"
+}
+
+@test "ntfy-notify.sh is a silent no-op without the env file" {
+  ENV_FILE="${BATS_TEST_TMPDIR}/does-not-exist"
+  run_wrapper '{"hook_event_name":"Stop","session_id":"abc","cwd":"/tmp"}'
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/curl_args" ]
+}
+
+@test "permission_prompt goes to the attention topic with priority 4" {
+  run_wrapper '{"hook_event_name":"Notification","notification_type":"permission_prompt","session_id":"0123456789abcdef","cwd":"/tmp"}'
+  [ "$status" -eq 0 ]
+  [ -f "${STUB_DIR}/curl_stdin" ]
+  payload="$(cat "${STUB_DIR}/curl_stdin")"
+  [ "$(printf '%s' "$payload" | jq -r '.topic')" = "claude-attention" ]
+  [ "$(printf '%s' "$payload" | jq -r '.priority')" = "4" ]
+  [[ "$(printf '%s' "$payload" | jq -r '.title')" == *"permission_prompt"* ]]
+  # Attribution (requirement 1.2): account in title and tags; cwd=/tmp is not a
+  # git repo so repo/branch fall back to "-", which must also land in the tags.
+  [[ "$(printf '%s' "$payload" | jq -r '.title')" == *"[default]"* ]]
+  printf '%s' "$payload" | jq -e '.tags | index("default")' >/dev/null
+  printf '%s' "$payload" | jq -e '.tags | index("-")' >/dev/null
+  # 8-char session id lands in tags
+  printf '%s' "$payload" | jq -e '.tags | index("01234567")' >/dev/null
+}
+
+@test "agent_needs_input is attention class; agent_completed is done class" {
+  run_wrapper '{"hook_event_name":"Notification","notification_type":"agent_needs_input","session_id":"abc","cwd":"/tmp"}'
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.topic' "${STUB_DIR}/curl_stdin")" = "claude-attention" ]
+  [ "$(jq -r '.priority' "${STUB_DIR}/curl_stdin")" = "4" ]
+  run_wrapper '{"hook_event_name":"Notification","notification_type":"agent_completed","session_id":"abc","cwd":"/tmp"}'
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.topic' "${STUB_DIR}/curl_stdin")" = "claude-done" ]
+  [ "$(jq -r '.priority' "${STUB_DIR}/curl_stdin")" = "3" ]
+}
+
+@test "Stop goes to the done topic (priority 3) and truncates to exactly 200 chars" {
+  long_msg="$(printf 'a%.0s' $(seq 1 300))"
+  run_wrapper "{\"hook_event_name\":\"Stop\",\"session_id\":\"abc\",\"cwd\":\"/tmp\",\"last_assistant_message\":\"${long_msg}\"}"
+  [ "$status" -eq 0 ]
+  payload="$(cat "${STUB_DIR}/curl_stdin")"
+  [ "$(printf '%s' "$payload" | jq -r '.topic')" = "claude-done" ]
+  [ "$(printf '%s' "$payload" | jq -r '.priority')" = "3" ]
+  # jq length counts codepoints: the exact BODY_LIMIT boundary, not a loose cap
+  [ "$(printf '%s' "$payload" | jq -r '.message | length')" -eq 200 ]
+}
+
+@test "multibyte body is truncated on codepoint boundaries (stays valid UTF-8)" {
+  long_msg="$(printf 'あ%.0s' $(seq 1 250))"
+  run_wrapper "{\"hook_event_name\":\"Stop\",\"session_id\":\"abc\",\"cwd\":\"/tmp\",\"last_assistant_message\":\"${long_msg}\"}"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.message | length' "${STUB_DIR}/curl_stdin")" -eq 200 ]
+  # No mid-character cut: the message must still be pure あ (no U+FFFD debris)
+  jq -e '.message | test("^あ+$")' "${STUB_DIR}/curl_stdin" >/dev/null
+}
+
+@test "missing NTFY_TOPIC_* in the env file fails open without publishing" {
+  cat >"$ENV_FILE" <<'EOF'
+NTFY_URL='http://127.0.0.1:9'
+NTFY_TOKEN='tk_bats_secret'
+EOF
+  run_wrapper '{"hook_event_name":"Stop","session_id":"abc","cwd":"/tmp"}'
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/curl_args" ]
+}
+
+@test "Stop without last_assistant_message publishes an empty message" {
+  run_wrapper '{"hook_event_name":"Stop","session_id":"abc","cwd":"/tmp"}'
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.message' "${STUB_DIR}/curl_stdin")" = "" ]
+}
+
+@test "client identifiers are scrubbed via the deployed redact pattern" {
+  command -v perl >/dev/null 2>&1 || skip "perl not available"
+  printf "regex = '''(?i)(acmecorp|widgetco)'''\n" >"$REDACT_TOML"
+  run_wrapper '{"hook_event_name":"Stop","session_id":"abc","cwd":"/tmp","last_assistant_message":"deployed AcmeCorp api for WidgetCo"}'
+  [ "$status" -eq 0 ]
+  msg="$(jq -r '.message' "${STUB_DIR}/curl_stdin")"
+  [[ "$msg" != *"AcmeCorp"* ]]
+  [[ "$msg" != *"WidgetCo"* ]]
+  [[ "$msg" == *"[redacted]"* ]]
+}
+
+@test "malformed redact TOML falls back to truncation-only" {
+  printf 'not the expected format\n' >"$REDACT_TOML"
+  run_wrapper '{"hook_event_name":"Stop","session_id":"abc","cwd":"/tmp","last_assistant_message":"mentions AcmeCorp"}'
+  [ "$status" -eq 0 ]
+  msg="$(jq -r '.message' "${STUB_DIR}/curl_stdin")"
+  [[ "$msg" == *"AcmeCorp"* ]]
+}
+
+@test "publish failure is fail-open: exit 0, logged, token never logged" {
+  NTFY_TEST_CURL_EXIT=22
+  run_wrapper '{"hook_event_name":"Notification","notification_type":"idle_prompt","session_id":"abc","cwd":"/tmp"}'
+  [ "$status" -eq 0 ]
+  [ -f "$LOG_FILE" ]
+  grep -q 'publish failed' "$LOG_FILE"
+  ! grep -q 'tk_bats_secret' "$LOG_FILE"
+}
+
+@test "unsubscribed events are ignored without publishing" {
+  run_wrapper '{"hook_event_name":"Notification","notification_type":"auth_success","session_id":"abc","cwd":"/tmp"}'
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/curl_args" ]
+}
+
+@test "token never reaches curl argv (travels via -K config file)" {
+  run_wrapper '{"hook_event_name":"Stop","session_id":"abc","cwd":"/tmp","last_assistant_message":"hi"}'
+  [ "$status" -eq 0 ]
+  ! grep -q 'tk_bats_secret' "${STUB_DIR}/curl_args"
+  grep -q -- '-K' "${STUB_DIR}/curl_args"
+}
+
+@test "wrapper source keeps token hygiene: no -H/--header Authorization, no set -x" {
+  # Catch -H"Authorization (no space) and the --header long option too;
+  # scope both greps to non-comment content so prose about the rule can't match
+  ! grep -E -- '^[^#]*(-H|--header)["'"'"'[:space:]]*"?Authorization' "$WRAPPER"
+  # Catch combined flag forms like `set -eux`, not just a literal `set -x`
+  ! grep -E '^[^#]*set -[a-zA-Z]*x' "$WRAPPER"
+}

--- a/tests/ntfy_notify.bats
+++ b/tests/ntfy_notify.bats
@@ -27,6 +27,8 @@ NTFY_TOKEN='tk_bats_secret'
 NTFY_TOPIC_ATTENTION='claude-attention'
 NTFY_TOPIC_DONE='claude-done'
 EOF
+  # The wrapper refuses env files that are not owner-only (0600/0400)
+  chmod 600 "$ENV_FILE"
 
   LOG_FILE="${BATS_TEST_TMPDIR}/ntfy-notify.log"
   REDACT_TOML="${BATS_TEST_TMPDIR}/gitleaks-own.toml"
@@ -110,9 +112,37 @@ run_wrapper() {
 NTFY_URL='http://127.0.0.1:9'
 NTFY_TOKEN='tk_bats_secret'
 EOF
+  chmod 600 "$ENV_FILE"
   run_wrapper '{"hook_event_name":"Stop","session_id":"abc","cwd":"/tmp"}'
   [ "$status" -eq 0 ]
   [ ! -f "${STUB_DIR}/curl_args" ]
+}
+
+@test "group/other-readable env file fails open without publishing" {
+  chmod 644 "$ENV_FILE"
+  run_wrapper '{"hook_event_name":"Stop","session_id":"abc","cwd":"/tmp"}'
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/curl_args" ]
+}
+
+@test "identifier straddling the truncation boundary is scrubbed (scrub before truncate)" {
+  command -v perl >/dev/null 2>&1 || skip "perl not available"
+  printf "regex = '''(?i)(acmecorp)'''\n" >"$REDACT_TOML"
+  long_msg="$(printf 'a%.0s' $(seq 1 195))acmecorp$(printf 'b%.0s' $(seq 1 50))"
+  run_wrapper "{\"hook_event_name\":\"Stop\",\"session_id\":\"abc\",\"cwd\":\"/tmp\",\"last_assistant_message\":\"${long_msg}\"}"
+  [ "$status" -eq 0 ]
+  msg="$(jq -r '.message' "${STUB_DIR}/curl_stdin")"
+  [[ "$msg" != *"acme"* ]]
+  [ "$(jq -r '.message | length' "${STUB_DIR}/curl_stdin")" -le 200 ]
+}
+
+@test "redact extraction understands the real gitleaks-own template format" {
+  # Integration guard against silent format drift: the wrapper's sed contract
+  # must keep matching the actual chezmoi source template's regex line.
+  run env NTFY_NOTIFY_REDACT_TOML="${HOME_DIR}/dot_config/git/private_gitleaks-own.toml.tmpl" \
+    bash -c "source '$WRAPPER'; extract_redact_pattern"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
 }
 
 @test "Stop without last_assistant_message publishes an empty message" {


### PR DESCRIPTION
## Summary

Replaces the ECC `stop:desktop-notify` Stop hook (local osascript, no history) with a
self-hosted **ntfy** notification system reachable over **Tailscale** (closes #337).
Claude Code events now push to tailnet devices with full attribution
(repo / branch / account / session / event) and a persistent, filterable server-side
history. The finalized decision record is committed as
`.claude/prds/337-ntfy-tailscale.prd.md`.

## Key design decisions

- **Docker, not Homebrew**: the Homebrew `ntfy` formula builds macOS binaries with the
  `noserver` Go tag — `ntfy serve` does not exist in the installed binary (verified on
  the target machine). The server therefore runs as the official `binwiederhier/ntfy`
  image (exact tag + digest pin, Renovate-tracked via a compose regex manager) under
  the Brewfile-provisioned Docker Desktop with `restart: unless-stopped`.
- **Network boundary**: the container publishes `127.0.0.1:<port>:80` only; tailnet
  exposure goes exclusively through `tailscale serve --bg` (Tailscale-managed TLS,
  persists across reboots). `tailscale funnel` is prohibited and bats-asserted absent.
  `upstream-base-url: https://ntfy.sh` enables iOS instant push (user-approved
  metadata-only egress; behavior on a tailnet-only server is recorded by the smoke
  test).
- **Auth**: `auth-default-access: deny-all`; write-only publisher token vs read-only
  subscriber token, both stored in 1Password (`Dotfiles - ntfy`), publisher token
  rendered into a 0600 env file via `onepasswordRead`.
- **Fail-open hook wrapper** (`~/.claude/ntfy-notify.sh`): every exit path is 0;
  unreachable server ⇒ log + content-free local alert; no env file ⇒ silent no-op.
  Stop bodies are truncated to 200 codepoints (jq slice, multibyte-safe) and scrubbed
  with the deployed client-identifier pattern. The token only ever travels via a
  `curl -K` config file — never argv/stdout/stderr/logs (bats-asserted).
- **Runtime state stays out of chezmoi**: `user.db` / `cache.db` live in
  `~/Library/Application Support/ntfy` (0700); recovery runbook documented.
- **Intentional deviation from lifecycle convention #6**: `run_onchange_after_31`
  warns and exits 0 when Docker Desktop is down — notifications must never block
  `chezmoi apply` (documented in-script and in docs).

## Changes

- `home/dot_config/ntfy/`: compose (pinned image, loopback ports), `server.yml`
  (cache 168h from the `[ntfy]` SSOT block, deny-all auth, upstream relay), publisher
  env — the two `onepasswordRead` templates are added to the CI exclude list in both
  jobs
- `home/dot_claude/`: `ntfy-notify.sh` wrapper; `settings.json` Notification
  (`permission_prompt|idle_prompt|agent_needs_input|agent_completed`) + Stop hooks,
  `stop:desktop-notify` disabled via `env.ECC_DISABLED_HOOKS` (one-step rollback
  documented)
- `home/run_onchange_after_31-setup-ntfy.sh.tmpl`: state dir, `docker compose up -d`,
  `tailscale serve --bg` assertion (embedded-hash, CI guard)
- Tests: `tests/ntfy_notify.bats` (14 cases), files.bats ntfy section (9 asserts),
  docs_facts constants; **`make test`: 206 ok / 0 failures**
- Docs: new `docs/architecture/notifications.md` (+ja) with setup / smoke-test /
  recovery / rollback runbooks; lifecycle, secrets, CI docs and FACT markers synced
  (item count 4→6, exclusion count 6→8)

## Review

Deliberated via a 4-perspective council (UX / engineering / security / ops) with a
2-reviewer adversarial pass on the PRD, then implemented and re-reviewed by a
3-role review team (code-quality / security / test) — all APPROVE. Notable
review-driven fixes: multibyte truncation moved from locale-dependent `cut -c` to jq
codepoint slicing; topic-name fallbacks removed in favor of the SSOT; attribution
and fail-open branches now bats-covered.

## Post-merge setup (one-time, documented in the runbook)

1. Create the `Dotfiles - ntfy` 1Password item (`base-url`, `credential`).
2. `chezmoi apply`, then provision users/tokens via `docker compose exec` and store
   them in 1Password.
3. Subscribe devices with the read-only token; run the documented smoke test
   (anonymous denial, ro-publish denial, iOS instant-push observation).
