### PR TITLE
feat(claude): add an over-provision threshold gate backed by statusline rate-limit snapshots

### DIFF
--- a/home/dot_agents/skills/model-fitness-check/SKILL.md
+++ b/home/dot_agents/skills/model-fitness-check/SKILL.md
@@ -91,7 +91,7 @@ trivial/small の毎回 FYI とは別に、**過剰スペックの累積**を「
 `${XDG_CACHE_HOME:-$HOME/.cache}/claude-statusline/rate_limits_<profile>.json` を Read する（statusline が stdin の `rate_limits` を書き出す snapshot。**パスは writer と同じ XDG フォールバック式で解決し、`~/.cache` 決め打ちにしない** —— `XDG_CACHE_HOME` を設定した環境で誤って「snapshot 無し」と誤判定しないため。`<profile>` は `CLAUDE_CONFIG_DIR` の basename、既定 `.claude`）。`five_hour.used_percentage` を圧力として使う。
 
 - **staleness / 欠損ガード**: 次のいずれかで quota 不明として count-only fallback（下表）に切り替える —— (a) ファイルが無い、(b) `ts` が 15 分より古い、(c) `five_hour.used_percentage` が欠落・非数値（writer は `five_hour` が無効でも `seven_day` だけの snapshot を書くため、fresh でも 5h が無いことがある）。silent skip はしない（fail-safe）。
-- **（要検証）Team プランの rate_limits**: `rate_limits` が statusline stdin に現れるのは公式には **Pro/Max のみ明記**（Team premium seat での populate は未確認）。Team で欠落する場合、本ゲートは常に count-only fallback で動く（実測圧力シグナルは使えないが、カウンタベースのゲートは機能する）。
+- **Team プランの rate_limits**: 公式ドキュメント（`code.claude.com/docs/en/statusline`）で **`rate_limits` は「Claude.ai subscribers (Pro/Max) が最初の API 応答後」にのみ現れると明記され、Team / Enterprise は列挙されていない**ことを確認済み。Team premium seat（`cld-r06`）で実際に populate されるかの live 検証は未実施（列挙外なので欠落前提で扱う）。欠落時はシグナル 2（実測圧力）が常に不在となり、本ゲートは count-only fallback（`OVERPROVISION_GATE_FALLBACK`）で動く——red 帯（2 件）への感度上げはできないが、カウンタベースのゲート自体は機能する。
 
 ### 発火条件（named constants）
 

--- a/home/dot_agents/skills/model-fitness-check/SKILL.md
+++ b/home/dot_agents/skills/model-fitness-check/SKILL.md
@@ -23,14 +23,14 @@ argument-hint: "<work tier>（例: orchestration / large / trivial-small）"
 | `pr-workflow` の分類 / GATE / 統合; `sdd` Phase 1–3 の spec 執筆; `multi-review` の統合・裁定 | Opus 5 | high（既定。ゲートは言及しない） | **floor**（blocking） |
 | large tier / PRD 審議 / adversarial verification / 横断設計 | Opus 5 | xhigh | **floor**（blocking） |
 | trivial / small tier のみ | Sonnet 5 | medium | **cost hint**（non-blocking FYI） |
-| Fable-orchestrator セッション（`cldf` 系） | Fable 5 | セッション既定 | 常に pass（monotonic ルール） |
+| Fable-orchestrator セッション（`cldf` 系） | Fable 5 | セッション既定 | floor 判定は常に pass（monotonic ルール）。over-provision 閾値ゲートは適用 |
 
 ## capability 順序（monotonic）
 
 能力順序を **Fable > Opus > Sonnet > Haiku** と定義する。同一 family 内では **generation が効く**（Opus 4.8 は Opus 5 の floor を**満たさない**）。判定は「現在の tier ≥ 行が要求する tier」なら**無条件で silent pass**（プロンプトを出さない）。
 
-- **Fable / cldf セッションはどの行に対しても switch 提案を受けない**。Fable は全行の要求を満たす（monotonic の最上位）うえ、`fable-orchestrator-prompt.md` で独自の委譲契約を持つため、Opus 契約に無理に合わせる提案は構造的に矛盾する。
-- over-provisioning（Fable で trivial をこなす等）は停止対象にしない（user が cldf を起動した時点で下せない決定であり、指摘しても是正不能）。
+- **Fable / cldf セッションは floor 行（上方向）の switch 提案を受けない**。Fable は全 floor の要求を満たす（monotonic の最上位）うえ、`fable-orchestrator-prompt.md` で独自の委譲契約を持つため、Opus 契約に合わせる上方向の提案は構造的に矛盾する。下方向（過剰スペックの解消）は「over-provision 閾値ゲート」の対象で、**Fable セッションも免除されない**。
+- over-provisioning（Fable で trivial をこなす等）は毎回は停止しないが、累積が閾値を超えたら 1 回だけ blocking する（「over-provision 閾値ゲート」参照）。cldf でも exit → `cld --continue` で orchestrator 契約ごと降りられるため、「是正不能」ではない。
 
 ## model の検出
 
@@ -58,15 +58,59 @@ argument-hint: "<work tier>（例: orchestration / large / trivial-small）"
 3. **abort**: 作業を中止する。
 
 - **effort は xhigh を要求する行でのみ言及する**。既定 high で足りる行では effort に一切触れない（`/effort` コマンドも出さない）。
-- effort はセッション内から確実には読めないため、**推論せず提示して確認する**（`effortLevel` は settings.json から読めるが、`/effort` によるセッション内状態と乖離しうるため）。
+- effort はセッション内から確実には読めないため、**推論せず提示して確認する**（`effortLevel` は settings.json から読めるが、`/effort` によるセッション内状態と乖離しうるため）。statusline snapshot（「over-provision 閾値ゲート」参照）の `effort` は harness 実出力由来の参考値として使えるが、描画タイミングにより stale がありうるため、これも確定値としては扱わない。
 
 ### trivial / small 行
 
 **non-blocking の一行 FYI** に留める。「trivial/small tier は Sonnet 5 @ medium で十分（現在より下げればコストが浮く）」程度の cost hint を出すだけで、**workflow を止めない**。trivial/small は分類が実行前に終わらないため、ここで停止させると軽い path の摩擦を最大化する。
 
+FYI を出すたびに over-provision カウンタを +1 する（「over-provision 閾値ゲート」参照）。毎回の FYI は non-blocking のまま維持し、blocking は閾値超過時の 1 回に限定する。
+
 ### 検出不能時の fallback
 
 model 検出が主経路・副経路とも失敗した場合、**silent skip せず**、常にチェック内容（要求水準と現在の不確実性）を提示する（fail-safe）。
+
+## over-provision 閾値ゲート
+
+trivial/small の毎回 FYI とは別に、**過剰スペックの累積**を「カウンタ × 実測 quota 圧力」の 2 シグナルで監視し、閾値超過時のみ 1 回 blocking する。サブスクリプション（Max / Team）では over-provision の実害は金額ではなく **quota（全モデル共有プール）のクラウドアウト**——Fable / Opus で軽作業を続けると、重作業に必要な quota が先に尽きる——なので、圧力シグナルと組み合わせ、quota に余裕がある間は止めない（alert fatigue の回避。blocking の希少性が floor 停止の信頼性を支える）。
+
+### シグナル 1: over-provision カウンタ（セッション内）
+
+- 「現在の tier が行の要求より上位」と判定するたび（trivial/small FYI を出すたび）にカウンタを +1 する。
+- セッション内でのみ保持する（永続化しない）。**floor 判定の idempotency とは別カウンタ**（idempotency は同一判定の再提示の抑制、本カウンタは累積の検出で、性質が逆）。
+- ゲート発火時、および continue anyway 選択時にリセットする。
+
+### シグナル 2: 実測 quota 圧力（statusline snapshot）
+
+`~/.cache/claude-statusline/rate_limits_<profile>.json` を Read する（statusline が stdin の `rate_limits` を書き出す snapshot。`<profile>` は `CLAUDE_CONFIG_DIR` の basename、既定 `.claude`）。`five_hour.used_percentage` を圧力として使う。
+
+- **staleness ガード**: `ts` が 15 分より古い、またはファイルが無い場合は quota 不明として count-only fallback（下表）に切り替える。silent skip はしない（fail-safe）。
+
+### 発火条件（named constants）
+
+帯域は statusline `pct_color` の色閾値（50 / 80）と一致させる:
+
+| 5h used_percentage | 帯域 | 発火閾値（カウンタ） |
+|---|---|---|
+| < 50 | green | 発火しない（FYI のみ） |
+| 50–79 | yellow | `OVERPROVISION_GATE_YELLOW = 5` 件 |
+| ≥ 80 | red | `OVERPROVISION_GATE_RED = 2` 件 |
+| snapshot 無し / stale | 不明 | `OVERPROVISION_GATE_FALLBACK = 5` 件（count-only） |
+
+### 発火時の提示（`AskUserQuestion` で 1 回 blocking）
+
+文面には snapshot の実測値をそのまま載せる（例: 「5h ウィンドウ 62% 消費（↻14:00 リセット）。直近 5 件は Sonnet で足りる軽作業でした。このペースだと重作業の前に上限に当たる見込みです」）。選択肢はセッション種別で分岐する:
+
+- **cld 系（通常セッション）**:
+  1. `/model sonnet` に下げて続行（推奨）
+  2. continue anyway（カウンタをリセットし、次の閾値まで沈黙）
+  3. abort
+- **cldf 系（Fable orchestrator）**:
+  1. exit → `cld --continue` で再開（推奨。orchestrator prompt は argv 注入のため再起動で契約ごと降りられ、会話文脈は保持される）
+  2. `/model opus` 等でセッション内切替（**注記必須**: system-prompt の自己申告 model identity が古い値を残すため、以後の本 skill の主経路検出を信用せず、切替済みであることをセッション内に記録する）
+  3. continue anyway（カウンタをリセット）
+
+このゲートは **Fable / cldf セッションにも適用される**（floor 免除は上方向の switch 提案に限る）。
 
 ## 呼び出し規約
 

--- a/home/dot_agents/skills/model-fitness-check/SKILL.md
+++ b/home/dot_agents/skills/model-fitness-check/SKILL.md
@@ -91,7 +91,7 @@ trivial/small の毎回 FYI とは別に、**過剰スペックの累積**を「
 `${XDG_CACHE_HOME:-$HOME/.cache}/claude-statusline/rate_limits_<profile>.json` を Read する（statusline が stdin の `rate_limits` を書き出す snapshot。**パスは writer と同じ XDG フォールバック式で解決し、`~/.cache` 決め打ちにしない** —— `XDG_CACHE_HOME` を設定した環境で誤って「snapshot 無し」と誤判定しないため。`<profile>` は `CLAUDE_CONFIG_DIR` の basename、既定 `.claude`）。`five_hour.used_percentage` を圧力として使う。
 
 - **staleness / 欠損ガード**: 次のいずれかで quota 不明として count-only fallback（下表）に切り替える —— (a) ファイルが無い、(b) `ts` が 15 分より古い、(c) `five_hour.used_percentage` が欠落・非数値（writer は `five_hour` が無効でも `seven_day` だけの snapshot を書くため、fresh でも 5h が無いことがある）。silent skip はしない（fail-safe）。
-- **Team プランの rate_limits**: 公式ドキュメント（`code.claude.com/docs/en/statusline`）で **`rate_limits` は「Claude.ai subscribers (Pro/Max) が最初の API 応答後」にのみ現れると明記され、Team / Enterprise は列挙されていない**ことを確認済み。Team premium seat（`cld-r06`）で実際に populate されるかの live 検証は未実施（列挙外なので欠落前提で扱う）。欠落時はシグナル 2（実測圧力）が常に不在となり、本ゲートは count-only fallback（`OVERPROVISION_GATE_FALLBACK`）で動く——red 帯（2 件）への感度上げはできないが、カウンタベースのゲート自体は機能する。
+- **Team プランの rate_limits（`cld-r06` で live 検証済み）**: 公式ドキュメント（`code.claude.com/docs/en/statusline`）は `rate_limits` を「Claude.ai subscribers (Pro/Max) が最初の API 応答後」にのみ現れると明記し Team / Enterprise を列挙しない。しかし **`cld-r06`（Team premium seat）の実 stdin では `five_hour` / `seven_day` とも populate されることを実機確認済み**（docs の Pro/Max-only 列挙は Team premium に対して不完全）。よって cld-r06 でもシグナル 2（実測圧力）は利用可能で、yellow/red 帯に到達する（count-only 固定ではない）。count-only fallback は真の欠損時——最初の API 応答前・stale snapshot・`five_hour` 欠落（docs: 各ウィンドウは独立に absent になりうる）——のための fallback として維持する。
 
 ### 発火条件（named constants）
 

--- a/home/dot_agents/skills/model-fitness-check/SKILL.md
+++ b/home/dot_agents/skills/model-fitness-check/SKILL.md
@@ -88,25 +88,25 @@ trivial/small の毎回 FYI とは別に、**過剰スペックの累積**を「
 
 ### シグナル 2: 実測 quota 圧力（statusline snapshot）
 
-`${XDG_CACHE_HOME:-$HOME/.cache}/claude-statusline/rate_limits_<profile>.json` を Read する（statusline が stdin の `rate_limits` を書き出す snapshot。**パスは writer と同じ XDG フォールバック式で解決し、`~/.cache` 決め打ちにしない** —— `XDG_CACHE_HOME` を設定した環境で誤って「snapshot 無し」と誤判定しないため。`<profile>` は `CLAUDE_CONFIG_DIR` の basename、既定 `.claude`）。`five_hour.used_percentage` を圧力として使う。
+`${XDG_CACHE_HOME:-$HOME/.cache}/claude-statusline/rate_limits_<profile>.json` を Read する（statusline が stdin の `rate_limits` を書き出す snapshot。**パスは writer と同じ XDG フォールバック式で解決し、`~/.cache` 決め打ちにしない** —— `XDG_CACHE_HOME` を設定した環境で誤って「snapshot 無し」と誤判定しないため。`<profile>` は `CLAUDE_CONFIG_DIR` の basename、既定 `.claude`）。**圧力値は `five_hour` と `seven_day` の `used_percentage` の大きい方（`max(5h, 7d)`）を使う**——ゲートが framing する harm は週次共有プールのクラウドアウト（`seven_day`）だが、短期バースト枯渇（`five_hour`）も捕捉したいので、圧力の高い方で発火判定する。片方のウィンドウが欠落していれば残る一方を使う。
 
-- **staleness / 欠損ガード**: 次のいずれかで quota 不明として count-only fallback（下表）に切り替える —— (a) ファイルが無い、(b) `ts` が 15 分より古い、(c) `five_hour.used_percentage` が欠落・非数値（writer は `five_hour` が無効でも `seven_day` だけの snapshot を書くため、fresh でも 5h が無いことがある）。silent skip はしない（fail-safe）。
-- **Team プランの rate_limits（`cld-r06` で live 検証済み）**: 公式ドキュメント（`code.claude.com/docs/en/statusline`）は `rate_limits` を「Claude.ai subscribers (Pro/Max) が最初の API 応答後」にのみ現れると明記し Team / Enterprise を列挙しない。しかし **`cld-r06`（Team premium seat）の実 stdin では `five_hour` / `seven_day` とも populate されることを実機確認済み**（docs の Pro/Max-only 列挙は Team premium に対して不完全）。よって cld-r06 でもシグナル 2（実測圧力）は利用可能で、yellow/red 帯に到達する（count-only 固定ではない）。count-only fallback は真の欠損時——最初の API 応答前・stale snapshot・`five_hour` 欠落（docs: 各ウィンドウは独立に absent になりうる）——のための fallback として維持する。
+- **staleness / 欠損ガード**: 次のいずれかで quota 不明として count-only fallback（下表）に切り替える —— (a) ファイルが無い、(b) `ts` が 15 分より古い、(c) `five_hour` と `seven_day` の `used_percentage` が**どちらも**欠落・非数値（writer は無効なウィンドウを省くため、fresh でも片方だけ／両方無いことがある）。**片方でも有効なら count-only にせず、有効な側の値で圧力を評価する**。silent skip はしない（fail-safe）。
+- **Team プランの rate_limits（`cld-r06` で live 検証済み）**: 公式ドキュメント（`code.claude.com/docs/en/statusline`）は `rate_limits` を「Claude.ai subscribers (Pro/Max) が最初の API 応答後」にのみ現れると明記し Team / Enterprise を列挙しない。しかし **`cld-r06`（Team premium seat）の実 stdin では `five_hour` / `seven_day` とも populate されることを実機確認済み**（docs の Pro/Max-only 列挙は Team premium に対して不完全）。よって cld-r06 でもシグナル 2（実測圧力）は利用可能で、yellow/red 帯に到達する（count-only 固定ではない）。count-only fallback は真の欠損時——最初の API 応答前・stale snapshot・両ウィンドウ欠落（docs: 各ウィンドウは独立に absent になりうる）——のための fallback として維持する。
 
 ### 発火条件（named constants）
 
 帯域は statusline `pct_color` の色閾値（50 / 80）と一致させる:
 
-| 5h used_percentage | 帯域 | 発火閾値（カウンタ） |
+| 圧力 = max(5h, 7d) | 帯域 | 発火閾値（カウンタ） |
 |---|---|---|
 | < 50 | green | 発火しない（FYI のみ） |
 | 50–79 | yellow | `OVERPROVISION_GATE_YELLOW = 5` 件 |
 | ≥ 80 | red | `OVERPROVISION_GATE_RED = 2` 件 |
-| snapshot 無し / stale | 不明 | `OVERPROVISION_GATE_FALLBACK = 5` 件（count-only） |
+| snapshot 無し / stale / 両窓欠落 | 不明 | `OVERPROVISION_GATE_FALLBACK = 5` 件（count-only） |
 
 ### 発火時の提示（`AskUserQuestion` で 1 回 blocking）
 
-文面には snapshot の実測値をそのまま載せる（例: 「5h ウィンドウ 62% 消費（↻14:00 リセット）。直近 5 件は Sonnet で足りる軽作業でした。このペースだと重作業の前に上限に当たる見込みです」）。選択肢はセッション種別で分岐する:
+文面には snapshot の実測値をそのまま載せ、**帯域を決めたウィンドウ（5h / 7d のうち圧力の高い方）を明示する**（例: 「7d ウィンドウ 63% 消費（↻07/30 07:00 リセット）。直近 5 件は Sonnet で足りる軽作業でした。このペースだと重作業の前に週次上限に当たる見込みです」）。選択肢はセッション種別で分岐する:
 
 - **cld 系（通常セッション）**:
   1. `/model sonnet` に下げて続行（推奨）

--- a/home/dot_agents/skills/model-fitness-check/SKILL.md
+++ b/home/dot_agents/skills/model-fitness-check/SKILL.md
@@ -27,15 +27,20 @@ argument-hint: "<work tier>（例: orchestration / large / trivial-small）"
 
 ## capability 順序（monotonic）
 
-能力順序を **Fable > Opus > Sonnet > Haiku** と定義する。同一 family 内では **generation が効く**（Opus 4.8 は Opus 5 の floor を**満たさない**）。判定は「現在の tier ≥ 行が要求する tier」なら**無条件で silent pass**（プロンプトを出さない）。
+能力順序を **Fable > Opus > Sonnet > Haiku** と定義する。同一 family 内では **generation が効く**（Opus 4.8 は Opus 5 の floor を**満たさない**）。
 
-- **Fable / cldf セッションは floor 行（上方向）の switch 提案を受けない**。Fable は全 floor の要求を満たす（monotonic の最上位）うえ、`fable-orchestrator-prompt.md` で独自の委譲契約を持つため、Opus 契約に合わせる上方向の提案は構造的に矛盾する。下方向（過剰スペックの解消）は「over-provision 閾値ゲート」の対象で、**Fable セッションも免除されない**。
-- over-provisioning（Fable で trivial をこなす等）は毎回は停止しないが、累積が閾値を超えたら 1 回だけ blocking する（「over-provision 閾値ゲート」参照）。cldf でも exit → `cld --continue` で orchestrator 契約ごと降りられるため、「是正不能」ではない。
+判定は **2 パス**で構成する（詳細は「判定と出力」）。**floor パス（上方向）を通過しても判定は終わらず、必ず over-provision パス（下方向）に進む**——ここが over-provision ゲートに到達する唯一の経路なので、floor パスを「無条件 silent pass」で早期 return してはならない:
+
+1. **floor パス**: 「現在の tier ≥ 行が要求する tier」なら floor をパスする（floor の switch 提案は出さず、プロンプトも出さない）。下回る場合のみ floor 行で blocking する。
+2. **over-provision パス**: floor 通過後、「現在の tier が行の要求より上位（過剰）」かつ trivial/small なら、FYI + カウンタ + 閾値ゲートに進む（「over-provision 閾値ゲート」）。floor と要求が同 tier（過剰でない）なら何もせず終了する。
+
+- **Fable / cldf セッションは floor 行（上方向）の switch 提案を受けない**。Fable は全 floor の要求を満たす（monotonic の最上位）うえ、`fable-orchestrator-prompt.md` で独自の委譲契約を持つため、Opus 契約に合わせる上方向の提案は構造的に矛盾する。下方向（過剰スペックの解消）は over-provision パスの対象で、**Fable セッションも免除されない**。
+- over-provisioning（Fable で trivial をこなす等）は毎回は停止しないが、累積が閾値を超えたら 1 回だけ blocking する（「over-provision 閾値ゲート」参照）。cldf でも exit → profile に応じた `cld` / `cld-r06` の `--continue` で orchestrator 契約ごと降りられるため、「是正不能」ではない。
 
 ## model の検出
 
 1. **主経路**: セッションの system-prompt に埋め込まれた model identity（自己申告。「You are powered by ...」等）を読む。
-   **主経路が Fable と解決したら、この時点で silent pass し副経路の cross-check も行わない**。`cldf` 系は `--model claude-fable-5` を argv で渡す（`home/dot_config/zsh/claude.zsh` の `_claude_fable`）ため settings.json とは**構造的に必ず乖離**し、cross-check は常に偽陽性になる。
+   **主経路が Fable と解決したら、副経路の cross-check はスキップする**（floor 判定を pass にするだけで、判定は終了せず over-provision パスに進む —— Fable も over-provision ゲートの対象だから）。`cldf` 系は `--model claude-fable-5` を argv で渡す（`home/dot_config/zsh/claude.zsh` の `_claude_fable`）ため settings.json とは**構造的に必ず乖離**し、cross-check は常に偽陽性になる。
 2. **副経路（cross-check）**: **主経路が Fable 以外のときのみ実行する**。`~/.claude/settings.json` の `model` を Read で読む（`cld-r06` セッションでも同じパスでよい —— `~/.claude-r06/settings.json` は `~/.claude/settings.json` への symlink であり、両アカウントは 1 つの settings.json を共有する。chezmoi source: `dot_claude-r06/symlink_settings.json.tmpl`）。これは `/model` によるセッション内変更を反映しない可能性があるため、**主経路と乖離したら silent に解決せず surface する**（どちらが有効かを user に提示して確認）。
 
 ### 正規化ルール
@@ -47,7 +52,7 @@ argument-hint: "<work tier>（例: orchestration / large / trivial-small）"
 
 ## 判定と出力
 
-作業の行種別に応じて分岐する:
+判定は capability 節の 2 パス（floor → over-provision）に沿って進む。**floor パスが pass でもそこで終了せず、over-provision パスに進む**（これがゲートに到達する唯一の経路）。作業の行種別に応じて次のように分岐する:
 
 ### floor 行（Opus 5 @ high / Opus 5 @ xhigh）で mismatch
 
@@ -62,7 +67,7 @@ argument-hint: "<work tier>（例: orchestration / large / trivial-small）"
 
 ### trivial / small 行
 
-**non-blocking の一行 FYI** に留める。「trivial/small tier は Sonnet 5 @ medium で十分（現在より下げればコストが浮く）」程度の cost hint を出すだけで、**workflow を止めない**。trivial/small は分類が実行前に終わらないため、ここで停止させると軽い path の摩擦を最大化する。
+この行は over-provision パスの本体（現在 tier > 要求 tier の過剰ケース）。**non-blocking の一行 FYI** に留める。「trivial/small tier は Sonnet 5 @ medium で十分（現在より下げればコストが浮く）」程度の cost hint を出すだけで、**workflow を止めない**。trivial/small は分類が実行前に終わらないため、ここで停止させると軽い path の摩擦を最大化する。
 
 FYI を出すたびに over-provision カウンタを +1 する（「over-provision 閾値ゲート」参照）。毎回の FYI は non-blocking のまま維持し、blocking は閾値超過時の 1 回に限定する。
 
@@ -79,12 +84,14 @@ trivial/small の毎回 FYI とは別に、**過剰スペックの累積**を「
 - 「現在の tier が行の要求より上位」と判定するたび（trivial/small FYI を出すたび）にカウンタを +1 する。
 - セッション内でのみ保持する（永続化しない）。**floor 判定の idempotency とは別カウンタ**（idempotency は同一判定の再提示の抑制、本カウンタは累積の検出で、性質が逆）。
 - ゲート発火時、および continue anyway 選択時にリセットする。
+- **compaction 対策**: カウンタを会話記憶だけに置くと context compaction で黙って 0 に戻り、特に red 帯（2 件）でゲートが実質死ぬ。カウンタを更新するたびに現在値を可視な形で残し（例: FYI 行末に `[over-provision: N]`）、compaction 後はその最新値を継承する。idempotency（二値の pass/continue-anyway）より復元が難しいため、この明示記録が必要。
 
 ### シグナル 2: 実測 quota 圧力（statusline snapshot）
 
-`~/.cache/claude-statusline/rate_limits_<profile>.json` を Read する（statusline が stdin の `rate_limits` を書き出す snapshot。`<profile>` は `CLAUDE_CONFIG_DIR` の basename、既定 `.claude`）。`five_hour.used_percentage` を圧力として使う。
+`${XDG_CACHE_HOME:-$HOME/.cache}/claude-statusline/rate_limits_<profile>.json` を Read する（statusline が stdin の `rate_limits` を書き出す snapshot。**パスは writer と同じ XDG フォールバック式で解決し、`~/.cache` 決め打ちにしない** —— `XDG_CACHE_HOME` を設定した環境で誤って「snapshot 無し」と誤判定しないため。`<profile>` は `CLAUDE_CONFIG_DIR` の basename、既定 `.claude`）。`five_hour.used_percentage` を圧力として使う。
 
-- **staleness ガード**: `ts` が 15 分より古い、またはファイルが無い場合は quota 不明として count-only fallback（下表）に切り替える。silent skip はしない（fail-safe）。
+- **staleness / 欠損ガード**: 次のいずれかで quota 不明として count-only fallback（下表）に切り替える —— (a) ファイルが無い、(b) `ts` が 15 分より古い、(c) `five_hour.used_percentage` が欠落・非数値（writer は `five_hour` が無効でも `seven_day` だけの snapshot を書くため、fresh でも 5h が無いことがある）。silent skip はしない（fail-safe）。
+- **（要検証）Team プランの rate_limits**: `rate_limits` が statusline stdin に現れるのは公式には **Pro/Max のみ明記**（Team premium seat での populate は未確認）。Team で欠落する場合、本ゲートは常に count-only fallback で動く（実測圧力シグナルは使えないが、カウンタベースのゲートは機能する）。
 
 ### 発火条件（named constants）
 
@@ -106,7 +113,7 @@ trivial/small の毎回 FYI とは別に、**過剰スペックの累積**を「
   2. continue anyway（カウンタをリセットし、次の閾値まで沈黙）
   3. abort
 - **cldf 系（Fable orchestrator）**:
-  1. exit → `cld --continue` で再開（推奨。orchestrator prompt は argv 注入のため再起動で契約ごと降りられ、会話文脈は保持される）
+  1. exit → profile に応じた `cld` / `cld-r06` で `--continue` 再開（推奨。orchestrator prompt は argv 注入のため再起動で契約ごと降りられ、会話文脈は保持される）。**アカウントを取り違えない**: `cldf-r06`（`CLAUDE_CONFIG_DIR` が `*.claude-r06`）なら `cld-r06 --continue`、それ以外は `cld --continue`。両アカウントはセッション状態が分離しており、誤ると無関係な default セッションを再開してしまう
   2. `/model opus` 等でセッション内切替（**注記必須**: system-prompt の自己申告 model identity が古い値を残すため、以後の本 skill の主経路検出を信用せず、切替済みであることをセッション内に記録する）
   3. continue anyway（カウンタをリセット）
 

--- a/home/dot_claude/executable_statusline.sh
+++ b/home/dot_claude/executable_statusline.sh
@@ -306,8 +306,10 @@ write_harness_cost() {
 # gate on measured quota pressure instead of guessing from session length.
 write_rate_limits_snapshot() {
   local fh_pct="$1" fh_reset="$2" sd_pct="$3" sd_reset="$4" effort="$5"
-  # API-key auth sessions never populate rate_limits on stdin; skip silently
-  # and leave any prior snapshot in place (the reader ages it out via ts).
+  # rate_limits is absent on stdin for API-key auth sessions, and also for
+  # subscription sessions before the first API response lands. Either way, skip
+  # silently and leave any prior snapshot in place (the reader ages it out via
+  # ts) rather than clobbering a still-fresh window with an empty one.
   [ -n "$fh_pct" ] || [ -n "$sd_pct" ] || return 0
   # Same JSON-number regex as write_harness_cost. Reject each field
   # independently so one malformed value can't sink the other window.
@@ -346,8 +348,18 @@ write_rate_limits_snapshot() {
     fi
   fi
 
-  local target="$CACHE_DIR/rate_limits_${profile}.json" tmpf
-  tmpf=$(mktemp "$CACHE_DIR/rate_limits_${profile}.XXXXXX" 2>/dev/null) || return 0
+  # Match write_harness_cost: umask 077 so the temp file is 0600 regardless of
+  # the caller's umask. CACHE_DIR is already chmod 700, but that chmod swallows
+  # errors (2>/dev/null), so a pre-existing loosely-permissioned XDG_CACHE_HOME
+  # would otherwise leak quota/effort data to group/other. Belt and suspenders.
+  local target="$CACHE_DIR/rate_limits_${profile}.json" tmpf old_umask
+  old_umask=$(umask)
+  umask 077
+  tmpf=$(mktemp "$CACHE_DIR/rate_limits_${profile}.XXXXXX" 2>/dev/null) || {
+    umask "$old_umask"
+    return 0
+  }
+  umask "$old_umask"
   if printf '{"ts":%s,"profile":"%s",%s%s"effort":"%s"}' \
     "$(date +%s)" "$profile" "$fh_json" "$sd_json" "$effort_out" >"$tmpf" 2>/dev/null; then
     mv -f "$tmpf" "$target" 2>/dev/null || rm -f "$tmpf" 2>/dev/null

--- a/home/dot_claude/executable_statusline.sh
+++ b/home/dot_claude/executable_statusline.sh
@@ -299,7 +299,64 @@ write_harness_cost() {
     rm -f "$tmpf" 2>/dev/null
   fi
 }
+# Rate-limits snapshot contract: persist the harness-reported quota pressure
+# (five_hour/seven_day used_percentage + resets_at) and the current effort
+# level to a per-profile cache file, the same "statusline -> file -> reader"
+# contract write_harness_cost uses above. model-fitness-check reads this to
+# gate on measured quota pressure instead of guessing from session length.
+write_rate_limits_snapshot() {
+  local fh_pct="$1" fh_reset="$2" sd_pct="$3" sd_reset="$4" effort="$5"
+  # API-key auth sessions never populate rate_limits on stdin; skip silently
+  # and leave any prior snapshot in place (the reader ages it out via ts).
+  [ -n "$fh_pct" ] || [ -n "$sd_pct" ] || return 0
+  # Same JSON-number regex as write_harness_cost. Reject each field
+  # independently so one malformed value can't sink the other window.
+  local num_re='^(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?$'
+  [[ "$fh_pct" =~ $num_re ]] || fh_pct=""
+  [[ "$fh_reset" =~ $num_re ]] || fh_reset=""
+  [[ "$sd_pct" =~ $num_re ]] || sd_pct=""
+  [[ "$sd_reset" =~ $num_re ]] || sd_reset=""
+  # Both windows may have been invalidated above; re-check before writing.
+  [ -n "$fh_pct" ] || [ -n "$sd_pct" ] || return 0
+
+  # ~/.claude and ~/.claude-r06 share this script and CACHE_DIR, so the
+  # profile (derived from CLAUDE_CONFIG_DIR, same as the line-1 badge) must
+  # be baked into the filename to keep the two accounts' snapshots apart.
+  local profile=${CLAUDE_CONFIG_DIR##*/}
+  [ -n "$profile" ] || profile=".claude"
+  profile=$(printf '%s' "$profile" | tr -c 'A-Za-z0-9._-' '_')
+  local effort_out
+  effort_out=$(printf '%s' "$effort" | tr -c 'A-Za-z0-9_-' '_')
+
+  # Build each window fragment only from validated fields; an empty fragment
+  # omits the whole window object rather than emit a null/garbage value.
+  local fh_json="" sd_json=""
+  if [ -n "$fh_pct" ]; then
+    if [ -n "$fh_reset" ]; then
+      fh_json="\"five_hour\":{\"used_percentage\":${fh_pct},\"resets_at\":${fh_reset}},"
+    else
+      fh_json="\"five_hour\":{\"used_percentage\":${fh_pct}},"
+    fi
+  fi
+  if [ -n "$sd_pct" ]; then
+    if [ -n "$sd_reset" ]; then
+      sd_json="\"seven_day\":{\"used_percentage\":${sd_pct},\"resets_at\":${sd_reset}},"
+    else
+      sd_json="\"seven_day\":{\"used_percentage\":${sd_pct}},"
+    fi
+  fi
+
+  local target="$CACHE_DIR/rate_limits_${profile}.json" tmpf
+  tmpf=$(mktemp "$CACHE_DIR/rate_limits_${profile}.XXXXXX" 2>/dev/null) || return 0
+  if printf '{"ts":%s,"profile":"%s",%s%s"effort":"%s"}' \
+    "$(date +%s)" "$profile" "$fh_json" "$sd_json" "$effort_out" >"$tmpf" 2>/dev/null; then
+    mv -f "$tmpf" "$target" 2>/dev/null || rm -f "$tmpf" 2>/dev/null
+  else
+    rm -f "$tmpf" 2>/dev/null
+  fi
+}
 write_harness_cost "$cost" "$session_id"
+write_rate_limits_snapshot "$fh_pct" "$fh_reset" "$sd_pct" "$sd_reset" "$effort"
 
 # ---------------------------------------------------------------------------
 # Line 1: host | dir | branch *dirty ⇡ahead⇣behind | worktree

--- a/home/dot_claude/fable-orchestrator-prompt.md
+++ b/home/dot_claude/fable-orchestrator-prompt.md
@@ -74,8 +74,10 @@ Sonnet 5 は指示に literal に従い（特に低い effort レベルでは顕
   effort で動く。**どの agent がどの tier かは各 agent 定義の frontmatter が SSOT**
   （この prompt に値を再掲しない）。
 - **Fable セッション（このセッション）は §4 model/effort contract の全行を常に満たす**
-  （monotonic: Fable > Opus > Sonnet > Haiku）。`model-fitness-check` ゲートは Fable に
-  対して switch 提案を出さない。委譲既定（`model: sonnet`）はこの effort pin 導入後も不変。
+  （monotonic: Fable > Opus > Sonnet > Haiku）。`model-fitness-check` の **floor 判定**は
+  Fable に対して switch 提案を出さない。ただし **over-provision 閾値ゲート（下方向の降格提案）は
+  Fable セッションにも適用される**（軽作業で quota を浪費した累積が閾値を超えたときのみ 1 回 blocking）。
+  委譲既定（`model: sonnet`）はこの effort pin 導入後も不変。
 
 `CLAUDE_CODE_SUBAGENT_MODEL` は起動側で意図的に**未設定**にしてある（この env var は
 per-invocation `model` param・agent frontmatter より最優先で全 subagent を固定するため、

--- a/tests/statusline.bats
+++ b/tests/statusline.bats
@@ -137,3 +137,14 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$(cat "$snapshot")" != *not_a_number* ]]
 }
+
+# Guards the umask-077 bracket around the snapshot's mktemp: the file holds
+# quota-pressure data and must stay 0600 even when the session runs under a lax
+# umask (mktemp otherwise honors the ambient umask, e.g. 000 -> 0666).
+@test "statusline writes the rate-limits snapshot as 0600 even under a lax umask" {
+  run bash -c "umask 000; printf '%s' '${MOCK_JSON_RL}' | XDG_CACHE_HOME='${RL_CACHE_HOME}' CLAUDE_CONFIG_DIR='' bash '${SCRIPT}'"
+  [ "$status" -eq 0 ]
+  local snapshot="${RL_CACHE_HOME}/claude-statusline/rate_limits_.claude.json"
+  [ -f "$snapshot" ]
+  [ "$(_file_mode "$snapshot")" = "600" ]
+}

--- a/tests/statusline.bats
+++ b/tests/statusline.bats
@@ -10,13 +10,30 @@ load helpers/setup
 SCRIPT="${HOME_DIR}/dot_claude/executable_statusline.sh"
 MOCK_JSON='{"model":{"display_name":"TestModel"},"effort":{"level":"high"},"workspace":{"current_dir":"/tmp","project_dir":"/tmp"},"context_window":{"remaining_percentage":50},"cost":{"total_cost_usd":1.23},"session_id":"bats-statusline"}'
 
+# Same as MOCK_JSON but with a rate_limits block, exercising the
+# write_rate_limits_snapshot contract.
+MOCK_JSON_RL='{"model":{"display_name":"TestModel"},"effort":{"level":"high"},"workspace":{"current_dir":"/tmp","project_dir":"/tmp"},"context_window":{"remaining_percentage":50},"cost":{"total_cost_usd":1.23},"rate_limits":{"five_hour":{"used_percentage":42,"resets_at":1700000000},"seven_day":{"used_percentage":17.5,"resets_at":1700600000}},"session_id":"bats-statusline"}'
+
+# Same as MOCK_JSON_RL but five_hour.used_percentage is not a JSON number;
+# seven_day stays valid so we can assert per-field (not whole-write) rejection.
+MOCK_JSON_RL_INVALID='{"model":{"display_name":"TestModel"},"effort":{"level":"high"},"workspace":{"current_dir":"/tmp","project_dir":"/tmp"},"context_window":{"remaining_percentage":50},"cost":{"total_cost_usd":1.23},"rate_limits":{"five_hour":{"used_percentage":"not_a_number","resets_at":1700000000},"seven_day":{"used_percentage":17.5,"resets_at":1700600000}},"session_id":"bats-statusline"}'
+
 # Every test that pipes MOCK_JSON exercises write_harness_cost (the harness-cost
 # contract), which writes a cache file keyed by session_id into the resolved
 # tmpdir. Clean it up so the suite leaves no stray tmpdir artifacts.
 HARNESS_COST_FILE="${TMPDIR:-/tmp}"
 HARNESS_COST_FILE="${HARNESS_COST_FILE%/}/harness-cost-bats-statusline.json"
+
+# write_rate_limits_snapshot writes under $XDG_CACHE_HOME/claude-statusline, so
+# give each test its own throwaway XDG_CACHE_HOME instead of touching the
+# real ~/.cache.
+setup() {
+  RL_CACHE_HOME="$(mktemp -d)"
+}
+
 teardown() {
   rm -f "$HARNESS_COST_FILE" 2>/dev/null || true
+  rm -rf "$RL_CACHE_HOME" 2>/dev/null || true
 }
 
 @test "statusline script is present" {
@@ -73,4 +90,50 @@ teardown() {
   [ -f "$HARNESS_COST_FILE" ]
   run jq -e '.cost_usd == 1.23 and (.ts | type == "number")' "$HARNESS_COST_FILE"
   [ "$status" -eq 0 ]
+}
+
+# Guards the rate-limits-snapshot contract: model-fitness-check reads
+# $CACHE_DIR/rate_limits_<profile>.json to see measured quota pressure
+# (five_hour/seven_day used_percentage + resets_at) and the current effort.
+@test "statusline writes a valid rate-limits snapshot for the default profile" {
+  run bash -c "printf '%s' '${MOCK_JSON_RL}' | XDG_CACHE_HOME='${RL_CACHE_HOME}' CLAUDE_CONFIG_DIR='' bash '${SCRIPT}'"
+  [ "$status" -eq 0 ]
+  local snapshot="${RL_CACHE_HOME}/claude-statusline/rate_limits_.claude.json"
+  [ -f "$snapshot" ]
+  run jq -e '
+    (.ts | type == "number") and
+    .five_hour.used_percentage == 42 and
+    .five_hour.resets_at == 1700000000 and
+    .seven_day.used_percentage == 17.5 and
+    .seven_day.resets_at == 1700600000 and
+    .effort == "high"
+  ' "$snapshot"
+  [ "$status" -eq 0 ]
+}
+
+@test "statusline writes no rate-limits snapshot when stdin has no rate_limits" {
+  run bash -c "printf '%s' '${MOCK_JSON}' | XDG_CACHE_HOME='${RL_CACHE_HOME}' CLAUDE_CONFIG_DIR='' bash '${SCRIPT}'"
+  [ "$status" -eq 0 ]
+  [ ! -f "${RL_CACHE_HOME}/claude-statusline/rate_limits_.claude.json" ]
+  run bash -c "ls '${RL_CACHE_HOME}/claude-statusline'/rate_limits_* 2>/dev/null"
+  [ -z "$output" ]
+}
+
+@test "statusline separates rate-limits snapshots by CLAUDE_CONFIG_DIR profile" {
+  run bash -c "printf '%s' '${MOCK_JSON_RL}' | XDG_CACHE_HOME='${RL_CACHE_HOME}' CLAUDE_CONFIG_DIR='${HOME}/.claude-r06' bash '${SCRIPT}'"
+  [ "$status" -eq 0 ]
+  [ -f "${RL_CACHE_HOME}/claude-statusline/rate_limits_.claude-r06.json" ]
+  [ ! -f "${RL_CACHE_HOME}/claude-statusline/rate_limits_.claude.json" ]
+}
+
+@test "statusline drops an invalid rate-limits field instead of writing it" {
+  run bash -c "printf '%s' '${MOCK_JSON_RL_INVALID}' | XDG_CACHE_HOME='${RL_CACHE_HOME}' CLAUDE_CONFIG_DIR='' bash '${SCRIPT}'"
+  [ "$status" -eq 0 ]
+  local snapshot="${RL_CACHE_HOME}/claude-statusline/rate_limits_.claude.json"
+  [ -f "$snapshot" ]
+  # five_hour must be absent (its used_percentage was non-numeric); seven_day
+  # (still valid) must be present and untouched by the invalid sibling field.
+  run jq -e '(.five_hour | not) and .seven_day.used_percentage == 17.5' "$snapshot"
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$snapshot")" != *not_a_number* ]]
 }


### PR DESCRIPTION
## Summary

Adds an **over-provision threshold gate**: a mechanism that notices when a session
keeps doing lightweight work on an oversized model (e.g. Fable/Opus on trivial
tasks) and blocks **once** — only when measured subscription-quota pressure makes
the waste real. Related issue: #352 (kept out of scope; separate cleanup).

### statusline: rate-limit snapshot writer

- New `write_rate_limits_snapshot` in `home/dot_claude/executable_statusline.sh`:
  persists the harness-reported quota pressure (`rate_limits.five_hour` /
  `seven_day` `used_percentage` + `resets_at`) and the current `effort` level to
  `$CACHE_DIR/rate_limits_<profile>.json`, following the existing
  `write_harness_cost` "statusline → file → reader" contract.
- Snapshots are keyed by `CLAUDE_CONFIG_DIR` profile: the two accounts share this
  script and cache dir, and cross-session clobbering was observed empirically.
- API-key sessions (no `rate_limits` on stdin) skip the write; every numeric field
  is validated independently with the same JSON-number regex as
  `write_harness_cost` before it can reach the JSON body.
- The temp file is written inside a `umask 077` bracket so the snapshot stays
  `0600` even under a lax caller umask — it holds quota/effort data — matching
  `write_harness_cost`.

### model-fitness-check: over-provision threshold gate

- New SKILL.md section: a **two-signal** gate — a session-local over-provision
  counter (incremented on every trivial/small FYI) × measured quota pressure read
  from the snapshot. It fires one blocking `AskUserQuestion` only in the yellow
  (≥ 50% → 5 hits) / red (≥ 80% → 2 hits) bands, matching the statusline
  `pct_color` tiers; below 50% it never blocks. The band is driven by
  `max(five_hour, seven_day)` `used_percentage` — the weekly window maps to the
  crowd-out harm the gate is framed around, while the 5-hour window still catches
  short-burst exhaustion. A count-only fallback (5 hits) applies when the snapshot
  is missing, stale (> 15 min), or both windows lack a numeric `used_percentage`.
- Capability judgment is structured as an explicit **two-pass** flow — floor pass
  (upward) then over-provision pass (downward) — so a floor pass no longer
  early-returns before the gate. This was the core defect the first review round
  surfaced: the monotonic "unconditional silent pass" made the gate unreachable
  dead code.
- The Fable/cldf exemption is narrowed to **upward (floor) switch proposals
  only**; the downgrade gate now applies to Fable sessions too. On Fable model
  detection only the settings cross-check is skipped (not the whole judgment), so
  Fable sessions still reach the over-provision pass.
- The recommended de-escalation for a Fable session is `exit → cld --continue`
  (or `cld-r06 --continue` on the `.claude-r06` account — the two accounts have
  isolated session state, so the profile must pick the right wrapper), which drops
  the argv-injected orchestrator prompt while keeping conversation context.
- The gate message frames the harm as **shared-quota crowd-out** (subscription
  plans: Max / Team premium — burning the shared weekly pool on light work starves
  the heavy work that actually needs the big model), quoting the measured window
  values, instead of dollar cost.
- The snapshot's `effort` field is noted as a non-authoritative second source for
  effort detection. The counter carries a compaction-survival marker so context
  compaction cannot silently reset it to 0 (which would neuter the 2-hit red
  band).
- Per-occurrence FYIs stay non-blocking; the gate counter is explicitly separate
  from the existing floor-check idempotency state.

### Design notes

- Investigated first: there is **no Fable-specific usage window** (officially,
  Fable draws from the shared weekly pool with a 50%-of-weekly cap), and the
  statusline stdin `rate_limits` schema only exposes the aggregate `five_hour` /
  `seven_day` windows (verified against a live probe, the official statusline
  docs, and the Claude Code CHANGELOG). Hence the aggregate-pressure design; a
  Fable-share estimation segment was considered and rejected as out of scope.
- **Plan eligibility for `rate_limits`**: the official statusline docs
  (`code.claude.com/docs/en/statusline`) enumerate `rate_limits` for "Claude.ai
  subscribers (Pro/Max)" only, but a live check on the `cld-r06` Team premium seat
  confirmed `rate_limits` IS populated there (both `five_hour` and `seven_day`
  present with plausible `resets_at`) — the docs' Pro/Max-only list is incomplete
  for Team premium. So the measured-pressure signal is available on both accounts
  and the yellow/red bands are reachable on `cld-r06` too. The count-only fallback
  stays a first-class path for genuine absence (pre-first-API-response, stale
  snapshot, or a missing `five_hour` window).

## Review round 2 (multi-review follow-up)

A multi-tool review (cc-code-review / cc-security-review / codex) found the gate
was unreachable dead code and flagged several supported-configuration bugs. All
blocker (P1) and SHOULD (P2/N) findings were addressed:

- **P1 ×2 — gate unreachable**: fixed via the two-pass restructure and the
  Fable-detection cross-check-only skip described above.
- **P2 — reader path**: the reader now resolves the snapshot via the writer's
  `${XDG_CACHE_HOME:-$HOME/.cache}` fallback instead of a hard-coded `~/.cache`.
- **P2 — incomplete snapshot**: a missing/non-numeric `five_hour.used_percentage`
  is treated as unknown and routed to the count-only fallback (the writer may emit
  a `seven_day`-only snapshot).
- **P2 — account restart**: a `cldf-r06` session restarts with `cld-r06 --continue`
  (not `cld`) to preserve the active account.
- **N1 — snapshot permissions**: `umask 077` bracket + a bats regression test
  asserting the snapshot is `0600` under `umask 000`.
- **N2 — comment accuracy**: documented that subscription sessions also lack
  `rate_limits` before the first API response, so absence must not clobber a
  still-fresh snapshot (the codex "clear on absence" suggestion was rejected for
  this reason).
- **Follow-up from the live `cld-r06` check — firing window**: the live data
  (`five_hour` 1% but `seven_day` 53%) exposed that a 5-hour-only signal stays
  silent under real weekly-pool pressure. The band now reads
  `max(five_hour, seven_day)` so it tracks the weekly crowd-out the gate is framed
  around, not just the 5-hour burst window.

## Test plan

- [x] `make lint` — shellcheck / shfmt / zsh syntax all clean
- [x] `make test` — 211 bats tests passing (includes 5 new statusline tests:
  valid write, absent `rate_limits`, per-profile filename isolation,
  malformed-value rejection, and the `0600`-under-lax-umask permission
  regression)

## Checklist

- [ ] コードレビューが完了している
- [x] テストケースが追加されている
