### PR TITLE
feat(ntfy): username/password device auth, one-command setup + rotation

### DIFF
--- a/.claude/prds/337-ntfy-setup-rotation.prd.md
+++ b/.claude/prds/337-ntfy-setup-rotation.prd.md
@@ -1,0 +1,219 @@
+---
+slug: 337-ntfy-setup-rotation
+feature: Correct ntfy device auth to username/password and make setup + rotation a two-phase-aware command
+created_at: 2026-07-26T19:00:21+09:00
+grill_session: 8ee99923-4cfa-42ba-b680-1d51dbb3ffce
+status: finalized
+---
+
+# Background
+
+Self-hosted ntfy notifications (kryota-dev/dotfiles#337) were introduced in #350 and
+refined in #357. After #357 the write-only **publisher** token is written into
+`~/.config/ntfy/notify-env` (0600 runtime state); the read-only **subscriber** credential
+and the **base-url** still live in the `Dotfiles - ntfy` 1Password item.
+
+Three problems now stand:
+
+1. **The device-auth model is wrong (empirically confirmed).** #350/#357 provision a
+   read-only **subscriber token** and tell the user to enter it on each phone. In practice
+   the ntfy iOS app cannot authenticate to the self-hosted server with a token — only a
+   username/password login works. The ntfy phone docs describe the app's auth as mutually
+   exclusive: *"If you have a user configured for a server, you cannot add an `Authorization`
+   header for that server, as ntfy sets this header automatically. Similarly, if you have a
+   custom `Authorization` header, you cannot add a user for that server."* The first-class
+   path is **username/password** (app auto-sets Basic Auth); a token only works via the
+   manual **custom `Authorization: Bearer` header** path, which did not work on iOS. The
+   subscriber user is currently created with a *throwaway* random password that is discarded,
+   so no usable device credential ever exists.
+2. **Initial setup is manual and order-fragile.** The user must hand-create the 1Password
+   item (looking up the tailnet MagicDNS name for `base-url`) before `chezmoi apply`, or the
+   validate gate hard-fails. And at first setup **Tailscale is not yet `up` and Docker
+   Desktop is not running**, so server-dependent provisioning cannot complete during the
+   first apply — it is inherently **two-phase**.
+3. **Key rotation is a manual, error-prone multi-command dance** with no single entry point.
+
+Verified primary-source facts driving the design:
+
+- **Device (mobile app) auth = username/password.** Token auth on the app requires the
+  manual custom-`Authorization`-header path (empirically non-working on iOS). Basic Auth
+  (`curl -u user:pass`) is universally supported (docs.ntfy.sh/config).
+- **Publisher (HTTP API / curl) auth with a Bearer token works** — the iOS-app limitation
+  does not apply to the local curl publisher, so the publisher token in notify-env stays.
+- **ntfy user CLI:** `ntfy user add <u>`, `ntfy user del <u>`, `ntfy user change-pass <u>`,
+  `ntfy user list`; `ntfy access <u> <topic> ro` grants read-only. `NTFY_PASSWORD` env sets
+  the password non-interactively for **both** `user add` and `user change-pass` (verified in
+  the ntfy CLI source `cmd/user.go`: `change-pass` UsageText shows
+  `NTFY_PASSWORD=... ntfy user change-pass USERNAME` and `execUserChangePass` reads
+  `os.Getenv("NTFY_PASSWORD")`).
+- **ntfy token CLI:** `ntfy token add <u>` is additive (max 60/user, does not invalidate
+  others); revoke with `ntfy token remove <u> <token>`; only deleting `user.db` invalidates
+  everything at once.
+- **ntfy `base-url` is optional for core messaging** (docs.ntfy.sh) — required only for
+  attachments and email footer links (both unused here); it does not affect the
+  `upstream-base-url` iOS relay and is not mandated by `behind-proxy: true`.
+- **chezmoi `output` aborts template execution on a non-zero exit** and runs every apply, so
+  deriving base-url via `{{ output "tailscale" … }}` would hard-fail `chezmoi apply` when
+  Tailscale is down — incompatible with the fail-open contract.
+- **`run_onchange` re-fires only on a rendered-hash change** and records exit-0, so an
+  existing machine will not re-provision (or restart a downed container) via `chezmoi apply`
+  alone — a re-runnable command is required.
+
+# User Story
+
+As the single operator of this repo, I want a fresh machine's ntfy notifications set up (and
+a leaked credential rotated, or a downed container brought back) with **one re-runnable
+command** that understands the two-phase reality, and I want my phones to actually
+authenticate — logging in with a username and password read from 1Password — without the
+tailnet name or a publisher token ever landing in the public repo or in 1Password
+unnecessarily.
+
+# Acceptance Criteria
+
+- **AC-001** Device authentication uses a **subscriber username + password**, not a token.
+  The `subscriber` ntfy user is a read-only user (read-only ACL on the topics) provisioned
+  with a **known, strong, generated password**; the `Dotfiles - ntfy` 1Password item holds
+  `subscriber-username` (value `subscriber`) and `subscriber-password` (concealed). The
+  subscriber-token concept is removed.
+- **AC-002** The publisher path is unchanged in principle: a write-only token is issued and
+  written into `~/.config/ntfy/notify-env` (0600 via `umask 077`, heredoc, no `set -x`,
+  never echoed/traced), matching the wrapper-sourced format. Publisher auth is API/Bearer,
+  unaffected by the mobile-app limitation.
+- **AC-003** `base-url` is fully removed from the 1Password path: (a) the `base-url:` line and
+  its `onepasswordRead` call in `private_server.yml.tmpl`; (b) the `Dotfiles - ntfy/base-url`
+  entry in the `run_once_after_11` ITEMS array; **and (c) the separate base-url
+  format-validation stanza in the same script** (the `op read …/base-url` + `https://*.ts.net`
+  check) — leaving (c) in place would hard-fail `chezmoi apply` once the field is gone. The
+  tailnet MagicDNS URL is never stored; it is derived on demand for human-facing steps only
+  (device login server URL, smoke test) via `tailscale status --json | jq -r .Self.DNSName`
+  (trailing dot stripped, `https://` prepended). `onepassword-vault-item-count` FACT → **4**.
+- **AC-004** A shared bash library is the SSOT for the whole ntfy lifecycle (bring-up +
+  provision + rotate). It is a chezmoi template `home/dot_config/ntfy/lib.sh.tmpl` →
+  `~/.config/ntfy/lib.sh` (no secrets, mode 644) that bakes in the `.ntfy.*` constants
+  (`port`, `topic_attention`, `topic_done`) via lint-safe assignment-only lines. Both
+  `run_onchange_after_31-setup-ntfy` and the `ntfy-setup` command source it; provisioning
+  logic is not duplicated. The lib's hash is added to `run_onchange_after_31`'s embedded
+  re-trigger hashes so a lib change re-fires the apply-time path.
+- **AC-005** The library creates the `Dotfiles - ntfy` 1Password item **only when it is
+  absent** (`op item get` fails) — a create-time non-destructive guard — via `op item create`
+  as a Secure Note holding `subscriber-username=subscriber` and a `subscriber-password`
+  bootstrap placeholder. It never touches an existing item's pre-existing fields, is
+  idempotent, and warns-and-continues (fail-open) on any op failure.
+- **AC-006** Provisioning issues the publisher token → notify-env, and creates (fresh) or
+  repairs (existing) the read-only `subscriber` user with a generated password
+  (`NTFY_PASSWORD=… ntfy user add` when absent, else `… ntfy user change-pass`), then writes
+  the password into the item's `subscriber-password` field via `op item edit`. The subscriber
+  half requires `op`; its absence is a warn-and-continue skip that does not fail the publisher
+  half. **Secret hygiene:** the generated password reaches ntfy via the `NTFY_PASSWORD` env
+  (never argv); the only argv exposure is the local `op item edit field=value` call — the
+  same documented, transient trade-off already accepted for tokens (op offers no stdin path
+  for single-field edits); no `set -x`, never echoed.
+- **AC-007** `ntfy-setup` (deployed `~/.local/bin/ntfy-setup`, on PATH; source
+  `home/dot_local/bin/executable_ntfy-setup`) is idempotent and re-runnable and performs the
+  **full lib flow**: start the container (`docker compose up -d --remove-orphans`), assert
+  `tailscale serve --bg`, then provision/repair both credentials. It fails **clearly** (prints
+  the missing prerequisite and exits non-zero) only when a prerequisite it cannot fix itself
+  is absent — Docker Desktop daemon not running, or Tailscale not `up`/logged-in. Distinct
+  non-zero exit codes distinguish "prerequisite unmet" from "operation error". Non-darwin: the
+  binary is `.chezmoiignore`d (mirroring the existing `.config/ntfy` exclusion).
+- **AC-008** `ntfy-setup --rotate publisher|subscriber|all` rotates:
+  - *publisher* — **read the current token from notify-env first**, issue a new token, write
+    notify-env, then `ntfy token remove` the previously-read old token (correct order so the
+    genuinely-old, possibly-leaked token is the one revoked).
+  - *subscriber* — `NTFY_PASSWORD=<new> ntfy user change-pass subscriber` (preserves the user
+    and its ACLs; no del/re-add gap), then update the 1Password `subscriber-password`.
+  When real (non-placeholder) credentials already exist and no `--rotate` flag is given, it
+  prompts via `/dev/tty` ("credentials already exist — rotate? [y/N]"); if `/dev/tty` cannot
+  be opened (non-interactive), it defaults to **N (skip)**, consistent with fail-open.
+  Subscriber rotation prints a reminder that every device must re-enter the new password.
+- **AC-009** `install/install.sh` stays thin (still just bootstraps chezmoi) and does **not**
+  attempt ntfy provisioning at bootstrap; it prints a closing note that ntfy notifications
+  need Tailscale `up` + Docker running, after which the user runs `ntfy-setup`.
+- **AC-010** `run_onchange_after_31-setup-ntfy` stays fail-open (exit 0) on any missing
+  docker/tailscale/op and delegates the whole flow to `lib.sh`; a clean install self-heals,
+  and the documented recovery/repair path for existing machines (downed container, throwaway
+  subscriber password, credential rotation) is the single `ntfy-setup` command.
+- **AC-011** Docs (EN + JA mirrors: `notifications`, `secrets-1password`, `lifecycle-scripts`,
+  `secrets-and-isolation`, `ci-and-tests`) are updated: **device subscription uses a
+  username/password login (from 1Password), not a token**; setup runbook centered on
+  `ntfy-setup`; rotation via `ntfy-setup --rotate`; honest recovery semantics; on-demand
+  base-url derivation. The inaccurate "Re-issuing tokens invalidates every existing token"
+  sentence is corrected. Stale rationale that ties the CI exclusion of `server.yml` to
+  `onepasswordRead`/1Password (its own header comment, `ci-and-tests`, and the relevant
+  bats-test comments) is reworded to "no longer op-backed but kept excluded". The
+  pre-existing drift in `secrets-1password.md` (its "CI exclusions" list omits
+  `private_server.yml.tmpl` and states a stale count) is reconciled to the actual value and
+  given a machine-checkable FACT marker.
+- **AC-012** FACT markers are synced (`onepassword-vault-item-count` → 4;
+  `ci-both-exclusion-count` stays 7) and bats tests updated to pin the new behavior —
+  including the two `files.bats` ntfy tests that currently assert the *opposite* ("1password
+  ITEMS covers the ntfy item fields" asserting base-url present + `onepasswordRead …/base-url`
+  in server.yml; and the "CI excludes the ntfy onepasswordRead template" wording). `make test`
+  (lint + all bats) passes.
+- **AC-013** Backward compatible / self-migrating: the library never overwrites the existing
+  item, so an existing machine's now-unused fields (`base-url`, `credential`,
+  `subscriber-token`) are left untouched and harmless; `private_server.yml.tmpl` re-renders
+  without base-url and the container restart picks it up; the deployed `notify-env` is
+  unchanged. Running `ntfy-setup` on an existing machine **repairs** the subscriber user
+  (which had a throwaway password) to a known password via `change-pass` and records
+  `subscriber-username` + `subscriber-password` in 1Password. No destructive data migration.
+- **AC-014** No tailnet MagicDNS name or client/employer identifier literal appears in the
+  repo; commits, PR body, and docs are in English with no AI credit/signature.
+
+# Considered Alternatives / Rejection Rationale
+
+- **Device auth via read-only token (status quo of #350/#357)** — *Rejected / corrected.*
+  Empirically the ntfy iOS app cannot log in with a token; per the phone docs the token path
+  is the manual custom-`Authorization`-header route, which did not work on iOS. Username/
+  password (Basic Auth) is the app's first-class, working path. (AC-001)
+- **Subscriber password rotation via `ntfy user del` + `ntfy user add`** — *Rejected* in
+  favor of `ntfy user change-pass`: the CLI source confirms `change-pass` honors
+  `NTFY_PASSWORD` non-interactively, so it is scriptable **and** preserves the user's ACLs
+  with no window where the user does not exist — del+add would need a fragile ACL re-grant
+  step and a brief existence gap. (AC-008)
+- **Derive base-url via chezmoi `{{ output "tailscale" … }}`** — *Rejected.* `output` aborts
+  `chezmoi apply` on a non-zero exit and runs every apply, so a Tailscale-down machine would
+  hard-fail apply, violating fail-open. (AC-003)
+- **Store/derive base-url at all (1Password or runtime state)** — *Rejected.* base-url is
+  optional for our use; dropping it is simpler and removes the only op dependency from
+  server.yml. (AC-003)
+- **`ntfy-setup` that only *checks* preconditions (does not start the container)** —
+  *Rejected.* Because `run_onchange` won't re-fire, a check-only command cannot restart a
+  downed container after a reboot, breaking the "one re-runnable command" promise; the command
+  runs the full bring-up + provision flow via the shared lib. (AC-007, AC-010)
+- **`ntfy-setup` as a pure zsh function / a `~/.config/zsh/*.zsh` glob-source shim** —
+  *Rejected.* A bash lib sourced by both the apply script and a real on-PATH executable keeps
+  provisioning DRY and works from any shell/hook; and this repo has no zsh glob-source
+  mechanism — the real precedent is on-PATH executables under `~/.local/`
+  (`home/dot_local/launchers/…`, #358 launcher unification). (AC-004, AC-007)
+- **Auto-rotate via credential expiry + a scheduled job** — *Rejected.* Over-engineering for
+  a single-user fail-open path; expiry adds a silent-break failure mode. (AC-008)
+- **Assumption (auto-resolved, from the user's explicit direction):** the 1Password item is
+  auto-created when absent, the entry point is `ntfy-setup`, and it is run interactively after
+  Tailscale/Docker are up.
+
+# Out of Scope
+
+- Auto-deleting the now-unused `base-url` / `credential` / `subscriber-token` fields from an
+  existing item (optional, manual; harmless if left).
+- Auto-configuring subscriber devices (inherently manual username/password re-entry).
+- Scheduled/automatic credential expiry or rotation.
+- Attachments, email notifications, or Web Push (would require reintroducing base-url).
+- Changing the `notify-env` format or the hook wrapper (`~/.claude/ntfy-notify.sh`).
+- The publisher API-auth model (stays a Bearer token).
+- Removing `private_server.yml.tmpl` from the CI exclude list (it no longer calls
+  `onepasswordRead`, but stays excluded to minimize churn; `ci-both-exclusion-count` stays 7).
+
+# Open Questions
+
+- **Q1 (security surface — user-confirmed):** the library runs `op item create` to
+  auto-create the `Dotfiles - ntfy` item when absent, and `op item edit` to store the
+  subscriber password — automated writes to the 1Password vault, and the stored
+  `subscriber-password` is a real login secret (scoped read-only via ACL), a stronger secret
+  than the former read-only token. Accepted because it is the only credential the iOS app
+  accepts. Confirmed mechanism: create **only when absent** (never overwrite other fields),
+  Secure Note, `subscriber-username` + `subscriber-password` placeholder, fail-open on error.
+- **Q2:** iOS instant-push remains pending the first real smoke test; dropping base-url does
+  not affect the `upstream-base-url` relay per docs, but the smoke test should confirm
+  end-to-end iOS delivery once device username/password login is in place. (Verification, not
+  a design blocker.)

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ all: help
 ## Run shellcheck, shfmt check, and zsh syntax check
 lint:
 	@echo "==> Running shellcheck..."
-	@find home \( -name '*.sh' -o -name '*.sh.tmpl' \) ! -name 'symlink_*' | while read -r f; do \
-		sed '/{{/d' "$$f" | shellcheck --shell=bash --exclude=SC1091,SC2034,SC2086,SC2317,SC2329 -; \
+	@find home \( -name '*.sh' -o -name '*.sh.tmpl' -o -path 'home/dot_local/bin/executable_*' \) ! -name 'symlink_*' | while read -r f; do \
+		sed '/{{/d' "$$f" | shellcheck --shell=bash --exclude=SC1091,SC2034,SC2086,SC2317,SC2329 - || exit 1; \
 	done
 	@echo "==> Running shfmt check..."
-	@find home \( -name '*.sh' -o -name '*.sh.tmpl' \) ! -name 'symlink_*' | while read -r f; do \
-		sed '/{{/d' "$$f" | shfmt -d -i 2 -ci; \
+	@find home \( -name '*.sh' -o -name '*.sh.tmpl' -o -path 'home/dot_local/bin/executable_*' \) ! -name 'symlink_*' | while read -r f; do \
+		sed '/{{/d' "$$f" | shfmt -d -i 2 -ci || exit 1; \
 	done
 	@echo "==> Checking zsh syntax..."
 	@for f in home/dot_config/zsh/*.zsh; do zsh -n "$$f" || exit 1; done

--- a/docs/architecture/lifecycle-scripts.ja.md
+++ b/docs/architecture/lifecycle-scripts.ja.md
@@ -80,7 +80,7 @@ flowchart TD
 | `17-setup-claude-plugins` | `dot_claude/settings.json` |
 | `18-setup-agent-browser` | `dot_config/mise/config.toml` |
 | `30-register-launchd-agents` | `Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl` |
-| `31-setup-ntfy` | `dot_config/ntfy/compose.yaml.tmpl` + `dot_config/ntfy/private_server.yml.tmpl` |
+| `31-setup-ntfy` | `dot_config/ntfy/compose.yaml.tmpl` + `dot_config/ntfy/private_server.yml.tmpl` + `dot_config/ntfy/lib.sh.tmpl` |
 | `40-setup-sheldon` | `dot_config/sheldon/plugins.toml` |
 | `20-macos-defaults` | 自分自身のソースファイル（任意の編集で再トリガー） |
 
@@ -131,15 +131,20 @@ Xcode CLI ツール（macOS、`xcode-select -p` が成功するまでポーリ�
 
 ### 11 — validate-1password (`run_once`、after、macOS のみ)
 
-ハードゲートです。`op` がインストール済みかつ認証済みであることを確認し、<!-- FACT:onepassword-vault-item-count -->5<!-- /FACT --> つの必須 vault 参照に対して `op read` を呼び出します。
+ハードゲートです。`op` がインストール済みかつ認証済みであることを確認し、<!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> つの必須 vault 参照に対して `op read` を呼び出します。
 
 - `op://kryota.dev/Dotfiles - AWS Config/notesPlain`
 - `op://kryota.dev/Dotfiles - Exa API/credential`
 - `op://kryota.dev/Dotfiles - Firecrawl API/credential`
 - `op://kryota.dev/Dotfiles - Redact Patterns/pattern`
-- `op://kryota.dev/Dotfiles - ntfy/base-url`
 
-（ntfy の publisher トークンは意図的に含まれません: スクリプト 31 がこれを `~/.config/ntfy/notify-env` へランタイム状態として直接書き出すため、1Password には保存されず、ゲートがチェックする対象もありません。）
+（`Dotfiles - ntfy` アイテムはこのリストに意図的に含まれません: 1 フィールドだけでなくアイテム全体が
+検証ゲートの対象外だからです。保持するのは read-only の `subscriber-username`/`subscriber-password`
+デバイスログイン用クレデンシャルのみで、`chezmoi apply` の後、Tailscale/Docker が起動した後に
+このスクリプトではなく `ntfy-setup` が自動作成・充填します。もう `base-url` フィールドはありません:
+tailnet の MagicDNS 名は保存されず、必要な都度その場で導出されます。write-only の publisher
+トークンも 1Password には一切触れません——スクリプト 31 がこれを `~/.config/ntfy/notify-env` へ
+ランタイム状態として直接書き出します。）
 
 `Dotfiles - Redact Patterns` アイテムについては単純な存在確認にとどまらず、パターンが非空であること、`private_gitleaks-own.toml.tmpl` の TOML 生文字列リテラルを破壊する `'''` を含まないこと、有効な正規表現としてコンパイルできることも検証します。破損したパターンは自社名前空間リポジトリのすべてのコミットでクライアント識別子ルールをサイレントに無効化してしまいます。
 
@@ -177,7 +182,7 @@ repo 管理の launchd LaunchAgent（現在は平日朝ブリーフを発火す�
 
 ### 31 — setup-ntfy (`run_onchange`、after、macOS のみ)
 
-自己ホスト ntfy 通知サーバー（kryota-dev/dotfiles#337; [Notifications](notifications.ja.md) 参照）を起動します。ランタイム状態ディレクトリ（`~/Library/Application Support/ntfy`、0700、chezmoi のターゲットツリー外）を作成し、`~/.config/ntfy/compose.yaml` に対して `docker compose up -d` を実行し、`tailscale serve --bg` のマッピングを検証してサーバーが tailnet 全体から HTTPS で到達可能な状態を保ちます。続いて認証を冪等に自動プロビジョニングします: publisher/subscriber ユーザーとトピック別 ACL を作成し、write-only の publisher トークンを `~/.config/ntfy/notify-env`（0600 のランタイム状態。1Password を経由せず、再 apply も不要）へ直接書き出し、read-only の subscriber トークンを `Dotfiles - ntfy` 1Password アイテムに保存します（この処理には `op` CLI が必要）。クリーンインストールは notify-env が存在しないため書き直されて自己修復しますが、既存マシンでは exit 0 が記録されるため `chezmoi apply` だけでは再発火しません（Notifications のリカバリ節参照）。compose テンプレートとサーバー設定の埋め込みハッシュで再トリガーされます。CI ではスキップします（サービスもネットワークもないため）。**規約 #6 からの意図的な逸脱**: Docker Desktop が起動していない（または tailscale CLI が存在しない）場合、ハードフェイルせず警告を出して exit 0 します——通知はセットアップクリティカルではなく、`chezmoi apply` をブロックしてはならないためです。各スキップパスは手動リカバリ手順を出力します。
+自己ホスト ntfy 通知サーバー（kryota-dev/dotfiles#337; [Notifications](notifications.ja.md) 参照）を、共有ライブラリ `~/.config/ntfy/lib.sh`（同じく chezmoi がデプロイ）を source して起動します——このライブラリが ntfy ライフサイクル全体の単一情報源であるため、この apply 時パスとオンデマンドの `ntfy-setup` コマンドは決して乖離しません。ライブラリはランタイム状態ディレクトリ（`~/Library/Application Support/ntfy`、0700、chezmoi のターゲットツリー外）を作成し、`~/.config/ntfy/compose.yaml` に対して `docker compose up -d --remove-orphans` を実行し、`tailscale serve --bg` のマッピングを検証してサーバーが tailnet 全体から HTTPS で到達可能な状態を保ちます。続いて認証を冪等に自動プロビジョニングします: publisher/subscriber ユーザーとトピック別 ACL を作成し、write-only の publisher トークンを `~/.config/ntfy/notify-env`（0600 のランタイム状態。1Password を経由せず、再 apply も不要）へ直接書き出し、`op` CLI が存在する場合は read-only の `subscriber` ユーザーを生成パスワードで作成（または修復）し `Dotfiles - ntfy` 1Password アイテム（不在なら自動作成）に保存します。もう `base-url` はありません。tailnet の MagicDNS 名は保存されません。クリーンインストールは notify-env が存在しないため書き直されて自己修復しますが、既存マシンでは exit 0 が記録されるため `chezmoi apply` だけではコンテナのダウンからの復旧もクレデンシャルのローテーションも起きません——復旧は `ntfy-setup`（Notifications のリカバリ節参照）。compose テンプレート・サーバー設定・ライブラリ自体の埋め込みハッシュで再トリガーされます。CI ではスキップします(サービスもネットワークもないため)。**規約 #6 からの意図的な逸脱**: Docker Desktop が起動していない(または tailscale CLI が存在しない)場合、ハードフェイルせず警告を出して exit 0 します——通知はセットアップクリティカルではなく、`chezmoi apply` をブロックしてはならないためです。各スキップパスはリカバリコマンドとして `ntfy-setup` を出力します。
 
 ### 40 — setup-sheldon (`run_onchange`、after)
 

--- a/docs/architecture/lifecycle-scripts.md
+++ b/docs/architecture/lifecycle-scripts.md
@@ -80,7 +80,7 @@ When `dot_Brewfile` changes, the rendered comment line changes, the script body 
 | `17-setup-claude-plugins` | `dot_claude/settings.json` |
 | `18-setup-agent-browser` | `dot_config/mise/config.toml` |
 | `30-register-launchd-agents` | `Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl` |
-| `31-setup-ntfy` | `dot_config/ntfy/compose.yaml.tmpl` + `dot_config/ntfy/private_server.yml.tmpl` |
+| `31-setup-ntfy` | `dot_config/ntfy/compose.yaml.tmpl` + `dot_config/ntfy/private_server.yml.tmpl` + `dot_config/ntfy/lib.sh.tmpl` |
 | `40-setup-sheldon` | `dot_config/sheldon/plugins.toml` |
 | `20-macos-defaults` | its own source file (any edit re-triggers) |
 
@@ -132,15 +132,14 @@ Runs `brew bundle --no-upgrade` against `dot_Brewfile`. On Linux, filters the Br
 
 ### 11 — validate-1password (`run_once`, after, macOS only)
 
-Hard gate. Verifies `op` is installed and authenticated, then calls `op read` on each of the <!-- FACT:onepassword-vault-item-count -->5<!-- /FACT --> required vault references:
+Hard gate. Verifies `op` is installed and authenticated, then calls `op read` on each of the <!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> required vault references:
 
 - `op://kryota.dev/Dotfiles - AWS Config/notesPlain`
 - `op://kryota.dev/Dotfiles - Exa API/credential`
 - `op://kryota.dev/Dotfiles - Firecrawl API/credential`
 - `op://kryota.dev/Dotfiles - Redact Patterns/pattern`
-- `op://kryota.dev/Dotfiles - ntfy/base-url`
 
-(The ntfy publisher token is intentionally absent: script 31 writes it straight into `~/.config/ntfy/notify-env` as runtime state, so 1Password never holds it and the gate has nothing to check.)
+(The `Dotfiles - ntfy` item is intentionally absent from this list: it is outside the validation gate entirely, not just one field of it. It holds only the read-only `subscriber-username`/`subscriber-password` device-login credential, and `ntfy-setup` — not this script — auto-creates and fills it after `chezmoi apply`, once Tailscale/Docker are up. There is no `base-url` field any more: the tailnet MagicDNS name is never stored, only derived on demand. The write-only publisher token also never touches 1Password — script 31 writes it straight into `~/.config/ntfy/notify-env` as runtime state.)
 
 For the `Dotfiles - Redact Patterns` item the script goes further than a simple existence check: it also verifies the pattern is non-empty, contains no `'''` (which would break the TOML raw-string literal in `private_gitleaks-own.toml.tmpl`), and compiles as a valid regex. A broken pattern would otherwise allow `chezmoi apply` to succeed while silently disabling the client-identifier gitleaks rule on every commit in own-namespace repos.
 
@@ -179,22 +178,29 @@ Registers the repo-managed launchd LaunchAgents — currently one, `dev.kryota.m
 ### 31 — setup-ntfy (`run_onchange`, after, macOS only)
 
 Starts the self-hosted ntfy notification server (kryota-dev/dotfiles#337; see
-[Notifications](notifications.md)): creates the runtime-state dir
+[Notifications](notifications.md)) by sourcing the shared library
+`~/.config/ntfy/lib.sh` (also deployed by chezmoi) — the single source of truth for
+the whole ntfy lifecycle, so this apply-time path and the on-demand `ntfy-setup`
+command can never drift. The library creates the runtime-state dir
 (`~/Library/Application Support/ntfy`, 0700, outside the chezmoi target tree), runs
-`docker compose up -d` on `~/.config/ntfy/compose.yaml`, and asserts the
-`tailscale serve --bg` mapping so the server stays reachable tailnet-wide over HTTPS.
-It then auto-provisions auth idempotently: creates the publisher/subscriber users
-and per-topic ACLs, writes the write-only publisher token straight into
+`docker compose up -d --remove-orphans` on `~/.config/ntfy/compose.yaml`, and asserts
+the `tailscale serve --bg` mapping so the server stays reachable tailnet-wide over
+HTTPS. It then auto-provisions auth idempotently: creates the publisher/subscriber
+users and per-topic ACLs, writes the write-only publisher token straight into
 `~/.config/ntfy/notify-env` (0600 runtime state, no 1Password round-trip and no
-second apply), and stores the read-only subscriber token in the `Dotfiles - ntfy`
-1Password item (that half needs the `op` CLI). A clean install self-heals because
-notify-env is absent and gets rewritten; on an existing machine the exit-0 run means
-`chezmoi apply` alone will not re-fire it (see the Notifications recovery section).
-Re-triggered by the embedded hashes of the compose template and the server config.
-Skips in CI (no services, no network). **Intentional deviation from convention #6**:
-when Docker Desktop is not running (or the tailscale CLI is missing) it warns and
-exits 0 instead of hard-failing — notifications are not setup-critical and must never
-block `chezmoi apply`; each skip path prints its manual recovery command.
+second apply), and — when the `op` CLI is present — creates (or repairs) the
+read-only `subscriber` user with a generated password and stores it in the
+`Dotfiles - ntfy` 1Password item (auto-created if absent). There is no `base-url`
+any more; the tailnet MagicDNS name is never stored. A clean install self-heals
+because notify-env is absent and gets rewritten; on an existing machine the exit-0
+run means `chezmoi apply` alone will not re-fire it, restart a downed container, or
+rotate a credential — recover with `ntfy-setup` (see the Notifications recovery
+section). Re-triggered by the embedded hashes of the compose template, the server
+config, and the library itself. Skips in CI (no services, no network).
+**Intentional deviation from convention #6**: when Docker Desktop is not running (or
+the tailscale CLI is missing) it warns and exits 0 instead of hard-failing —
+notifications are not setup-critical and must never block `chezmoi apply`; each skip
+path prints `ntfy-setup` as the recovery command.
 
 ### 40 — setup-sheldon (`run_onchange`, after)
 

--- a/docs/architecture/notifications.ja.md
+++ b/docs/architecture/notifications.ja.md
@@ -32,7 +32,7 @@ http://127.0.0.1:2586 ── docker: binwiederhier/ntfy (restart: unless-stopped
         ▲                        └─ state: ~/Library/Application Support/ntfy/
 tailscale serve --bg (HTTPS, MagicDNS)          (user.db, cache.db — outside chezmoi)
         ▲
-phones/tablets on the tailnet (read-only token)
+phones/tablets on the tailnet (username/password login)
 ```
 
 - **サーバーランタイム**: Homebrew の `ntfy` formula は `noserver` タグ付きで macOS バイナリを
@@ -44,9 +44,15 @@ phones/tablets on the tailnet (read-only token)
   funnel` は禁止です — 疑わしい場合は `tailscale funnel status`（何も serve していないことを期待）で
   確認してください。
 - **publisher クレデンシャル**: write-only トークンは `~/.config/ntfy/notify-env`（0600）に
-  置かれます。これは `run_onchange_after_31-setup-ntfy` が `user.db`/`cache.db` と並ぶランタイム状態
-  として書き出すもので、chezmoi の管理対象でも 1Password の保管対象でもありません。1Password に
-  残すのは read-only の subscriber トークン（クロスデバイス配布チャネル）のみです。
+  置かれます。これは共有ライブラリ `~/.config/ntfy/lib.sh`（`run_onchange_after_31-setup-ntfy`
+  と `ntfy-setup` の両方が source する）が `user.db`/`cache.db` と並ぶランタイム状態として
+  書き出すもので、chezmoi の管理対象でも 1Password の保管対象でもありません。
+- **subscriber クレデンシャル**: read-only の `subscriber` ntfy ユーザーは、トークンではなく
+  **username + password** で認証します。ntfy モバイルアプリの公式ドキュメントは、2つの認証方式
+  ——サーバーごとのユーザーログイン（Basic Auth、アプリが自動設定）と、カスタム `Authorization`
+  ヘッダー（手動のトークン経路）——が互いに排他的だと説明しており、実際に iOS で機能するのは
+  前者のみです。username（`subscriber`）と生成されたパスワードは `Dotfiles - ntfy` 1Password
+  アイテムに保存されます。
 - **iOS の即時 push**: `upstream-base-url: https://ntfy.sh` は、**受信メッセージすべて**について
   ntfy.sh へポーリングリクエストを送ります — iOS デバイスが購読しているかどうかに関係なく
   （トピックのメタデータのみで、メッセージ本文は含みません）— これが APNs に即時配信の材料を渡します。
@@ -71,65 +77,74 @@ phones/tablets on the tailnet (read-only token)
 
 ## セットアップ手順（初回のみ）
 
-1. **1Password アイテム** — `kryota.dev` Vault に `Dotfiles - ntfy` を作成し、
-   `base-url` には実値（serve エンドポイント `https://<host>.<tailnet>.ts.net`。
-   `tailscale status --json | jq -r .Self.DNSName` で確認可能）を、`subscriber-token`
-   にはブートストラップ用プレースホルダー（`tk_REPLACE…`）を設定します — 自動
-   プロビジョニングは、プレースホルダーが残っている間のみ read-only の subscriber
-   トークンを発行します。write-only の publisher トークンはここには**置きません**:
-   セットアップスクリプトが `~/.config/ntfy/notify-env` へ直接書き出します（手順 4 参照）。
-   [secrets-1password](../getting-started/secrets-1password.ja.md) を参照してください。
-2. **Docker Desktop** — *サインイン時に Docker Desktop を起動する*（設定 →
+これらの手順の前提として、`chezmoi apply` が compose ファイル・`~/.config/ntfy/lib.sh`・
+`ntfy-setup` コマンドをすでにデプロイ済みです — どれも手作業で作る必要はありません。
+
+1. **Docker Desktop** — *サインイン時に Docker Desktop を起動する*（設定 →
    一般）を有効化します。これにより compose の `restart: unless-stopped` ポリシーが、
    再起動のたびにサーバーを復帰させます。
-3. **Apply** — `chezmoi apply` が設定をレンダリングし、コンテナを起動し
-   （`run_onchange_after_31-setup-ntfy`）、`tailscale serve --bg` のマッピングを検証します。
-4. **認証は手順 3 が自動でプロビジョニングします**（再 apply 不要の 1 パス）: スクリプトが
-   `publisher`/`subscriber` ユーザーを使い捨てパスワードで作成し、トピック別 ACL を
-   付与し、2 つのトークンをプロビジョニングします:
+2. **Tailscale** — この Mac が `tailscale up` 済みでログインしていることを確認します。
+3. **`ntfy-setup` を実行**（`~/.local/bin/ntfy-setup`、PATH 済み）— ライフサイクル
+   全体のための単一の再実行可能エントリポイントです。コンテナを起動し
+   （`docker compose up -d --remove-orphans`）、`tailscale serve --bg` を検証した上で、
+   1 パスで両方のクレデンシャルをプロビジョニングします:
    - **publisher** トークンは `~/.config/ntfy/notify-env`（0600）へ直接書き出されます —
-     フックラッパーが source するランタイム状態ファイルです。1Password には一切触れず、
-     この処理に `op` は不要です。
-   - **subscriber** トークンは 1Password アイテムに保存されます（各スマホに手入力する
-     クロスデバイスチャネル）。この処理には `op` CLI が必要です。
+     フックラッパーが source するランタイム状態ファイルです。この処理に `op` は不要です。
+   - **subscriber** ユーザーは生成されたパスワードで作成（または修復）され、そのパスワードは
+     `Dotfiles - ntfy` 1Password アイテムに保存されます。この処理には `op` CLI が必要です。
+     **1Password アイテムは、存在しない場合に初回だけ自動作成されます**（Secure Note、
+     `subscriber-username`/`subscriber-password`）— 手動での 1Password 設定は不要です。
+     [secrets-1password](../getting-started/secrets-1password.ja.md) を参照してください。
 
-   以下のコマンドは、プロビジョニングがスキップ警告を出した場合（例: Docker 停止中、
-   または subscriber 側で `op` 不在）の**手動フォールバック**です:
+   `chezmoi apply` も同じプロビジョニングを apply 時に実行します
+   （`run_onchange_after_31-setup-ntfy` が同じ `~/.config/ntfy/lib.sh` を source します）が、
+   Tailscale がすでに up、かつ Docker がすでに起動しているマシンでのみ完了します。
+   **フレッシュなマシンではどちらもまだ true ではない**ため、apply 時の実行は警告してスキップ
+   します（下記の障害モード参照）— 両方が揃った時点で `ntfy-setup` を実行してセットアップを
+   完了させてください。この 2 フェーズのギャップこそが、`ntfy-setup` を `chezmoi apply` 単独に
+   頼らない独立した再実行可能コマンドとして用意している理由です。
+
+   以下のコマンドは、`op` が利用できない場合（subscriber 側は警告付きでスキップされます）の
+   **手動フォールバック**専用です:
 
    ```bash
    cd ~/.config/ntfy
    docker compose exec ntfy ntfy user add publisher     # publisher, write-only
-   docker compose exec ntfy ntfy user add subscriber    # devices, read-only
+   NTFY_PASSWORD='<choose-a-strong-password>' \
+     docker compose exec -T -e NTFY_PASSWORD ntfy ntfy user add subscriber   # devices, read-only
    for t in claude-attention claude-done claude-test; do
      docker compose exec ntfy ntfy access publisher "$t" write-only
      docker compose exec ntfy ntfy access subscriber "$t" read-only
    done
    docker compose exec ntfy ntfy token add --label chezmoi publisher
-   docker compose exec ntfy ntfy token add --label devices subscriber
    ```
 
    フォールバック時は、publisher トークンを `~/.config/ntfy/notify-env` に
-   `NTFY_TOKEN='tk_…'` として書き込み（ファイルは 0600 のまま）、subscriber トークンは
-   アイテムの `subscriber-token` フィールドに保存します。
+   `NTFY_TOKEN='tk_…'` として書き込み（ファイルは 0600 のまま）、subscriber の
+   username/password は `Dotfiles - ntfy` アイテムの `subscriber-username`/
+   `subscriber-password` フィールドに保存します。
    注: `ntfy token add` はトークンを端末の scrollback にそのまま出力します — 値を保存したら
    scrollback をクリアしてください。
-5. **デバイスの subscribe** — ntfy アプリ（iOS/Android）→ *別のサーバーを使う* で `base-url`
-   エンドポイント、1Password の subscriber トークン、2つのトピックを設定します。
+4. **デバイスの subscribe** — ntfy アプリ（iOS/Android）→ *別のサーバーを使う* → サーバー URL
+   （`ntfy-setup` が表示します。または `tailscale status --json | jq -r .Self.DNSName` で
+   自分で導出し、末尾のドットを除去して `https://` を前置します）→ username `subscriber` と
+   `Dotfiles - ntfy` 1Password アイテムのパスワードでログイン → 2 つのトピックを購読します。
 
 ## Smoke test
 
-トークンをコマンドラインに乗せることは決してしません（`-H` だと `ps` やシェル履歴に露出します —
-wrapper が課しているのと同じルールです）。代わりに process substitution で curl に header 設定を
-渡します:
+トークンやパスワードをコマンドラインに乗せることは決してしません（`-H`/`-u` だと `ps` やシェル
+履歴に露出します — wrapper が課しているのと同じルールです）。代わりに process substitution で
+curl に設定を渡します。サーバー URL もその場で導出し、保存はしません:
 
 ```bash
-BASE="$(op read 'op://kryota.dev/Dotfiles - ntfy/base-url')"
-ro() { printf 'header = "Authorization: Bearer %s"\n' "$(op read 'op://kryota.dev/Dotfiles - ntfy/subscriber-token')"; }
+DNS="$(tailscale status --json | jq -r .Self.DNSName)"
+BASE="https://${DNS%.}"
+ro() { printf 'user = "subscriber:%s"\n' "$(op read 'op://kryota.dev/Dotfiles - ntfy/subscriber-password')"; }
 # publisher トークンは 1Password にないため、notify-env から source する。
 wo() { ( . ~/.config/ntfy/notify-env; printf 'header = "Authorization: Bearer %s"\n' "$NTFY_TOKEN" ); }
 # anonymous publish must be denied (401/403)
 curl -s -o /dev/null -w '%{http_code}\n' -d test "$BASE/claude-test"
-# read-only token must be denied for publish (403)
+# read-only な username/password は publish が拒否されなければならない (403)
 curl -s -o /dev/null -w '%{http_code}\n' -K <(ro) -d test "$BASE/claude-test"
 # publisher token succeeds (200); phones should receive it
 curl -s -o /dev/null -w '%{http_code}\n' -K <(wo) -d test "$BASE/claude-test"
@@ -145,26 +160,37 @@ upstream リレーは upstream 側で未検証です — PRD 参照）。
 
 | Symptom | Cause / fix |
 |---------|-------------|
-| Local alert sound, no phone notification | Wrapper publish failed — server down. Check `~/Library/Logs/ntfy-notify.log`, then `docker compose -f ~/.config/ntfy/compose.yaml up -d` |
-| No notifications right after login | Docker Desktop still starting; the fail-open window is expected. Enable start-at-login (runbook step 2) |
-| `chezmoi apply` prints `[ntfy] Docker Desktop is not running` | Intentional warn-and-skip (deviation from lifecycle convention #6): notifications must not block apply. **復旧は印字された `docker compose up -d` コマンドで行う** — `chezmoi apply` の再実行だけでは再試行されない（exit 0 で `run_onchange` の state が記録され、compose/server テンプレートが変更されたときのみ再発火する） |
-| Phone can't reach the server | Device off the tailnet, or `tailscale serve` mapping lost — re-run `tailscale serve --bg http://127.0.0.1:2586` (also asserted by every re-triggered apply) |
+| Local alert sound, no phone notification | Wrapper publish failed — server down. Check `~/Library/Logs/ntfy-notify.log`, then run `ntfy-setup` |
+| No notifications right after login | Docker Desktop still starting; the fail-open window is expected. Enable start-at-login (runbook step 1) |
+| `chezmoi apply` prints `[ntfy] Docker Desktop is not running` | Intentional warn-and-skip (deviation from lifecycle convention #6): notifications must not block apply. **復旧は Docker 起動後に `ntfy-setup` を実行する** — `chezmoi apply` の再実行だけでは再試行されない（exit 0 で `run_onchange` の state が記録され、compose/server/lib テンプレートが変更されたときのみ再発火する） |
+| Phone can't reach the server | Device off the tailnet, or `tailscale serve` mapping lost — `ntfy-setup` を実行する（`tailscale serve --bg` を再検証する。再トリガーされた apply のたびにも検証される） |
 | Old messages missing | `cache-duration` (168h, `[ntfy]` in `.chezmoidata.toml`) elapsed |
 | Notifications on the wrong account badge | `CLAUDE_CONFIG_DIR` unset in that session; account falls back to `default` |
 
-## リカバリ: user.db (auth) の消失・破損、またはトークンローテーション
+## リカバリ: user.db (auth) の消失・破損、またはクレデンシャルのローテーション
 
 **クリーンインストールは自己修復します**: `run_onchange` の状態が無いためセットアップ
-スクリプトが走り、`~/.config/ntfy/notify-env` が存在しないことを検知して publisher トークンを
-再プロビジョニングします。
+スクリプトが走り、`~/.config/ntfy/notify-env` が存在しないことを検知して publisher トークンと
+subscriber のユーザー/パスワードを再プロビジョニングします。
 
-**既存マシン**では notify-env を削除するだけでは不十分です — `run_onchange_after_31-setup-ntfy`
-は exit 0 を記録し、compose/server テンプレートが変更されたときのみ再発火するため、`chezmoi apply`
-だけでは書き直されません。手動フォールバック（手順 4）で再プロビジョニングしてください: 新しい
-`ntfy token add … publisher` を発行し、notify-env に `NTFY_TOKEN='tk_…'`（0600 のまま）として
-書き込みます。`user.db` が消失・破損している場合は先に削除してください。**トークンを再発行すると
-すべての既存トークンが無効化されます**ので、subscribe している全デバイスで subscriber トークンも
-再入力してください。
+**既存マシン**では、`run_onchange_after_31-setup-ntfy` は exit 0 を記録し、compose/server/lib
+テンプレートが変更されたときのみ再発火するため、`chezmoi apply` だけではダウンしたコンテナの
+復旧も、`user.db` の消失の修復も、クレデンシャルのローテーションもできません。**`ntfy-setup` が
+これらすべてに対する単一のリカバリコマンドです**:
+
+- **コンテナのダウン / `tailscale serve` マッピングの喪失** — `ntfy-setup` がコンテナを再起動し、
+  `tailscale serve --bg` を再検証します。
+- **`user.db` の消失・破損** — 先に削除してから `ntfy-setup` を実行します。両方のユーザーを
+  再作成し、既知のパスワード/トークンを再適用します。
+- **クレデンシャルの漏洩・ローテーション** — `ntfy-setup --rotate publisher|subscriber|all`。
+  `ntfy token add` は加算的です（各ユーザーは複数のトークンを持てます。新規発行は既存トークンを
+  無効化**しません**）。そのため publisher のローテーションは、まず notify-env から現在の
+  トークンを読み取り、新しいトークンを発行して書き込んだ後、古いトークンを（`ntfy token remove`
+  で）失効させます — すべてのクレデンシャルを一括無効化するのは `user.db` を削除した場合のみです。
+  subscriber のローテーションは `ntfy user change-pass` を使います（ユーザーと ACL を維持、
+  del/re-add のギャップなし）。1Password の `subscriber-password` フィールドも更新します。
+  **subscriber のローテーション後は、subscribe している全デバイスで新しいパスワードを
+  再入力する必要があります。**
 
 ## ロールバック（1ステップ）
 

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -30,7 +30,7 @@ http://127.0.0.1:2586 ── docker: binwiederhier/ntfy (restart: unless-stopped
         ▲                        └─ state: ~/Library/Application Support/ntfy/
 tailscale serve --bg (HTTPS, MagicDNS)          (user.db, cache.db — outside chezmoi)
         ▲
-phones/tablets on the tailnet (read-only token)
+phones/tablets on the tailnet (username/password login)
 ```
 
 - **Server runtime**: the Homebrew `ntfy` formula builds macOS binaries with the
@@ -42,9 +42,15 @@ phones/tablets on the tailnet (read-only token)
   funnel` is prohibited — verify with `tailscale funnel status` (expect nothing
   served) whenever in doubt.
 - **Publisher credential**: the write-only token lives in `~/.config/ntfy/notify-env`
-  (0600), runtime state written by `run_onchange_after_31-setup-ntfy` alongside the
-  `user.db`/`cache.db` state — never a chezmoi target, never in 1Password. Only the
-  read-only subscriber token (the cross-device channel) is kept in 1Password.
+  (0600), runtime state written by the shared `~/.config/ntfy/lib.sh` library
+  (sourced by both `run_onchange_after_31-setup-ntfy` and `ntfy-setup`) alongside the
+  `user.db`/`cache.db` state — never a chezmoi target, never in 1Password.
+- **Subscriber credential**: the read-only `subscriber` ntfy user authenticates with a
+  **username + password**, not a token. The ntfy mobile app's own docs describe the
+  two auth modes as mutually exclusive — a per-server user login (Basic Auth, set
+  automatically by the app) or a custom `Authorization` header (the manual token
+  path) — and only the former works in practice on iOS. The username (`subscriber`)
+  and a generated password are stored in the `Dotfiles - ntfy` 1Password item.
 - **iOS instant push**: `upstream-base-url: https://ntfy.sh` publishes a poll
   request to ntfy.sh for **every incoming message** — regardless of whether any
   iOS device subscribes (topic metadata only, never message bodies) — feeding
@@ -71,66 +77,77 @@ the 200-char window — general secret detection is explicitly out of scope.
 
 ## Setup runbook (one-time)
 
-1. **1Password item** — create `Dotfiles - ntfy` in the `kryota.dev` vault with a
-   real `base-url` (the serve endpoint, `https://<host>.<tailnet>.ts.net`; look it
-   up with `tailscale status --json | jq -r .Self.DNSName`) and a bootstrap
-   placeholder (`tk_REPLACE…`) in the `subscriber-token` field — auto-provisioning
-   issues the read-only subscriber token only while that placeholder is in place.
-   The write-only publisher token is **not** kept here: the setup script writes it
-   straight into `~/.config/ntfy/notify-env` (see step 4). See
-   [secrets-1password](../getting-started/secrets-1password.md).
-2. **Docker Desktop** — enable *Start Docker Desktop when you sign in* (Settings →
+`chezmoi apply` must have already deployed the compose file, `~/.config/ntfy/lib.sh`,
+and the `ntfy-setup` command before these steps — none of them need to be created by
+hand.
+
+1. **Docker Desktop** — enable *Start Docker Desktop when you sign in* (Settings →
    General); the compose `restart: unless-stopped` policy then revives the server
    after every reboot.
-3. **Apply** — `chezmoi apply` renders the config, starts the container
-   (`run_onchange_after_31-setup-ntfy`), and asserts the `tailscale serve --bg`
-   mapping.
-4. **Auth is provisioned automatically by step 3**, in a single pass with no
-   second apply: the script creates the `publisher`/`subscriber` users (throwaway
-   passwords), grants the per-topic ACLs, then provisions the two tokens:
+2. **Tailscale** — make sure this Mac is `tailscale up` and logged in.
+3. **Run `ntfy-setup`** (`~/.local/bin/ntfy-setup`, on PATH) — the single
+   re-runnable entry point for the whole lifecycle. It starts the container
+   (`docker compose up -d --remove-orphans`), asserts `tailscale serve --bg`, then
+   provisions both credentials in one pass:
    - the **publisher** token is written straight into `~/.config/ntfy/notify-env`
-     (0600) — the runtime-state file the hook wrapper sources. It never touches
-     1Password, and `op` is not required for this half.
-   - the **subscriber** token is stored in the 1Password item (the cross-device
-     channel you type into each phone); this half needs the `op` CLI.
+     (0600) — the runtime-state file the hook wrapper sources. `op` is not
+     required for this half.
+   - the **subscriber** user is created (or repaired) with a generated password,
+     which is stored in the `Dotfiles - ntfy` 1Password item. This half needs the
+     `op` CLI; **the 1Password item is auto-created the first time it is
+     absent** (Secure Note, `subscriber-username`/`subscriber-password`) — no
+     manual 1Password setup is required. See
+     [secrets-1password](../getting-started/secrets-1password.md).
 
-   The commands below are the **manual fallback** only for when provisioning
-   printed a skip warning (e.g. Docker down, or `op` unavailable for the
-   subscriber half):
+   `chezmoi apply` runs the same provisioning at apply time
+   (`run_onchange_after_31-setup-ntfy` sources the same `~/.config/ntfy/lib.sh`),
+   but only completes it on a machine where Tailscale is already up and Docker is
+   already running. On a **fresh machine neither is true yet**, so the apply-time
+   run warns and skips (see Failure modes below) — run `ntfy-setup` once both are
+   available to finish setup. This two-phase gap is why `ntfy-setup` exists as a
+   separate, re-runnable command rather than relying on `chezmoi apply` alone.
+
+   The commands below are the **manual fallback** only for when `op` is
+   unavailable (the subscriber half is then skipped with a warning):
 
    ```bash
    cd ~/.config/ntfy
    docker compose exec ntfy ntfy user add publisher     # publisher, write-only
-   docker compose exec ntfy ntfy user add subscriber    # devices, read-only
+   NTFY_PASSWORD='<choose-a-strong-password>' \
+     docker compose exec -T -e NTFY_PASSWORD ntfy ntfy user add subscriber   # devices, read-only
    for t in claude-attention claude-done claude-test; do
      docker compose exec ntfy ntfy access publisher "$t" write-only
      docker compose exec ntfy ntfy access subscriber "$t" read-only
    done
    docker compose exec ntfy ntfy token add --label chezmoi publisher
-   docker compose exec ntfy ntfy token add --label devices subscriber
    ```
 
    In the fallback case, write the publisher token into `~/.config/ntfy/notify-env`
-   as `NTFY_TOKEN='tk_…'` (keep the file 0600), and store the subscriber token in
-   the item's `subscriber-token` field. Note: `ntfy token add` echoes tokens into
-   terminal scrollback — clear it after storing the values.
-5. **Subscribe devices** — ntfy app (iOS/Android) → *Use another server* with the
-   `base-url` endpoint, the subscriber token from 1Password, and the two topics.
+   as `NTFY_TOKEN='tk_…'` (keep the file 0600), and store the subscriber
+   username/password in the `Dotfiles - ntfy` item's `subscriber-username`/
+   `subscriber-password` fields. Note: `ntfy token add` echoes the token into
+   terminal scrollback — clear it after storing the value.
+4. **Subscribe devices** — ntfy app (iOS/Android) → *Use another server* → the
+   server URL (`ntfy-setup` prints it; or derive it yourself with
+   `tailscale status --json | jq -r .Self.DNSName`, strip the trailing dot,
+   prepend `https://`) → log in with username `subscriber` and the password from
+   the `Dotfiles - ntfy` 1Password item → subscribe to the two topics.
 
 ## Smoke test
 
-Tokens never go on the command line (`-H` would expose them in `ps` and shell
-history — the same rule the wrapper enforces); feed curl a header config via
-process substitution instead:
+Tokens and passwords never go on the command line (`-H`/`-u` would expose them in
+`ps` and shell history — the same rule the wrapper enforces); feed curl a config via
+process substitution instead. The server URL is derived on the spot, not stored:
 
 ```bash
-BASE="$(op read 'op://kryota.dev/Dotfiles - ntfy/base-url')"
-ro() { printf 'header = "Authorization: Bearer %s"\n' "$(op read 'op://kryota.dev/Dotfiles - ntfy/subscriber-token')"; }
+DNS="$(tailscale status --json | jq -r .Self.DNSName)"
+BASE="https://${DNS%.}"
+ro() { printf 'user = "subscriber:%s"\n' "$(op read 'op://kryota.dev/Dotfiles - ntfy/subscriber-password')"; }
 # The publisher token is not in 1Password — source it from notify-env instead.
 wo() { ( . ~/.config/ntfy/notify-env; printf 'header = "Authorization: Bearer %s"\n' "$NTFY_TOKEN" ); }
 # anonymous publish must be denied (401/403)
 curl -s -o /dev/null -w '%{http_code}\n' -d test "$BASE/claude-test"
-# read-only token must be denied for publish (403)
+# read-only user/password must be denied for publish (403)
 curl -s -o /dev/null -w '%{http_code}\n' -K <(ro) -d test "$BASE/claude-test"
 # publisher token succeeds (200); phones should receive it
 curl -s -o /dev/null -w '%{http_code}\n' -K <(wo) -d test "$BASE/claude-test"
@@ -146,27 +163,37 @@ tailnet-only server is unverified upstream — see the PRD).
 
 | Symptom | Cause / fix |
 |---------|-------------|
-| Local alert sound, no phone notification | Wrapper publish failed — server down. Check `~/Library/Logs/ntfy-notify.log`, then `docker compose -f ~/.config/ntfy/compose.yaml up -d` |
-| No notifications right after login | Docker Desktop still starting; the fail-open window is expected. Enable start-at-login (runbook step 2) |
-| `chezmoi apply` prints `[ntfy] Docker Desktop is not running` | Intentional warn-and-skip (deviation from lifecycle convention #6): notifications must not block apply. **Recover with the printed `docker compose up -d` command** — re-running `chezmoi apply` alone does NOT retry (the exit-0 run records the `run_onchange` state; the script only re-fires when the compose/server templates change) |
-| Phone can't reach the server | Device off the tailnet, or `tailscale serve` mapping lost — re-run `tailscale serve --bg http://127.0.0.1:2586` (also asserted by every re-triggered apply) |
+| Local alert sound, no phone notification | Wrapper publish failed — server down. Check `~/Library/Logs/ntfy-notify.log`, then run `ntfy-setup` |
+| No notifications right after login | Docker Desktop still starting; the fail-open window is expected. Enable start-at-login (runbook step 1) |
+| `chezmoi apply` prints `[ntfy] Docker Desktop is not running` | Intentional warn-and-skip (deviation from lifecycle convention #6): notifications must not block apply. **Recover by running `ntfy-setup` once Docker is running** — re-running `chezmoi apply` alone does NOT retry (the exit-0 run records the `run_onchange` state; the script only re-fires when the compose/server/lib templates change) |
+| Phone can't reach the server | Device off the tailnet, or `tailscale serve` mapping lost — run `ntfy-setup` (re-asserts `tailscale serve --bg`; also asserted by every re-triggered apply) |
 | Old messages missing | `cache-duration` (168h, `[ntfy]` in `.chezmoidata.toml`) elapsed |
 | Notifications on the wrong account badge | `CLAUDE_CONFIG_DIR` unset in that session; account falls back to `default` |
 
-## Recovery: user.db (auth) lost or corrupted, or token rotation
+## Recovery: user.db (auth) lost or corrupted, or credential rotation
 
 A **clean install self-heals**: with no prior `run_onchange` state the setup
 script runs, finds `~/.config/ntfy/notify-env` absent, and re-provisions the
-publisher token into it.
+publisher token and the subscriber user/password into it.
 
-On an **existing machine**, deleting notify-env is not enough on its own —
-`run_onchange_after_31-setup-ntfy` records exit-0 and only re-fires when the
-compose/server templates change, so `chezmoi apply` alone will not rewrite it.
-Re-provision with the manual fallback (runbook step 4): issue a fresh
-`ntfy token add … publisher` and write it into notify-env as `NTFY_TOKEN='tk_…'`
-(0600). If `user.db` was lost or corrupted, delete it first. **Re-issuing tokens
-invalidates every existing token**, so also re-enter the subscriber token on every
-subscribed device.
+On an **existing machine**, `run_onchange_after_31-setup-ntfy` records exit-0 and
+only re-fires when the compose/server/lib templates change, so `chezmoi apply`
+alone will not repair a downed container, a lost `user.db`, or rotate a
+credential. **`ntfy-setup` is the single recovery command** for all of these:
+
+- **Downed container / lost `tailscale serve` mapping** — `ntfy-setup` restarts
+  the container and re-asserts `tailscale serve --bg`.
+- **Lost or corrupted `user.db`** — delete it, then run `ntfy-setup`; it
+  recreates both users and re-applies the known password/token.
+- **Leaked or rotating credential** — `ntfy-setup --rotate publisher|subscriber|all`.
+  `ntfy token add` is additive (each user can hold multiple tokens; issuing a new
+  one does **not** invalidate existing ones), so publisher rotation reads the
+  current token from notify-env first, issues the new one, writes it, then
+  revokes the old one (`ntfy token remove`) — only deleting `user.db` invalidates
+  every credential at once. Subscriber rotation uses `ntfy user change-pass`
+  (preserves the user and its ACLs, no del/re-add gap) and updates the
+  `subscriber-password` field in 1Password. **Every subscribed device must
+  re-enter the new password after a subscriber rotation.**
 
 ## Rollback (one step)
 

--- a/docs/contributing/ci-and-tests.ja.md
+++ b/docs/contributing/ci-and-tests.ja.md
@@ -124,7 +124,7 @@ awk パーサーは `[ecc]` テーブルの `skills` 配列のみにスコープ
 - `home/run_once_after_90-other-apps.sh.tmpl`
 - `home/run_once_after_30-setup-fonts.sh.tmpl` — **古い参照**: このスクリプトはもう存在しません。フォントは `home/.chezmoiexternal.toml` の `["Library/Fonts"]` external を通じて chezmoi エンジン自体がデプロイします。`if [ -f ]` ガードにより、ファイルが存在しなくてもサイレントに処理されます（既知の問題を参照）
 
-新しい 1Password バックドのシークレットテンプレートを追加する際は、両ジョブの除外リストにも追加してください。
+エントリの多くは 1Password バックドのテンプレート（apply 時に `op` を呼ぶ）です。`home/dot_config/ntfy/private_server.yml.tmpl` は例外で、base-url が除去された（#337）ことで 1Password を読まなくなりましたが、コンテナ専用パスのみの 0600 設定でありレンダリングに CI 上の価値がないため、除外リストには残しています。apply 時に `op` を呼ぶ（またはその他の理由で CI 非互換な）新しいテンプレートを追加する際は、両ジョブの除外リストにも追加してください。
 
 ### Brewfile の処理
 

--- a/docs/contributing/ci-and-tests.md
+++ b/docs/contributing/ci-and-tests.md
@@ -124,7 +124,7 @@ Files excluded by the **macOS job only**:
 - `home/run_once_after_90-other-apps.sh.tmpl`
 - `home/run_once_after_30-setup-fonts.sh.tmpl` — **stale**: this script no longer exists; the `if [ -f ]` guard tolerates the missing file silently (see Known Issues)
 
-When adding a new 1Password-backed secret template, add it to the exclusion list in both jobs.
+Most entries are 1Password-backed templates (they call `op` at apply time). `home/dot_config/ntfy/private_server.yml.tmpl` is the exception: since base-url was dropped (#337) it no longer reads 1Password, but it stays excluded because it is a 0600 config of container-only paths with no CI value in rendering. When adding a new template that calls `op` at apply time (or is otherwise CI-incompatible), add it to the exclusion list in both jobs.
 
 ### Brewfile handling
 

--- a/docs/explanation/secrets-and-isolation.ja.md
+++ b/docs/explanation/secrets-and-isolation.ja.md
@@ -36,6 +36,10 @@
 
 値自体はレンダリング時にシングルクォートされます（chezmoi テンプレート関数 `squote`）。`$` やバッククォートを含むキーは、レンダリングされたファイルがシェルによってソースされる際にシェル展開やコマンド置換を引き起こすことができません。
 
+### 唯一の書き込みパス: ntfy-setup のプロビジョニング（#337）
+
+上記の参照はすべて読み取り専用です——`op read` / `onepasswordRead` が vault から値を取り出して `0600` ファイルに書き込みます。自己ホスト ntfy のセットアップ（#337）は、このリポジトリで唯一の 1Password への**書き込み**パスを追加します: 共通ライブラリ `~/.config/ntfy/lib.sh` が `op item create`（`Dotfiles - ntfy` アイテムが不在のときだけ、1 回）と `op item edit`（read-only の `subscriber-password` 端末ログイン資格情報の保存・ローテーション）を呼びます。これは `ntfy-setup`（オンデマンド）と `run_onchange_after_31-setup-ntfy`（apply 時）から実行され、テンプレートレンダリング中には決して実行されません。この新しい面は 2 つの性質で境界づけられます: create は**非破壊**（`op item get` でガードされ、既存アイテムのフィールドを決して上書きしない）であり、**apply-strict パスの外**にあります——macOS 限定で、失敗しても apply を中断せず warn して継続します（下記の fail-open 契約）。単一フィールドの `op item edit field=value` 呼び出しが、この書き込みで受容される唯一の transient な argv 露出です（op には単一フィールドの stdin ショートカットが無いため）。[Notifications](../architecture/notifications.md) を参照。
+
 ---
 
 ## 2 段階の厳格さ: apply-strict と runtime-graceful

--- a/docs/explanation/secrets-and-isolation.ja.md
+++ b/docs/explanation/secrets-and-isolation.ja.md
@@ -44,13 +44,19 @@
 
 ### Apply-strict: `run_once_after_11-validate-1password.sh.tmpl`
 
-このライフサイクルスクリプトは macOS 上で一度だけ実行され、<!-- FACT:onepassword-vault-item-count -->5<!-- /FACT --> つの必要な 1Password アイテム参照のいずれかが見つからないか到達不能な場合、ゼロ以外の終了コードで `chezmoi apply` を中断します。確認される参照は以下のとおりです:
+このライフサイクルスクリプトは macOS 上で一度だけ実行され、<!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> つの必要な 1Password アイテム参照のいずれかが見つからないか到達不能な場合、ゼロ以外の終了コードで `chezmoi apply` を中断します。確認される参照は以下のとおりです:
 
 - `op://kryota.dev/Dotfiles - AWS Config/notesPlain`
 - `op://kryota.dev/Dotfiles - Exa API/credential`
 - `op://kryota.dev/Dotfiles - Firecrawl API/credential`
 - `op://kryota.dev/Dotfiles - Redact Patterns/pattern`
-- `op://kryota.dev/Dotfiles - ntfy/base-url`
+
+`Dotfiles - ntfy` アイテム（自己ホスト通知、#337）は意図的にこのゲートの対象外です:
+保持するのは read-only の `subscriber-username`/`subscriber-password` デバイスログイン用
+クレデンシャルのみで、`chezmoi apply` の後、Tailscale/Docker が起動した後——この検証スクリプトより
+後のフェーズで `ntfy-setup` が自動作成・充填します。もう `base-url` フィールドはありません;
+tailnet の MagicDNS 名は 1Password に保存されず、必要な都度その場で導出されます。
+[Notifications](../architecture/notifications.ja.md) を参照してください。
 
 `op` がインストールされていない、認証されていない、またはアイテムが読み取れない場合、`chezmoi apply` はフェイルファストします。注意点として、`run_once_after_11` は AFTER フェーズのスクリプトであり、実行時点ではホームディレクトリはすでに変更されています。実際のフェイルファストパスは次の 2 つです: (1) `.tmpl` ファイル内の `onepasswordRead` がテンプレートレンダリング中に apply を中断する（当該ファイルが書き込まれる前）; (2) `run_once_after_11` が後続の重い after フェーズプロビジョニング（mise、MCP、CLV2 等）の前のフェイルファストゲートとして機能する。シークレットが欠落した状態で途中までプロビジョニングされたマシンは、これらいずれかの時点でのクリーンな中断よりも悪い結果をもたらすという考えに基づいています。スクリプトは macOS のみです（`{{ if ne .chezmoi.os "darwin" }}` で早期終了）。CI は 1Password インストールなしで Ubuntu 上で実行されるためです。
 

--- a/docs/explanation/secrets-and-isolation.md
+++ b/docs/explanation/secrets-and-isolation.md
@@ -44,13 +44,14 @@ The system draws a hard line between apply-time and runtime behavior:
 
 ### Apply-strict: `run_once_after_11-validate-1password.sh.tmpl`
 
-This lifecycle script runs once on macOS and aborts `chezmoi apply` with a non-zero exit if any of the <!-- FACT:onepassword-vault-item-count -->5<!-- /FACT --> required 1Password item references is missing or unreachable. The checked references are:
+This lifecycle script runs once on macOS and aborts `chezmoi apply` with a non-zero exit if any of the <!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> required 1Password item references is missing or unreachable. The checked references are:
 
 - `op://kryota.dev/Dotfiles - AWS Config/notesPlain`
 - `op://kryota.dev/Dotfiles - Exa API/credential`
 - `op://kryota.dev/Dotfiles - Firecrawl API/credential`
 - `op://kryota.dev/Dotfiles - Redact Patterns/pattern`
-- `op://kryota.dev/Dotfiles - ntfy/base-url`
+
+The `Dotfiles - ntfy` item (self-hosted notifications, #337) is deliberately outside this gate: it holds only the read-only `subscriber-username`/`subscriber-password` device-login credential, auto-created and filled by `ntfy-setup` after `chezmoi apply` and after Tailscale/Docker are up — a later phase than this validation script. There is no `base-url` field any more; the tailnet MagicDNS name is never stored in 1Password, only derived on demand. See [Notifications](../architecture/notifications.md).
 
 If `op` is not installed, not authenticated, or an item cannot be read, `chezmoi apply` fails fast. Note that `run_once_after_11` is an AFTER-phase script — home has already been mutated by the time it runs. The actual fail-fast paths are: (1) `onepasswordRead` inside `.tmpl` files aborts apply during template render, before those files are written; and (2) `run_once_after_11` acts as a fail-fast gate before the heavier after-phase provisioning (mise, MCP, CLV2, etc.). The intent is that a partially-provisioned machine with missing secrets is worse than a clean abort at either of those points. The script is macOS-only (`{{ if ne .chezmoi.os "darwin" }}` exits early) because CI runs on Ubuntu without a 1Password installation.
 

--- a/docs/explanation/secrets-and-isolation.md
+++ b/docs/explanation/secrets-and-isolation.md
@@ -36,6 +36,10 @@ The `private_` chezmoi prefix is the mechanism that enforces `0600` on the desti
 
 The values themselves are single-quoted at render time (the `squote` chezmoi template function): a key containing `$` or a backtick cannot trigger shell expansion or command substitution when the rendered file is sourced by the shell.
 
+### The one write path: ntfy-setup provisioning (#337)
+
+Every reference above is read-only — `op read` / `onepasswordRead` pulling a value out of the vault into a `0600` file. The self-hosted ntfy setup (#337) adds this repo's only 1Password **write** path: the shared library `~/.config/ntfy/lib.sh` calls `op item create` (once, only when the `Dotfiles - ntfy` item is absent) and `op item edit` (to store / rotate the read-only `subscriber-password` device-login credential). It runs from `ntfy-setup` on demand and from `run_onchange_after_31-setup-ntfy` at apply time, never during template render. Two properties bound this new surface: the create is **non-destructive** (guarded by `op item get`, so it never overwrites an existing item's fields), and it sits **off the apply-strict path** — macOS-only, and a failure warns and continues rather than aborting apply (the fail-open contract below). The single-field `op item edit field=value` call is the one accepted transient argv exposure for this write (op has no single-field stdin shortcut). See [Notifications](../architecture/notifications.md).
+
 ---
 
 ## Two strictness levels: apply-strict vs runtime-graceful

--- a/docs/getting-started/secrets-1password.ja.md
+++ b/docs/getting-started/secrets-1password.ja.md
@@ -44,7 +44,7 @@ macOS で `chezmoi apply` を実行する前に:
 1. **1Password デスクトップアプリ**がインストールされ、サインイン済みであること。
 2. **CLI 統合が有効**: 1Password → 設定 → デベロッパー → "1Password CLI と統合"。
 3. **1Password CLI（`op`）**がインストール済み: `brew install --cask 1password-cli`。
-4. 以下に示す <!-- FACT:onepassword-vault-item-count -->5<!-- /FACT --> つの Vault アイテム参照すべてが `kryota.dev` Vault に存在すること。
+4. 以下に示す <!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> つの Vault アイテム参照すべてが `kryota.dev` Vault に存在すること。
 
 ---
 
@@ -104,18 +104,18 @@ macOS で `chezmoi apply` を実行する前に:
 
 クライアント/勤務先の識別子パターンを `name1|name2|...` の交替形式で保存します（必要に応じて regex エスケープ済み; `'''` と改行は不可）。chezmoi は apply 時にこれを自社名前空間リポジトリ用の gitleaks 設定にレンダリングします。`run_once_after_11` スクリプトはさらにこの値をスモークテストします——パターンが非空であること、TOML 生文字列リテラルを破壊する `'''` を含まないこと、有効な正規表現としてコンパイルできることを検証します。破損したパターンは自社名前空間リポジトリのすべてのコミットでクライアント識別子ルールをサイレントに無効化してしまいます。
 
-### 5. `Dotfiles - ntfy`
+### 5. `Dotfiles - ntfy`（ゲートの検証対象外）
 
 | 属性 | 値 |
 |-----|---|
 | Vault | `kryota.dev` |
 | アイテムタイトル | `Dotfiles - ntfy` |
-| フィールド参照 | `base-url`（検証対象）, `subscriber-token`（デバイス手入力） |
-| op:// URI | `op://kryota.dev/Dotfiles - ntfy/base-url` |
-| レンダリング先 | `~/.config/ntfy/server.yml`（`base-url`） |
-| ファイルモード | `0600`（`private_` プレフィックスによる） |
+| フィールド参照 | `subscriber-username`（値は `subscriber`）, `subscriber-password`（concealed） |
+| op:// URI | `op://kryota.dev/Dotfiles - ntfy/subscriber-username`, `op://kryota.dev/Dotfiles - ntfy/subscriber-password` |
+| レンダリング先 | chezmoi テンプレートではレンダリングされない — `~/.local/bin/ntfy-setup`（と、それが source する共有ライブラリ `~/.config/ntfy/lib.sh`）が読み書きする |
+| ファイルモード | n/a（1Password アイテムであり、レンダリングされるファイルではない） |
 
-自己ホスト ntfy 通知サーバー（#337; [Notifications](../architecture/notifications.ja.md) 参照）用の 1 アイテムです。`base-url` は `tailscale serve` の HTTPS エンドポイント（`https://<host>.<tailnet>.ts.net`）です——tailnet の MagicDNS 名がこの公開リポジトリに残らないよう 1Password に保存しており、検証ゲートがチェックする唯一のフィールドです。`subscriber-token` はブートストラップ用プレースホルダー（`tk_REPLACE…`）として作成し、セットアップスクリプトが**読み取り専用**のデバイストークンを書き込みます。各スマホへ手入力するためゲートはチェックしません。**書き込み専用**の publisher トークンはここには一切保存しません——セットアップスクリプトが `~/.config/ntfy/notify-env` へ直接書き出します（`user.db` と同様のランタイム状態で、1Password を経由しません）。
+自己ホスト ntfy 通知サーバー（#337; [Notifications](../architecture/notifications.ja.md) 参照）用の 1 アイテムで、**read-only** のデバイスログイン用クレデンシャルのみを保持します。`ntfy-setup` は、このアイテムが存在しない場合に初回だけ自動作成します（Secure Note として）——それは `chezmoi apply` の後、かつ Tailscale/Docker が起動した後というタイミングで、`run_once_after_11` の検証ゲートより後のフェーズです。そのため**このゲートはこのアイテムを一切検証しません**——`Dotfiles - ntfy` が欠落していても `chezmoi apply` が失敗することはありません。**書き込み専用**の publisher トークンも 1Password には保存しません——`ntfy-setup` が `~/.config/ntfy/notify-env` へ直接書き出します（`user.db` と同様のランタイム状態）。`base-url` フィールドはありません: tailnet の MagicDNS 名は保存されず、必要になるたび（デバイスログイン、smoke test）に `tailscale status --json | jq -r .Self.DNSName` でその場導出します。
 
 ---
 
@@ -127,9 +127,9 @@ macOS で `chezmoi apply` を実行する前に:
 | `Dotfiles - Exa API` | 検証ゲートで `chezmoi apply` が exit 1 | `claude-secrets.zsh` がレンダリングされない、exa MCP サーバーが認証失敗 |
 | `Dotfiles - Firecrawl API` | 検証ゲートで `chezmoi apply` が exit 1 | `claude-secrets.zsh` がレンダリングされない、firecrawl MCP サーバーが認証失敗 |
 | `Dotfiles - Redact Patterns` | 検証ゲートで `chezmoi apply` が exit 1 | `gitleaks-own.toml` がレンダリングされない、自社名前空間リポジトリでクライアント識別子 gitleaks ルールが無効化 |
-| `Dotfiles - ntfy` | 検証ゲートで `chezmoi apply` が exit 1（`base-url` 欠落） | `~/.config/ntfy/server.yml` がレンダリングされない、ntfy サーバーに tailnet エンドポイントが設定されずフックラッパーが no-op のまま |
+| `Dotfiles - ntfy` | **`chezmoi apply` は失敗しない** — このアイテムは検証ゲートの対象外 | `ntfy-setup` を実行するまで 1Password にデバイスログイン用クレデンシャルが存在せず、それまでスマホはログインできない。`ntfy-setup` が初回実行時にアイテムを自動作成する。 |
 
-ゲートはすべての 5 参照を成功前にチェックするため、1 つのアイテムが欠落するだけでライフサイクルスクリプトの after フェーズ全体がブロックされます。
+ゲートはこれより上の4参照すべてを成功前にチェックするため、その4つのうち1つのアイテムが欠落するだけでライフサイクルスクリプトの after フェーズ全体がブロックされます。`Dotfiles - ntfy` は意図的にこのゲートの対象外です。
 
 ---
 
@@ -159,7 +159,7 @@ regex = '''(?i)({{ onepasswordRead "op://kryota.dev/Dotfiles - Redact Patterns/p
 
 ## CI での除外
 
-`setup-validation.yml` は CI で `chezmoi apply` を実行する前に 1Password 依存のファイルをすべて除外します。以下の 6 ファイルは **両方のジョブ**（macOS および Ubuntu）で `/tmp/chezmoi-excluded/` に移動されます:
+`setup-validation.yml` は CI で `chezmoi apply` を実行する前に、1Password 依存のファイルに加え、レンダリングだけでなくインストール/対話を行うファイルも除外します。以下の <!-- FACT:ci-both-exclusion-count -->7<!-- /FACT --> ファイルは **両方のジョブ**（macOS および Ubuntu）で `/tmp/chezmoi-excluded/` に移動されます:
 
 ```
 home/private_dot_aws/config.tmpl
@@ -168,7 +168,10 @@ home/run_once_before_00-install-prerequisites.sh.tmpl
 home/run_onchange_before_10-brew-bundle.sh.tmpl
 home/run_once_after_11-validate-1password.sh.tmpl
 home/dot_config/git/private_gitleaks-own.toml.tmpl
+home/dot_config/ntfy/private_server.yml.tmpl
 ```
+
+`home/dot_config/ntfy/private_server.yml.tmpl` はもう 1Password バックドではありません（`base-url`/`onepasswordRead` 呼び出しを廃止したため——[Notifications](../architecture/notifications.ja.md) 参照）が、除外リストには残っています。ntfy Docker コンテナ内でのみ意味を持つコンテナ専用パスを含む 0600 の設定をレンダリングするファイルであり、除外を維持することで churn を最小化するためです（[CI とテスト](../contributing/ci-and-tests.ja.md) 参照）。
 
 **macOS ジョブ**はさらに `home/run_once_after_90-other-apps.sh.tmpl` を除外します（および `home/run_once_after_30-setup-fonts.sh.tmpl` への古い参照も含みますが、そのスクリプトはもう存在しないため `if [ -f ]` ガードにより無視されます）。
 

--- a/docs/getting-started/secrets-1password.md
+++ b/docs/getting-started/secrets-1password.md
@@ -44,7 +44,7 @@ Before running `chezmoi apply` on macOS:
 1. **1Password desktop app** installed and signed in.
 2. **CLI integration enabled**: 1Password → Settings → Developer → "Integrate with 1Password CLI".
 3. **1Password CLI (`op`)** installed: `brew install --cask 1password-cli`.
-4. All <!-- FACT:onepassword-vault-item-count -->5<!-- /FACT --> vault item references listed below exist in the `kryota.dev` vault.
+4. All <!-- FACT:onepassword-vault-item-count -->4<!-- /FACT --> vault item references listed below exist in the `kryota.dev` vault.
 
 ---
 
@@ -104,18 +104,18 @@ Used by the `firecrawl` user-scope Claude Code MCP server. Sets `FIRECRAWL_API_K
 
 Store the client/employer identifier pattern as a `name1|name2|...` alternation (regex-escaped where needed; no `'''`, no newlines). chezmoi renders it into the owner-scoped gitleaks config at apply time. The `run_once_after_11` script additionally smoke-tests this value — it verifies the pattern is non-empty, contains no `'''` (which would break the TOML raw-string literal), and compiles as a valid regex. A broken pattern would silently disable the client-identifier rule on every commit in own-namespace repos.
 
-### 5. `Dotfiles - ntfy`
+### 5. `Dotfiles - ntfy` (not validated by the gate)
 
 | Attribute | Value |
 |-----------|-------|
 | Vault | `kryota.dev` |
 | Item title | `Dotfiles - ntfy` |
-| Field references | `base-url` (validated), `subscriber-token` (device-entered) |
-| op:// URIs | `op://kryota.dev/Dotfiles - ntfy/base-url` |
-| Rendered to | `~/.config/ntfy/server.yml` (`base-url`) |
-| File mode | `0600` (via `private_` prefix) |
+| Field references | `subscriber-username` (value `subscriber`), `subscriber-password` (concealed) |
+| op:// URIs | `op://kryota.dev/Dotfiles - ntfy/subscriber-username`, `op://kryota.dev/Dotfiles - ntfy/subscriber-password` |
+| Rendered to | Not rendered by chezmoi templates — read/written by `~/.local/bin/ntfy-setup` (and the shared `~/.config/ntfy/lib.sh` it sources) |
+| File mode | n/a (1Password item, not a rendered file) |
 
-One item for the self-hosted ntfy notification server (#337; see [Notifications](../architecture/notifications.md)). `base-url` is the `tailscale serve` HTTPS endpoint (`https://<host>.<tailnet>.ts.net`) — stored in 1Password so the tailnet's MagicDNS name never lands in this public repo, and it is the only field the validation gate checks. `subscriber-token` starts as a bootstrap placeholder (`tk_REPLACE…`) that the setup script fills with the **read-only** device token; you enter it on each phone by hand, so the gate does not check it. The **write-only** publisher token is not stored here at all — the setup script writes it straight into `~/.config/ntfy/notify-env` (runtime state, like `user.db`), with no 1Password round-trip.
+One item for the self-hosted ntfy notification server (#337; see [Notifications](../architecture/notifications.md)) — holding the **read-only** device-login credential only. `ntfy-setup` auto-creates this item (as a Secure Note) the first time it is absent, after `chezmoi apply` and after Tailscale/Docker are up — a later phase than the `run_once_after_11` validation gate, so **the gate does not validate this item at all**; a missing `Dotfiles - ntfy` item never fails `chezmoi apply`. The **write-only** publisher token is not stored in 1Password either — `ntfy-setup` writes it straight into `~/.config/ntfy/notify-env` (runtime state, like `user.db`). There is no `base-url` field: the tailnet's MagicDNS name is never stored, only derived on demand (device login, smoke test) via `tailscale status --json | jq -r .Self.DNSName`.
 
 ---
 
@@ -127,9 +127,9 @@ One item for the self-hosted ntfy notification server (#337; see [Notifications]
 | `Dotfiles - Exa API` | `chezmoi apply` exits 1 at the validation gate | `claude-secrets.zsh` not rendered; exa MCP server starts but fails to authenticate |
 | `Dotfiles - Firecrawl API` | `chezmoi apply` exits 1 at the validation gate | `claude-secrets.zsh` not rendered; firecrawl MCP server starts but fails to authenticate |
 | `Dotfiles - Redact Patterns` | `chezmoi apply` exits 1 at the validation gate | `gitleaks-own.toml` not rendered; client-identifier gitleaks rule inactive in own-namespace repos |
-| `Dotfiles - ntfy` | `chezmoi apply` exits 1 at the validation gate (missing `base-url`) | `~/.config/ntfy/server.yml` not rendered; ntfy server has no tailnet endpoint configured and the hook wrapper stays a no-op |
+| `Dotfiles - ntfy` | **`chezmoi apply` does not fail** — this item is outside the validation gate | No device-login credential in 1Password until `ntfy-setup` is run; phones cannot log in until then. `ntfy-setup` auto-creates the item on first run. |
 
-Because the gate checks all five references before any succeeds, a single missing item blocks the entire after-phase of lifecycle scripts.
+Because the gate checks all four references above it before any succeeds, a single missing item among those four blocks the entire after-phase of lifecycle scripts; `Dotfiles - ntfy` is deliberately outside that gate.
 
 ---
 
@@ -159,7 +159,7 @@ Key points:
 
 ## CI exclusions
 
-`setup-validation.yml` excludes all 1Password-dependent files before running `chezmoi apply` in CI. The following 6 files are moved to `/tmp/chezmoi-excluded/` in **both** jobs (macOS and Ubuntu):
+`setup-validation.yml` excludes all 1Password-dependent files, plus files that install/interact rather than merely render, before running `chezmoi apply` in CI. The following <!-- FACT:ci-both-exclusion-count -->7<!-- /FACT --> files are moved to `/tmp/chezmoi-excluded/` in **both** jobs (macOS and Ubuntu):
 
 ```
 home/private_dot_aws/config.tmpl
@@ -168,7 +168,10 @@ home/run_once_before_00-install-prerequisites.sh.tmpl
 home/run_onchange_before_10-brew-bundle.sh.tmpl
 home/run_once_after_11-validate-1password.sh.tmpl
 home/dot_config/git/private_gitleaks-own.toml.tmpl
+home/dot_config/ntfy/private_server.yml.tmpl
 ```
+
+`home/dot_config/ntfy/private_server.yml.tmpl` is no longer 1Password-backed (it dropped its `base-url`/`onepasswordRead` call — see [Notifications](../architecture/notifications.md)), but it stays on the exclusion list: it renders a 0600 config full of container-only paths that would only ever apply inside the ntfy Docker container, and excluding it minimizes churn (see [CI and tests](../contributing/ci-and-tests.md)).
 
 The **macOS job** additionally excludes `home/run_once_after_90-other-apps.sh.tmpl` (and a stale reference to `home/run_once_after_30-setup-fonts.sh.tmpl` that no longer exists — tolerated by an `if [ -f ]` guard).
 

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -125,4 +125,5 @@
 {{ if ne .chezmoi.os "darwin" }}
 Library/
 .config/ntfy
+.local/bin/ntfy-setup
 {{ end }}

--- a/home/dot_config/ntfy/lib.sh.tmpl
+++ b/home/dot_config/ntfy/lib.sh.tmpl
@@ -9,9 +9,11 @@
 #   - This file is SOURCED. It never calls `exit`; functions `return` a status
 #     and the caller decides the exit policy. It never enables `set -x`.
 #   - No secret is ever echoed or traced. Passwords reach ntfy via the
-#     NTFY_PASSWORD env (never argv); the only argv exposure is the local
-#     `op item edit field=value` call, the same transient trade-off already
-#     accepted for tokens (op has no stdin path for single-field edits).
+#     NTFY_PASSWORD env (never argv). Two local, transient argv exposures are
+#     accepted: `op item edit field=value` (op has no single-field stdin
+#     shortcut — only a full JSON template), and the about-to-be-revoked old
+#     token passed to `ntfy token remove` (it takes the token positionally,
+#     with no env alternative). Both are local, one-shot, own-machine calls.
 #   - Template values live on assignment-only lines (the lint pipeline strips
 #     every line containing a template action before shellcheck); references use
 #     the ${var:-} form so the stripped body still lints clean. No comment or
@@ -74,7 +76,10 @@ ntfy_magicdns() {
   if command -v jq >/dev/null 2>&1; then
     dns="$(printf '%s' "$json" | jq -r '.Self.DNSName // empty' 2>/dev/null || true)"
   else
-    dns="$(printf '%s' "$json" | grep -oE '"DNSName"[[:space:]]*:[[:space:]]*"[^"]*"' | head -n 1 | sed 's/.*"\(.*\)"/\1/')"
+    # Scope to the .Self object before grabbing DNSName — JSON key order is not
+    # guaranteed, so a bare "first DNSName" could be a peer's. "Self" appears
+    # once at top level; strip everything up to it, then take the next DNSName.
+    dns="$(printf '%s' "$json" | sed 's/.*"Self"[[:space:]]*:[[:space:]]*{//' | grep -oE '"DNSName"[[:space:]]*:[[:space:]]*"[^"]*"' | head -n 1 | sed 's/.*"\(.*\)"/\1/')"
   fi
   dns="${dns%.}"
   [ -n "$dns" ] || return 1
@@ -119,7 +124,10 @@ ntfy_wait_ready() {
 # --- User / ACL / token primitives ------------------------------------------
 
 ntfy_user_exists() {
-  ntfy_exec user list 2>/dev/null | grep -q "user ${1}"
+  # Match the name exactly: the next char after it must be a field delimiter
+  # (space / colon / paren) or end of line, so `publisher` never matches a
+  # hypothetical `publisher-foo`. Does not assume where "user " sits on the line.
+  ntfy_exec user list 2>/dev/null | grep -qE "user ${1}([ :(]|$)"
 }
 
 # Create a user with a throwaway random password if it does not exist. Used for
@@ -190,9 +198,10 @@ ntfy_read_notify_env_token() {
 }
 
 ntfy_notify_env_has_token() {
+  # Only real server-issued tokens (tk_…) are ever written here; there is no
+  # placeholder-seeding path, so a shape check is sufficient.
   [ -f "$ntfy_env_file" ] &&
-    grep -qE '^NTFY_TOKEN=.*tk_' "$ntfy_env_file" &&
-    ! grep -qE '^NTFY_TOKEN=.*tk_REPLACE' "$ntfy_env_file"
+    grep -qE '^NTFY_TOKEN=.*tk_' "$ntfy_env_file"
 }
 
 # --- 1Password item (subscriber username/password) ---------------------------
@@ -211,8 +220,11 @@ ntfy_ensure_item() {
     "subscriber-password[password]=${ntfy_placeholder}" >/dev/null
 }
 
+# Prints the stored password (empty if the field is absent/empty) and — crucially
+# — propagates op's exit status so callers can tell a real op failure from a
+# genuinely empty value. Callers that overwrite on "empty" MUST check the status.
 ntfy_read_subscriber_password() {
-  op read "op://${ntfy_op_vault}/${ntfy_op_item}/subscriber-password" 2>/dev/null || true
+  op read "op://${ntfy_op_vault}/${ntfy_op_item}/subscriber-password" 2>/dev/null
 }
 
 ntfy_store_subscriber_password() {
@@ -224,12 +236,19 @@ ntfy_store_subscriber_password() {
 # --- High-level provisioning -------------------------------------------------
 
 ntfy_provision_publisher() {
+  local existed=1
+  ntfy_user_exists "$ntfy_pub_user" || existed=0
   ntfy_ensure_user "$ntfy_pub_user" || {
     ntfy_warn "could not create the publisher user; provision manually."
     return 1
   }
   ntfy_grant_acl "$ntfy_pub_user" write-only
-  if ntfy_notify_env_has_token; then
+  # Only trust an existing notify-env token if the publisher user was already
+  # present. If we just (re)created it — e.g. after a user.db loss — any token in
+  # notify-env is stale against the rebuilt server, so reissue. This mirrors the
+  # subscriber self-heal and makes "delete user.db, run ntfy-setup" actually
+  # restore the publisher too.
+  if [ "$existed" = 1 ] && ntfy_notify_env_has_token; then
     return 0
   fi
   local tok
@@ -254,8 +273,12 @@ ntfy_provision_subscriber() {
     ntfy_warn "could not ensure the 1Password item; skipping subscriber."
     return 1
   }
-  local stored pw
-  stored="$(ntfy_read_subscriber_password)"
+  local stored pw rc=0
+  stored="$(ntfy_read_subscriber_password)" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    ntfy_warn "could not read the stored subscriber password (op error); leaving the existing subscriber credential untouched to avoid a device lockout."
+    return 1
+  fi
   if [ -n "$stored" ] && ! printf '%s' "$stored" | grep -q "$ntfy_placeholder"; then
     ntfy_ensure_user_with_password "$ntfy_sub_user" "$stored" || {
       ntfy_warn "could not reconcile the subscriber user password."
@@ -306,8 +329,13 @@ ntfy_rotate_publisher() {
   }
   ntfy_write_notify_env "$new" || return 1
   if [ -n "$old" ] && [ "$old" != "$new" ]; then
-    ntfy_exec token remove "$ntfy_pub_user" "$old" >/dev/null 2>&1 ||
-      ntfy_warn "could not revoke the old publisher token (it may already be gone)."
+    if ! ntfy_exec token remove "$ntfy_pub_user" "$old" >/dev/null 2>&1; then
+      # The new token is already active, but the OLD one may still be valid —
+      # for a leaked-token rotation that is the whole point, so surface it
+      # (non-zero) instead of reporting success.
+      ntfy_warn "the new publisher token is active, but revoking the old one failed; it may still be valid. Retry 'ntfy-setup --rotate publisher' or remove it manually."
+      return 1
+    fi
   fi
   ntfy_log "publisher token rotated."
 }
@@ -333,7 +361,9 @@ ntfy_creds_exist() {
   ntfy_notify_env_has_token || return 1
   command -v op >/dev/null 2>&1 || return 1
   local stored
-  stored="$(ntfy_read_subscriber_password)"
+  # An op read error here is conservatively treated as "no usable creds" (the
+  # interactive path then provisions rather than prompting to rotate).
+  stored="$(ntfy_read_subscriber_password || true)"
   [ -n "$stored" ] && ! printf '%s' "$stored" | grep -q "$ntfy_placeholder"
 }
 
@@ -345,8 +375,8 @@ ntfy_prompt_yn() {
     read -r ans </dev/tty || ans=""
   fi
   case "$ans" in
-  [yY] | [yY][eE][sS]) return 0 ;;
-  *) return 1 ;;
+    [yY] | [yY][eE][sS]) return 0 ;;
+    *) return 1 ;;
   esac
 }
 

--- a/home/dot_config/ntfy/lib.sh.tmpl
+++ b/home/dot_config/ntfy/lib.sh.tmpl
@@ -1,0 +1,365 @@
+# shellcheck shell=bash
+# ntfy lifecycle library (kryota-dev/dotfiles#337). Deployed 0644 to
+# ~/.config/ntfy/lib.sh and sourced by run_onchange_after_31-setup-ntfy (apply
+# time, fail-open) and ~/.local/bin/ntfy-setup (user command, fail-clear). This
+# is the single source of truth for bringing the server up and provisioning /
+# rotating credentials, so the two entry points can never drift.
+#
+# Design contract:
+#   - This file is SOURCED. It never calls `exit`; functions `return` a status
+#     and the caller decides the exit policy. It never enables `set -x`.
+#   - No secret is ever echoed or traced. Passwords reach ntfy via the
+#     NTFY_PASSWORD env (never argv); the only argv exposure is the local
+#     `op item edit field=value` call, the same transient trade-off already
+#     accepted for tokens (op has no stdin path for single-field edits).
+#   - Template values live on assignment-only lines (the lint pipeline strips
+#     every line containing a template action before shellcheck); references use
+#     the ${var:-} form so the stripped body still lints clean. No comment or
+#     control-flow line contains a literal open-brace pair.
+ntfy_port="{{ .ntfy.port }}"
+ntfy_topic_attention="{{ .ntfy.topic_attention }}"
+ntfy_topic_done="{{ .ntfy.topic_done }}"
+
+ntfy_compose_cfg="$HOME/.config/ntfy/compose.yaml"
+ntfy_env_file="$HOME/.config/ntfy/notify-env"
+ntfy_state_dir="$HOME/Library/Application Support/ntfy"
+ntfy_serve_target="http://127.0.0.1:${ntfy_port:-}"
+ntfy_op_item="Dotfiles - ntfy"
+ntfy_op_vault="kryota.dev"
+ntfy_smoke_topic="claude-test"
+ntfy_pub_user="publisher"
+ntfy_sub_user="subscriber"
+# Placeholder marker the 1Password bootstrap password carries until provisioned.
+ntfy_placeholder="REPLACE_ME"
+
+ntfy_log() { echo "[ntfy] $*"; }
+ntfy_warn() { echo "[ntfy] $*" >&2; }
+
+ntfy_ensure_state_dir() {
+  mkdir -p "$ntfy_state_dir"
+  chmod 700 "$ntfy_state_dir"
+}
+
+# --- Prerequisite probes -----------------------------------------------------
+
+ntfy_docker_ready() {
+  command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1
+}
+
+ntfy_tailscale_bin() {
+  local b
+  b="$(command -v tailscale 2>/dev/null || true)"
+  if [ -z "$b" ] && [ -x "/Applications/Tailscale.app/Contents/MacOS/Tailscale" ]; then
+    b="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+  fi
+  printf '%s' "$b"
+}
+
+ntfy_tailscale_up() {
+  local b
+  b="$(ntfy_tailscale_bin)"
+  [ -n "$b" ] || return 1
+  # BackendState is "Running" once tailscaled is up and logged in.
+  "$b" status --json 2>/dev/null | grep -q '"BackendState"[[:space:]]*:[[:space:]]*"Running"'
+}
+
+# MagicDNS name of this host (for human-facing device-login / smoke-test hints
+# only; never stored). Trailing dot stripped. Empty if unavailable.
+ntfy_magicdns() {
+  local b json dns
+  b="$(ntfy_tailscale_bin)"
+  [ -n "$b" ] || return 1
+  json="$("$b" status --json 2>/dev/null || true)"
+  [ -n "$json" ] || return 1
+  if command -v jq >/dev/null 2>&1; then
+    dns="$(printf '%s' "$json" | jq -r '.Self.DNSName // empty' 2>/dev/null || true)"
+  else
+    dns="$(printf '%s' "$json" | grep -oE '"DNSName"[[:space:]]*:[[:space:]]*"[^"]*"' | head -n 1 | sed 's/.*"\(.*\)"/\1/')"
+  fi
+  dns="${dns%.}"
+  [ -n "$dns" ] || return 1
+  printf '%s' "$dns"
+}
+
+# --- Server bring-up ---------------------------------------------------------
+
+ntfy_start_server() {
+  ntfy_ensure_state_dir
+  docker compose -f "$ntfy_compose_cfg" up -d --remove-orphans
+}
+
+# Assert the tailnet HTTPS front. `--bg` persists across reboots. NEVER use
+# `tailscale funnel` here: the server must stay tailnet-only.
+ntfy_assert_serve() {
+  local b
+  b="$(ntfy_tailscale_bin)"
+  [ -n "$b" ] || {
+    ntfy_warn "tailscale CLI not found; cannot assert serve mapping."
+    return 1
+  }
+  "$b" serve --bg "${ntfy_serve_target:-}"
+}
+
+ntfy_exec() {
+  docker compose -f "$ntfy_compose_cfg" exec -T ntfy ntfy "$@"
+}
+
+# Give the freshly-started container a moment to accept `ntfy user` calls.
+ntfy_wait_ready() {
+  local i
+  for i in 1 2 3 4 5 6 7 8; do
+    if ntfy_exec user list >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# --- User / ACL / token primitives ------------------------------------------
+
+ntfy_user_exists() {
+  ntfy_exec user list 2>/dev/null | grep -q "user ${1}"
+}
+
+# Create a user with a throwaway random password if it does not exist. Used for
+# the publisher, which authenticates with a token, so its password is never
+# needed or stored.
+ntfy_ensure_user() {
+  local u="$1"
+  ntfy_user_exists "$u" && return 0
+  ntfy_log "creating ntfy user ${u}..."
+  NTFY_PASSWORD="$(openssl rand -base64 24)" \
+    docker compose -f "$ntfy_compose_cfg" exec -T -e NTFY_PASSWORD ntfy ntfy user add "$u"
+}
+
+# Ensure a user exists with a specific (known) password. `user add` when absent,
+# `user change-pass` when present — both read the password from NTFY_PASSWORD
+# (verified in the ntfy CLI source), so the password never lands in argv, and
+# change-pass preserves the user's ACLs.
+ntfy_ensure_user_with_password() {
+  local u="$1" pw="$2" sub
+  if ntfy_user_exists "$u"; then
+    sub="change-pass"
+  else
+    sub="add"
+  fi
+  NTFY_PASSWORD="$pw" \
+    docker compose -f "$ntfy_compose_cfg" exec -T -e NTFY_PASSWORD ntfy ntfy user "$sub" "$u"
+}
+
+# Idempotent ACL grant across the two rendered topics plus the runbook-only
+# smoke-test topic.
+ntfy_grant_acl() {
+  local u="$1" perm="$2" t
+  for t in "${ntfy_topic_attention:-}" "${ntfy_topic_done:-}" "$ntfy_smoke_topic"; do
+    ntfy_exec access "$u" "$t" "$perm" >/dev/null 2>&1 || true
+  done
+}
+
+ntfy_issue_token() {
+  ntfy_exec token add --label "$1" "$2" 2>/dev/null | grep -oE 'tk_[A-Za-z0-9]+' | head -n 1
+}
+
+# --- notify-env (publisher token, runtime state) -----------------------------
+
+# Write notify-env 0600 via umask; the token reaches the file only through the
+# heredoc (never echoed or traced). Reuses the exact format the wrapper sources.
+ntfy_write_notify_env() {
+  (
+    umask 077
+    cat >"$ntfy_env_file" <<EOF
+# ntfy publisher credentials for the Claude Code hook wrapper
+# (~/.claude/ntfy-notify.sh, kryota-dev/dotfiles#337). Runtime state written
+# 0600 by ~/.config/ntfy/lib.sh — NOT a chezmoi target. Sourced, never exported,
+# by the wrapper so the token only lives in that process. The wrapper publishes
+# to the loopback listener directly, so it keeps working even if the tailscale
+# serve front is down.
+NTFY_URL='${ntfy_serve_target}'
+# Write-only publisher token (least privilege: cannot read history if leaked).
+NTFY_TOKEN='$1'
+NTFY_TOPIC_ATTENTION='${ntfy_topic_attention}'
+NTFY_TOPIC_DONE='${ntfy_topic_done}'
+EOF
+  )
+}
+
+ntfy_read_notify_env_token() {
+  [ -f "$ntfy_env_file" ] || return 1
+  sed -n "s/^NTFY_TOKEN='\{0,1\}\(tk_[A-Za-z0-9]*\).*/\1/p" "$ntfy_env_file" | head -n 1
+}
+
+ntfy_notify_env_has_token() {
+  [ -f "$ntfy_env_file" ] &&
+    grep -qE '^NTFY_TOKEN=.*tk_' "$ntfy_env_file" &&
+    ! grep -qE '^NTFY_TOKEN=.*tk_REPLACE' "$ntfy_env_file"
+}
+
+# --- 1Password item (subscriber username/password) ---------------------------
+
+ntfy_item_exists() {
+  op item get "$ntfy_op_item" --vault "$ntfy_op_vault" >/dev/null 2>&1
+}
+
+# Create the item only when absent — a create-time non-destructive guard. Never
+# touches an existing item's fields.
+ntfy_ensure_item() {
+  ntfy_item_exists && return 0
+  ntfy_log "creating 1Password item '${ntfy_op_item}'..."
+  op item create --category "Secure Note" --title "$ntfy_op_item" --vault "$ntfy_op_vault" \
+    "subscriber-username[text]=${ntfy_sub_user}" \
+    "subscriber-password[password]=${ntfy_placeholder}" >/dev/null
+}
+
+ntfy_read_subscriber_password() {
+  op read "op://${ntfy_op_vault}/${ntfy_op_item}/subscriber-password" 2>/dev/null || true
+}
+
+ntfy_store_subscriber_password() {
+  op item edit "$ntfy_op_item" --vault "$ntfy_op_vault" \
+    "subscriber-username[text]=${ntfy_sub_user}" \
+    "subscriber-password[password]=${1}" >/dev/null
+}
+
+# --- High-level provisioning -------------------------------------------------
+
+ntfy_provision_publisher() {
+  ntfy_ensure_user "$ntfy_pub_user" || {
+    ntfy_warn "could not create the publisher user; provision manually."
+    return 1
+  }
+  ntfy_grant_acl "$ntfy_pub_user" write-only
+  if ntfy_notify_env_has_token; then
+    return 0
+  fi
+  local tok
+  tok="$(ntfy_issue_token chezmoi "$ntfy_pub_user" || true)"
+  [ -n "$tok" ] || {
+    ntfy_warn "publisher token issuance failed; provision manually."
+    return 1
+  }
+  ntfy_write_notify_env "$tok" || {
+    ntfy_warn "failed to write notify-env."
+    return 1
+  }
+  ntfy_log "publisher token issued and written to notify-env."
+}
+
+# Requires op. Creates the item if absent, then reconciles the subscriber user's
+# password with 1Password: if a real password is stored, re-apply it to the
+# ntfy user (self-heals after a user.db loss); if only a placeholder is stored,
+# generate one, apply it, and store it.
+ntfy_provision_subscriber() {
+  ntfy_ensure_item || {
+    ntfy_warn "could not ensure the 1Password item; skipping subscriber."
+    return 1
+  }
+  local stored pw
+  stored="$(ntfy_read_subscriber_password)"
+  if [ -n "$stored" ] && ! printf '%s' "$stored" | grep -q "$ntfy_placeholder"; then
+    ntfy_ensure_user_with_password "$ntfy_sub_user" "$stored" || {
+      ntfy_warn "could not reconcile the subscriber user password."
+      return 1
+    }
+    ntfy_grant_acl "$ntfy_sub_user" read-only
+    ntfy_log "subscriber user reconciled with the password in 1Password."
+    return 0
+  fi
+  pw="$(openssl rand -base64 24)"
+  ntfy_ensure_user_with_password "$ntfy_sub_user" "$pw" || {
+    ntfy_warn "could not set the subscriber password."
+    return 1
+  }
+  ntfy_grant_acl "$ntfy_sub_user" read-only
+  ntfy_store_subscriber_password "$pw" || {
+    ntfy_warn "failed to store the subscriber password in 1Password."
+    return 1
+  }
+  ntfy_log "subscriber user provisioned; username/password stored in 1Password."
+}
+
+# Full provisioning. Publisher never needs op; the subscriber half is skipped
+# (warn) when op is absent, without failing the publisher half.
+ntfy_provision() {
+  ntfy_wait_ready || ntfy_warn "ntfy container not ready yet; provisioning may be incomplete."
+  ntfy_provision_publisher || ntfy_warn "publisher provisioning incomplete."
+  if command -v op >/dev/null 2>&1; then
+    ntfy_provision_subscriber || ntfy_warn "subscriber provisioning incomplete."
+  else
+    ntfy_warn "op CLI not found; skipping subscriber (device login) provisioning."
+  fi
+}
+
+# --- Rotation ----------------------------------------------------------------
+
+# Read the OLD token first, issue the NEW one, write it, then revoke the OLD so
+# the genuinely-previous (possibly leaked) token is the one that is removed.
+ntfy_rotate_publisher() {
+  ntfy_ensure_user "$ntfy_pub_user" || return 1
+  ntfy_grant_acl "$ntfy_pub_user" write-only
+  local old new
+  old="$(ntfy_read_notify_env_token || true)"
+  new="$(ntfy_issue_token chezmoi "$ntfy_pub_user" || true)"
+  [ -n "$new" ] || {
+    ntfy_warn "new publisher token issuance failed."
+    return 1
+  }
+  ntfy_write_notify_env "$new" || return 1
+  if [ -n "$old" ] && [ "$old" != "$new" ]; then
+    ntfy_exec token remove "$ntfy_pub_user" "$old" >/dev/null 2>&1 ||
+      ntfy_warn "could not revoke the old publisher token (it may already be gone)."
+  fi
+  ntfy_log "publisher token rotated."
+}
+
+ntfy_rotate_subscriber() {
+  command -v op >/dev/null 2>&1 || {
+    ntfy_warn "op CLI not found; cannot rotate the subscriber credential."
+    return 1
+  }
+  ntfy_ensure_item || return 1
+  local pw
+  pw="$(openssl rand -base64 24)"
+  ntfy_ensure_user_with_password "$ntfy_sub_user" "$pw" || return 1
+  ntfy_grant_acl "$ntfy_sub_user" read-only
+  ntfy_store_subscriber_password "$pw" || return 1
+  ntfy_log "subscriber password rotated and updated in 1Password."
+  ntfy_log "Re-enter the new password in the ntfy app on every subscribed device."
+}
+
+# --- Interactive helpers -----------------------------------------------------
+
+ntfy_creds_exist() {
+  ntfy_notify_env_has_token || return 1
+  command -v op >/dev/null 2>&1 || return 1
+  local stored
+  stored="$(ntfy_read_subscriber_password)"
+  [ -n "$stored" ] && ! printf '%s' "$stored" | grep -q "$ntfy_placeholder"
+}
+
+# Prompt on /dev/tty; default to N (skip) when no tty is available (fail-open).
+ntfy_prompt_yn() {
+  local ans=""
+  if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+    printf '%s' "$1" >/dev/tty
+    read -r ans </dev/tty || ans=""
+  fi
+  case "$ans" in
+  [yY] | [yY][eE][sS]) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+ntfy_print_device_info() {
+  local dns url
+  dns="$(ntfy_magicdns || true)"
+  if [ -n "$dns" ]; then
+    url="https://${dns}"
+  else
+    url="https://<your-tailnet-magicdns-name>"
+  fi
+  ntfy_log "Device login — server: ${url}"
+  ntfy_log "  username: ${ntfy_sub_user}"
+  ntfy_log "  password: 1Password ${ntfy_op_item} / subscriber-password"
+  ntfy_log "  topics:   ${ntfy_topic_attention}, ${ntfy_topic_done}"
+}

--- a/home/dot_config/ntfy/private_server.yml.tmpl
+++ b/home/dot_config/ntfy/private_server.yml.tmpl
@@ -1,12 +1,16 @@
 # ntfy server configuration (kryota-dev/dotfiles#337). Deployed 0600; mounted
 # read-only into the ntfy container at /etc/ntfy/server.yml (paths below are
-# container paths). CI never renders this file — it is on the
-# "Exclude CI-incompatible files" list in setup-validation.yml (onepasswordRead).
+# container paths). This file is kept on the "Exclude CI-incompatible files"
+# list in setup-validation.yml; it no longer reads from 1Password (base-url was
+# dropped — see below), but staying excluded avoids CI rendering a 0600 config
+# full of container-only paths.
 
-# Public URL of this server as seen by subscribers (the `tailscale serve`
-# HTTPS endpoint). Stored in 1Password so the tailnet's MagicDNS name never
-# lands in this public repo.
-base-url: "{{ onepasswordRead "op://kryota.dev/Dotfiles - ntfy/base-url" | trim }}"
+# NOTE: `base-url` is intentionally NOT set. It is optional for core messaging
+# (only attachments / email footer links need it, none of which this setup
+# uses), it does not affect the iOS `upstream-base-url` relay, and deriving the
+# tailnet MagicDNS name at apply time would couple `chezmoi apply` to Tailscale
+# being up. The MagicDNS URL is derived on demand (device login / smoke test)
+# by ntfy-setup instead, and never stored.
 
 # iOS instant push relay (user-approved at the #337 PRD gate). NOTE: per
 # docs.ntfy.sh/config this publishes a poll request to ntfy.sh for EVERY

--- a/home/dot_config/ntfy/private_server.yml.tmpl
+++ b/home/dot_config/ntfy/private_server.yml.tmpl
@@ -30,7 +30,8 @@ cache-file: /var/lib/ntfy/cache.db
 cache-duration: "{{ .ntfy.cache_duration }}"
 
 # Auth: private instance, deny-all by default. Users/tokens are provisioned
-# once manually via `docker compose exec` (see docs/architecture/notifications.md);
+# automatically by ~/.config/ntfy/lib.sh (run_onchange_after_31-setup-ntfy at
+# apply time, or `ntfy-setup` on demand — see docs/architecture/notifications.md);
 # user.db is runtime state, never chezmoi-managed.
 auth-file: /var/lib/ntfy/user.db
 auth-default-access: "deny-all"

--- a/home/dot_local/bin/executable_ntfy-setup
+++ b/home/dot_local/bin/executable_ntfy-setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ntfy-setup — bring up the self-hosted ntfy server and provision / rotate its
 # credentials (kryota-dev/dotfiles#337). All logic lives in the shared library;
 # this is the on-demand, re-runnable entry point (the apply-time
@@ -16,9 +16,9 @@
 # Desktop is not running, so run this once both are available.
 set -euo pipefail
 
-EXIT_ERR=1        # an operation failed
-EXIT_USAGE=2      # bad arguments / library missing
-EXIT_PREREQ=3     # a prerequisite this command cannot fix is missing
+EXIT_ERR=1    # an operation failed
+EXIT_USAGE=2  # bad arguments / library missing
+EXIT_PREREQ=3 # a prerequisite this command cannot fix is missing
 
 usage() {
   cat >&2 <<'USAGE'
@@ -32,25 +32,25 @@ USAGE
 
 rotate=""
 case "${1:-}" in
-"") ;;
---rotate)
-  rotate="${2:-}"
-  case "$rotate" in
-  publisher | subscriber | all) ;;
+  "") ;;
+  --rotate)
+    rotate="${2:-}"
+    case "$rotate" in
+      publisher | subscriber | all) ;;
+      *)
+        usage
+        exit "$EXIT_USAGE"
+        ;;
+    esac
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
   *)
     usage
     exit "$EXIT_USAGE"
     ;;
-  esac
-  ;;
--h | --help)
-  usage
-  exit 0
-  ;;
-*)
-  usage
-  exit "$EXIT_USAGE"
-  ;;
 esac
 
 lib="$HOME/.config/ntfy/lib.sh"
@@ -85,12 +85,12 @@ ntfy_wait_ready || echo "ntfy-setup: ntfy container is slow to become ready; con
 
 if [ -n "$rotate" ]; then
   case "$rotate" in
-  publisher) ntfy_rotate_publisher ;;
-  subscriber) ntfy_rotate_subscriber ;;
-  all)
-    ntfy_rotate_publisher
-    ntfy_rotate_subscriber
-    ;;
+    publisher) ntfy_rotate_publisher ;;
+    subscriber) ntfy_rotate_subscriber ;;
+    all)
+      ntfy_rotate_publisher
+      ntfy_rotate_subscriber
+      ;;
   esac
   ntfy_print_device_info
   exit 0

--- a/home/dot_local/bin/executable_ntfy-setup
+++ b/home/dot_local/bin/executable_ntfy-setup
@@ -1,0 +1,107 @@
+#!/bin/bash
+# ntfy-setup — bring up the self-hosted ntfy server and provision / rotate its
+# credentials (kryota-dev/dotfiles#337). All logic lives in the shared library;
+# this is the on-demand, re-runnable entry point (the apply-time
+# run_onchange_after_31-setup-ntfy sources the same library, fail-open).
+#
+# Unlike the apply-time path this command is fail-clear: it exits non-zero with
+# guidance when a prerequisite it cannot fix itself is missing.
+#
+#   ntfy-setup                         set up / repair (asks before rotating live creds)
+#   ntfy-setup --rotate publisher      rotate the publisher token
+#   ntfy-setup --rotate subscriber     rotate the subscriber password
+#   ntfy-setup --rotate all            rotate both
+#
+# Two-phase reality: on a fresh machine Tailscale is not yet `up` and Docker
+# Desktop is not running, so run this once both are available.
+set -euo pipefail
+
+EXIT_ERR=1        # an operation failed
+EXIT_USAGE=2      # bad arguments / library missing
+EXIT_PREREQ=3     # a prerequisite this command cannot fix is missing
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: ntfy-setup [--rotate publisher|subscriber|all]
+  (no args)                 set up or repair; prompts before rotating live credentials
+  --rotate publisher        rotate the write-only publisher token (notify-env)
+  --rotate subscriber       rotate the read-only subscriber password (1Password + devices)
+  --rotate all              rotate both
+USAGE
+}
+
+rotate=""
+case "${1:-}" in
+"") ;;
+--rotate)
+  rotate="${2:-}"
+  case "$rotate" in
+  publisher | subscriber | all) ;;
+  *)
+    usage
+    exit "$EXIT_USAGE"
+    ;;
+  esac
+  ;;
+-h | --help)
+  usage
+  exit 0
+  ;;
+*)
+  usage
+  exit "$EXIT_USAGE"
+  ;;
+esac
+
+lib="$HOME/.config/ntfy/lib.sh"
+if [ ! -r "$lib" ]; then
+  echo "ntfy-setup: $lib not found. Run 'chezmoi apply' first." >&2
+  exit "$EXIT_USAGE"
+fi
+# shellcheck source=/dev/null
+. "$lib"
+
+# Prerequisites this command cannot fix itself.
+if ! ntfy_docker_ready; then
+  echo "ntfy-setup: Docker Desktop is not running. Start it, then re-run ntfy-setup." >&2
+  exit "$EXIT_PREREQ"
+fi
+if ! ntfy_tailscale_up; then
+  echo "ntfy-setup: Tailscale is not up. Run 'tailscale up', then re-run ntfy-setup." >&2
+  exit "$EXIT_PREREQ"
+fi
+
+# Bring the server up (idempotent) — this is what restarts a container that went
+# down after a reboot, which a plain 'chezmoi apply' cannot do.
+if ! ntfy_start_server; then
+  echo "ntfy-setup: failed to start the ntfy container." >&2
+  exit "$EXIT_ERR"
+fi
+if ! ntfy_assert_serve; then
+  echo "ntfy-setup: 'tailscale serve' failed (is tailscaled healthy?)." >&2
+  exit "$EXIT_ERR"
+fi
+ntfy_wait_ready || echo "ntfy-setup: ntfy container is slow to become ready; continuing." >&2
+
+if [ -n "$rotate" ]; then
+  case "$rotate" in
+  publisher) ntfy_rotate_publisher ;;
+  subscriber) ntfy_rotate_subscriber ;;
+  all)
+    ntfy_rotate_publisher
+    ntfy_rotate_subscriber
+    ;;
+  esac
+  ntfy_print_device_info
+  exit 0
+fi
+
+# No explicit rotate: provision/repair. If live credentials already exist, ask
+# before rotating them (default N without a tty).
+if ntfy_creds_exist && ntfy_prompt_yn "ntfy credentials already exist — rotate them? [y/N] "; then
+  ntfy_rotate_publisher
+  ntfy_rotate_subscriber
+else
+  ntfy_provision
+fi
+ntfy_print_device_info

--- a/home/run_once_after_11-validate-1password.sh.tmpl
+++ b/home/run_once_after_11-validate-1password.sh.tmpl
@@ -36,19 +36,13 @@ ITEMS=(
   # pre-commit hook for own-namespace repos only). Create as a Secure Note
   # exposing a `pattern` field holding a single `name1|name2|...` alternation.
   "op://kryota.dev/Dotfiles - Redact Patterns/pattern"
-  # Self-hosted ntfy notification server (#337). Create one item exposing:
-  #   base-url        — the `tailscale serve` HTTPS endpoint
-  #                     (https://<host>.<tailnet>.ts.net), kept out of this
-  #                     public repo (rendered into ~/.config/ntfy/server.yml)
-  #   subscriber-token — a bootstrap placeholder (tk_REPLACE…); the setup script
-  #                     auto-issues the read-only token here, then it is entered
-  #                     on devices manually from 1Password, so it is not
-  #                     validated here.
-  # The write-only publisher token is NOT in 1Password: it is produced and
-  # consumed only on this machine, so run_onchange_after_31-setup-ntfy writes it
-  # straight into the 0600 ~/.config/ntfy/notify-env (runtime state, like
-  # user.db) with no 1Password round-trip.
-  "op://kryota.dev/Dotfiles - ntfy/base-url"
+  # Self-hosted ntfy notification server (#337) is intentionally NOT validated
+  # here. Its 1Password item ('Dotfiles - ntfy') holds only the read-only
+  # subscriber username/password used for phone logins, which ntfy-setup
+  # auto-creates and fills after Tailscale/Docker come up — a later phase than
+  # this gate, so validating it here would hard-fail a fresh apply. The
+  # write-only publisher token lives in ~/.config/ntfy/notify-env (runtime state,
+  # like user.db), never in 1Password. Nothing ntfy-related blocks apply here.
 )
 
 for item in "${ITEMS[@]}"; do
@@ -81,25 +75,5 @@ if command -v python3 &>/dev/null; then
     exit 1
   fi
 fi
-
-# Content validation for the ntfy base-url, mirroring the Redact Patterns
-# precedent above. A quote/newline in base-url would escape the YAML scalar in
-# server.yml (config-key injection). The publisher token is not read here — the
-# setup script issues and writes it into notify-env directly, so 1Password
-# never holds it.
-ntfy_url="$(op read "op://kryota.dev/Dotfiles - ntfy/base-url" 2>/dev/null || true)"
-case "$ntfy_url" in
-  https://*.ts.net) ;;
-  *)
-    echo "ERROR: ntfy base-url must be an https://<host>.<tailnet>.ts.net endpoint."
-    exit 1
-    ;;
-esac
-case "$ntfy_url" in
-  *['"'$'\n''']*)
-    echo "ERROR: ntfy base-url contains a quote or newline (breaks the YAML scalar in server.yml)."
-    exit 1
-    ;;
-esac
 
 echo "==> All 1Password items verified successfully."

--- a/home/run_onchange_after_31-setup-ntfy.sh.tmpl
+++ b/home/run_onchange_after_31-setup-ntfy.sh.tmpl
@@ -1,172 +1,57 @@
 {{ if eq .chezmoi.os "darwin" -}}
 #!/bin/bash
-# Start the self-hosted ntfy server and assert its tailnet front
-# (kryota-dev/dotfiles#337). Re-runs whenever the compose file or server
-# config changes (embedded hashes below).
+# Bring the self-hosted ntfy server up and provision its credentials via the
+# shared library (kryota-dev/dotfiles#337). All logic lives in
+# ~/.config/ntfy/lib.sh so this apply-time path and the ~/.local/bin/ntfy-setup
+# command can never drift. Re-runs whenever the compose file, the server config,
+# or the library changes (embedded hashes below).
 # compose hash: {{ include "dot_config/ntfy/compose.yaml.tmpl" | sha256sum }}
 # server.yml hash: {{ include "dot_config/ntfy/private_server.yml.tmpl" | sha256sum }}
+# lib hash: {{ include "dot_config/ntfy/lib.sh.tmpl" | sha256sum }}
 set -euo pipefail
 
 # CI runners must never start services or touch the network from this script.
-# Skip inside CI only — the render/apply path stays CI-validated.
 if [ -n "${CI:-}" ]; then
   echo "[ntfy] CI detected; skipping ntfy setup."
   exit 0
 fi
 
-# Template values live on assignment-only lines: the lint pipeline strips every
-# template-tag line before shellcheck/shfmt, so control flow must never carry
-# them (and comments must never contain a literal open-brace pair — the Go
-# template parser reads it as an action even inside a shell comment).
-# References use ${var:-} so the stripped body still lints clean.
-serve_target="http://127.0.0.1:{{ .ntfy.port }}"
-topic_attention="{{ .ntfy.topic_attention }}"
-topic_done="{{ .ntfy.topic_done }}"
-
-# Runtime state (auth user.db, message cache.db) lives outside the chezmoi
-# target tree; owner-only.
-state_dir="$HOME/Library/Application Support/ntfy"
-mkdir -p "$state_dir"
-chmod 700 "$state_dir"
+# Source the SSOT library (deployed before this after-phase script runs). Guard
+# its presence so a missing file never aborts apply.
+lib="$HOME/.config/ntfy/lib.sh"
+if [ ! -r "$lib" ]; then
+  echo "[ntfy] $lib not found; skipping. Run 'ntfy-setup' after apply." >&2
+  exit 0
+fi
+# shellcheck source=/dev/null
+. "$lib"
 
 # Intentional deviation from the launchctl exit-1 convention (lifecycle
 # convention #6): notification setup must never block `chezmoi apply` —
-# notifications are not setup-critical. NOTE the run_onchange consequence:
-# exit 0 records this script as done, so re-running `chezmoi apply` does NOT
-# retry until the compose/server templates change. The printed manual command
-# is the recovery path that actually works.
-if ! command -v docker >/dev/null 2>&1; then
-  echo "[ntfy] docker CLI not found; skipping server start." >&2
-  echo "[ntfy] Recover with: docker compose -f ~/.config/ntfy/compose.yaml up -d" >&2
-  exit 0
-fi
-if ! docker info >/dev/null 2>&1; then
+# notifications are not setup-critical. NOTE the run_onchange consequence: exit 0
+# records this script as done, so re-running `chezmoi apply` does NOT retry until
+# the compose/server/lib templates change. `ntfy-setup` is the recovery path that
+# actually works (it re-runs the same library flow on demand).
+if ! ntfy_docker_ready; then
   echo "[ntfy] Docker Desktop is not running; skipping server start." >&2
-  echo "[ntfy] Recover with: docker compose -f ~/.config/ntfy/compose.yaml up -d" >&2
+  echo "[ntfy] Recover once Docker is running: ntfy-setup" >&2
   exit 0
 fi
-
-echo "[ntfy] starting ntfy server (docker compose up -d)..."
-if ! docker compose -f "$HOME/.config/ntfy/compose.yaml" up -d --remove-orphans; then
+if ! ntfy_start_server; then
   echo "[ntfy] docker compose up failed; notifications will fail open." >&2
-  echo "[ntfy] Recover with: docker compose -f ~/.config/ntfy/compose.yaml up -d" >&2
+  echo "[ntfy] Recover with: ntfy-setup" >&2
   exit 0
 fi
-
-# Assert the tailnet HTTPS front. `--bg` persists the mapping across reboots
-# and tailscaled restarts (tailscale.com/kb/1242); re-running is idempotent.
-# NEVER use `tailscale funnel` here — the server must stay tailnet-only.
-tailscale_bin="$(command -v tailscale || true)"
-if [ -z "$tailscale_bin" ] && [ -x "/Applications/Tailscale.app/Contents/MacOS/Tailscale" ]; then
-  tailscale_bin="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
-fi
-if [ -z "$tailscale_bin" ]; then
-  echo "[ntfy] tailscale CLI not found; skipping serve assertion." >&2
-  echo "[ntfy] Recover with: tailscale serve --bg ${serve_target:-}" >&2
-  exit 0
-fi
-
-echo "[ntfy] asserting tailscale serve mapping..."
-if ! "$tailscale_bin" serve --bg "${serve_target:-}"; then
+if ! ntfy_assert_serve; then
   echo "[ntfy] tailscale serve failed (tailscaled down or not logged in)." >&2
-  echo "[ntfy] Recover with: tailscale serve --bg ${serve_target:-}" >&2
+  echo "[ntfy] Recover once Tailscale is up: ntfy-setup" >&2
   exit 0
 fi
-echo "[ntfy] ntfy server up at ${serve_target:-} behind tailscale serve."
+echo "[ntfy] ntfy server up at ${ntfy_serve_target:-} behind tailscale serve."
 
-# --- Auth auto-provisioning (idempotent; user-requested #337 follow-up,
-# overriding the PRD D6 manual runbook). Creates the publisher/subscriber
-# users and per-topic ACLs inside the container, then provisions two tokens:
-#   - publisher token  -> written straight into ~/.config/ntfy/notify-env,
-#     runtime state this script owns (like user.db); the wrapper sources it
-#     locally, so this half needs neither op nor a second apply.
-#   - subscriber token -> stored in 1Password, the cross-device channel typed
-#     by hand on each phone; this half needs the op CLI.
-# Every failure path warns and exits 0 (fail-open, same contract as above).
-# The ntfy CLI edits user.db directly via the mounted server.yml, so this
-# works as soon as the container is up. Throwaway passwords: tokens are the
-# real credential; recovery = delete user.db and re-run this provisioning.
-compose_cfg="$HOME/.config/ntfy/compose.yaml"
-ntfy_exec() {
-  docker compose -f "$compose_cfg" exec -T ntfy ntfy "$@"
-}
-user_list="$(ntfy_exec user list 2>&1 || true)"
-for u in publisher subscriber; do
-  if ! printf '%s' "$user_list" | grep -q "user ${u}"; then
-    echo "[ntfy] creating user ${u}..."
-    if ! NTFY_PASSWORD="$(openssl rand -base64 24)" docker compose -f "$compose_cfg" exec -T -e NTFY_PASSWORD ntfy ntfy user add "$u"; then
-      echo "[ntfy] user add ${u} failed; provision manually (see notifications.md runbook)." >&2
-      exit 0
-    fi
-  fi
-done
-# ACL grants are idempotent (re-applying the same grant is a no-op).
-# claude-test is the runbook-only smoke-test topic (not rendered config).
-for t in "${topic_attention:-}" "${topic_done:-}" claude-test; do
-  ntfy_exec access publisher "$t" write-only >/dev/null || true
-  ntfy_exec access subscriber "$t" read-only >/dev/null || true
-done
-issue_token() {
-  ntfy_exec token add --label "$1" "$2" 2>/dev/null | grep -oE 'tk_[A-Za-z0-9]+' | head -n 1
-}
-
-# Publisher token -> notify-env (runtime state; no op CLI, no second apply).
-# Written 0600 via umask and never echoed or traced. The assignment-only
-# template values captured up top (serve_target / topic_*) are reused here so
-# the heredoc carries no template action for the lint pipeline to strip.
-env_file="$HOME/.config/ntfy/notify-env"
-write_notify_env() {
-  (
-    umask 077
-    cat >"$env_file" <<EOF
-# ntfy publisher credentials for the Claude Code hook wrapper
-# (~/.claude/ntfy-notify.sh, kryota-dev/dotfiles#337). Runtime state written
-# 0600 by run_onchange_after_31-setup-ntfy — NOT a chezmoi target. Sourced,
-# never exported, by the wrapper so the token only lives in that process. The
-# wrapper publishes to the loopback listener directly, so it keeps working even
-# if the tailscale serve front is down.
-NTFY_URL='${serve_target}'
-# Write-only publisher token (least privilege: cannot read history if leaked).
-NTFY_TOKEN='$1'
-NTFY_TOPIC_ATTENTION='${topic_attention}'
-NTFY_TOPIC_DONE='${topic_done}'
-EOF
-  )
-}
-have_pub_token=0
-if [ -f "$env_file" ] && grep -qE '^NTFY_TOKEN=.*tk_' "$env_file" && ! grep -qE '^NTFY_TOKEN=.*tk_REPLACE' "$env_file"; then
-  have_pub_token=1
-fi
-if [ "$have_pub_token" = 0 ]; then
-  pub_token="$(issue_token chezmoi publisher || true)"
-  if [ -n "$pub_token" ]; then
-    if write_notify_env "$pub_token"; then
-      echo "[ntfy] publisher token issued and written to ~/.config/ntfy/notify-env."
-    else
-      echo "[ntfy] failed to write notify-env; provision manually (see notifications.md runbook)." >&2
-    fi
-  else
-    echo "[ntfy] publisher token issuance failed; provision manually (see notifications.md runbook)." >&2
-  fi
-fi
-
-# Subscriber token -> 1Password (cross-device channel). Needs the op CLI.
-# NOTE: `op item edit field=value` puts the token in argv for the local op
-# process — a deliberate, transient trade-off for one-shot local provisioning
-# (op offers no stdin path for individual field edits). Issue it only while the
-# item still holds a bootstrap placeholder.
-if command -v op >/dev/null 2>&1; then
-  sub="$(op read "op://kryota.dev/Dotfiles - ntfy/subscriber-token" 2>/dev/null || true)"
-  if [ -z "$sub" ] || printf '%s' "$sub" | grep -q '^tk_REPLACE'; then
-    sub_token="$(issue_token devices subscriber || true)"
-    if [ -n "$sub_token" ]; then
-      op item edit "Dotfiles - ntfy" --vault kryota.dev "subscriber-token[concealed]=${sub_token}" >/dev/null
-      echo "[ntfy] subscriber token issued and stored in 1Password."
-    fi
-  fi
-else
-  echo "[ntfy] op CLI not found; skipping subscriber-token provisioning (publisher/notify-env done)." >&2
-  echo "[ntfy] Store the subscriber token manually: docs/architecture/notifications.md (setup runbook)" >&2
-fi
-echo "[ntfy] auth provisioning complete."
+# Provision publisher (token -> notify-env) and subscriber (username/password ->
+# 1Password). Every failure inside is warn-and-continue; recovery is ntfy-setup.
+ntfy_provision || echo "[ntfy] provisioning incomplete; recover with: ntfy-setup" >&2
+echo "[ntfy] ntfy setup complete."
+exit 0
 {{ end -}}

--- a/install/install.sh
+++ b/install/install.sh
@@ -55,3 +55,14 @@ sh -c "$installer" -- init --apply kryota-dev
 echo ""
 echo "=== Setup complete! ==="
 echo "Please restart your terminal."
+
+# ntfy notifications are macOS-only and inherently two-phase: at first apply
+# Tailscale is not yet `up` and Docker Desktop is not running, so the server and
+# device credentials cannot be provisioned during bootstrap. Point the user at
+# the one command that finishes the job once those are available.
+if [ "$OS" = "Darwin" ]; then
+  echo ""
+  echo "ntfy notifications (this Mac): once Tailscale is up ('tailscale up') and"
+  echo "Docker Desktop is running, run 'ntfy-setup' to bring up the server and"
+  echo "provision device login. See docs/architecture/notifications.md."
+fi

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1910,32 +1910,80 @@ _gate_decision() {
   grep -qF 'cache-duration: "{{ .ntfy.cache_duration }}"' "$y"
   # iOS instant-push relay, the sole user-approved metadata egress (#337 PRD D2').
   grep -qF 'upstream-base-url: "https://ntfy.sh"' "$y"
-  # tailscale funnel must never appear anywhere in the ntfy config assets.
-  ! grep -ri 'funnel' "${HOME_DIR}/dot_config/ntfy"
+  # base-url was dropped (optional for core messaging); the server config no
+  # longer reads anything from 1Password.
+  ! grep -qE '^[[:space:]]*base-url:' "$y"
+  ! grep -q 'onepasswordRead' "$y"
+  # tailscale funnel must never be USED in the ntfy config assets. A comment that
+  # warns against it (as the lib does) is fine — only non-comment lines count.
+  [ -z "$(grep -rn 'funnel' "${HOME_DIR}/dot_config/ntfy" | grep -v '#')" ]
 }
 
-@test "ntfy setup script carries the embedded hashes and CI guard" {
+@test "ntfy setup script sources the lib, carries the embedded hashes and CI guard" {
   local s="${HOME_DIR}/run_onchange_after_31-setup-ntfy.sh.tmpl"
   [ -f "$s" ]
-  # embedded-hash trick: re-runs only when the compose file or server config changes
+  # embedded-hash trick: re-runs when the compose file, server config, OR the
+  # shared library changes (the last is what lets a lib edit re-fire apply).
   grep -qF 'include "dot_config/ntfy/compose.yaml.tmpl" | sha256sum' "$s"
   grep -qF 'include "dot_config/ntfy/private_server.yml.tmpl" | sha256sum' "$s"
+  grep -qF 'include "dot_config/ntfy/lib.sh.tmpl" | sha256sum' "$s"
+  # all logic is delegated to the SSOT library (sourced), not duplicated here
+  grep -qF '.config/ntfy/lib.sh' "$s"
+  grep -qF 'ntfy_provision' "$s"
   # CI must never start services from lifecycle scripts
   grep -qF 'if [ -n "${CI:-}" ]; then' "$s"
   # darwin-only: the whole body is inside the OS guard
   head -1 "$s" | grep -qF '{{ if eq .chezmoi.os "darwin" -}}'
   # template-stripped body must still parse
   sed '/{{/d' "$s" | bash -n
-  # tailscale serve with --bg (persists across reboots); funnel is forbidden
-  grep -qF 'serve --bg' "$s"
-  ! grep -qE '^[^#]*tailscale.*funnel' "$s"
-  # The publisher token is written straight into notify-env (runtime state),
-  # 0600 via umask, with no 1Password round-trip. Pin the write so it cannot
-  # silently regress back to `op item edit` for the publisher credential.
-  grep -qF 'write_notify_env' "$s"
-  grep -qF 'umask 077' "$s"
-  grep -qF '.config/ntfy/notify-env' "$s"
-  ! grep -qF 'credential[concealed]' "$s"
+  # fail-open: the apply path only ever exits 0 (never hard-fails)
+  ! grep -qE '(^|[[:space:];])exit 1([[:space:];]|$)' "$s"
+}
+
+@test "ntfy shared library provisions and rotates with secret hygiene" {
+  local l="${HOME_DIR}/dot_config/ntfy/lib.sh.tmpl"
+  [ -f "$l" ]
+  # template-stripped body must still parse
+  sed '/{{/d' "$l" | bash -n
+  # secrets are never traced
+  ! grep -qF 'set -x' "$l"
+  # publisher token -> notify-env (0600 via umask, heredoc)
+  grep -qF 'ntfy_write_notify_env' "$l"
+  grep -qF 'umask 077' "$l"
+  grep -qF '.config/ntfy/notify-env' "$l"
+  # device auth is username/password: change-pass fed via NTFY_PASSWORD env, not a token
+  grep -qF 'change-pass' "$l"
+  grep -qF 'NTFY_PASSWORD' "$l"
+  # 1Password item is created only when absent (op item get gate), never overwritten
+  grep -qF 'op item get' "$l"
+  grep -qF 'op item create' "$l"
+  # publisher rotation reads the OLD token first, then revokes it after issuing the new one
+  grep -qF 'ntfy_read_notify_env_token' "$l"
+  grep -qF 'token remove' "$l"
+  # serve --bg lives here now; funnel is forbidden across the ntfy assets
+  grep -qF 'serve --bg' "$l"
+  ! grep -qE '^[^#]*tailscale.*funnel' "$l"
+  # the removed token-in-1Password / subscriber-token paths must not resurrect
+  ! grep -qF 'credential[concealed]' "$l"
+  ! grep -qF 'subscriber-token' "$l"
+}
+
+@test "ntfy-setup command is on PATH, sources the lib, and rotates" {
+  local n="${HOME_DIR}/dot_local/bin/executable_ntfy-setup"
+  [ -f "$n" ]
+  bash -n "$n"
+  # sources the SSOT library rather than duplicating provisioning logic
+  grep -qF '.config/ntfy/lib.sh' "$n"
+  # full flow: brings the server up (not check-only) so it can restart a downed container
+  grep -qF 'ntfy_start_server' "$n"
+  grep -qF 'ntfy_assert_serve' "$n"
+  # rotation entry point for both credentials
+  grep -qF -- '--rotate' "$n"
+  grep -qF 'ntfy_rotate_publisher' "$n"
+  grep -qF 'ntfy_rotate_subscriber' "$n"
+  # fail-clear: a distinct exit code when it cannot fix docker/tailscale itself
+  grep -qF 'EXIT_PREREQ' "$n"
+  ! grep -qF 'set -x' "$n"
 }
 
 @test "settings.json disables stop:desktop-notify and wires the ntfy hooks (#337)" {
@@ -1965,15 +2013,15 @@ _gate_decision() {
   ' "$s" >/dev/null
 }
 
-@test "CI excludes the ntfy onepasswordRead template in both jobs" {
+@test "CI keeps the ntfy server config excluded in both jobs" {
   local w="${REPO_ROOT}/.github/workflows/setup-validation.yml"
   [ -f "$w" ]
-  # The CI precedent is the hardcoded mv list (NOT .chezmoiignore): the sole
-  # remaining onepasswordRead template (server.yml) must appear once per job
-  # (macOS + Ubuntu).
+  # server.yml no longer reads 1Password (base-url was dropped), but it stays on
+  # the hardcoded mv list — a 0600 config of container-only paths with no CI
+  # value in rendering — once per job (macOS + Ubuntu).
   [ "$(grep -cF 'home/dot_config/ntfy/private_server.yml.tmpl' "$w")" -eq 2 ]
-  # notify-env is no longer a chezmoi target — the setup script writes it as
-  # runtime state — so it must not linger in the exclude list.
+  # notify-env is not a chezmoi target — the lib writes it as runtime state — so
+  # it must not linger in the exclude list.
   ! grep -qF 'private_notify-env' "$w"
 }
 
@@ -1983,16 +2031,14 @@ _gate_decision() {
   grep -qF "compose\\\\.yaml\\\\.tmpl" "$r"
 }
 
-@test "1password ITEMS covers the ntfy item fields" {
-  _onepassword_item_list | grep -qF 'op://kryota.dev/Dotfiles - ntfy/base-url'
-  # The publisher token is no longer stored in 1Password — the setup script
-  # writes it straight into notify-env — so the gate must not validate a
-  # credential field for this item.
-  ! _onepassword_item_list | grep -qF 'op://kryota.dev/Dotfiles - ntfy/credential'
-  # The server.yml template must consume exactly the URI the gate validates — a
-  # typo on either side would otherwise pass both checks independently.
-  grep -qF 'onepasswordRead "op://kryota.dev/Dotfiles - ntfy/base-url"' \
-    "${HOME_DIR}/dot_config/ntfy/private_server.yml.tmpl"
+@test "1password ITEMS no longer references the ntfy item" {
+  # base-url was dropped; the ntfy item (read-only subscriber username/password)
+  # is provisioned by ntfy-setup after Tailscale/Docker come up, a later phase
+  # than the validate gate, so the gate must validate nothing ntfy — otherwise a
+  # fresh apply would hard-fail before the item exists.
+  ! _onepassword_item_list | grep -qF 'op://kryota.dev/Dotfiles - ntfy/'
+  # server.yml no longer reads any ntfy field from 1Password.
+  ! grep -qF 'onepasswordRead' "${HOME_DIR}/dot_config/ntfy/private_server.yml.tmpl"
 }
 
 @test "ntfy runtime state never lands in the chezmoi source tree" {
@@ -2004,6 +2050,8 @@ _gate_decision() {
   [ -z "$output" ]
 }
 
-@test "chezmoiignore excludes the ntfy config dir on non-darwin" {
+@test "chezmoiignore excludes the ntfy config dir and command on non-darwin" {
   grep -qF '.config/ntfy' "${HOME_DIR}/.chezmoiignore"
+  # the ntfy-setup command is macOS-only too (the server only runs on this Mac)
+  grep -qF '.local/bin/ntfy-setup' "${HOME_DIR}/.chezmoiignore"
 }

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1915,8 +1915,9 @@ _gate_decision() {
   ! grep -qE '^[[:space:]]*base-url:' "$y"
   ! grep -q 'onepasswordRead' "$y"
   # tailscale funnel must never be USED in the ntfy config assets. A comment that
-  # warns against it (as the lib does) is fine — only non-comment lines count.
-  [ -z "$(grep -rn 'funnel' "${HOME_DIR}/dot_config/ntfy" | grep -v '#')" ]
+  # warns against it (as the lib does) is fine — strip inline comments before
+  # matching so a trailing `# … funnel …` note never masks a real usage.
+  [ -z "$(grep -rn 'funnel' "${HOME_DIR}/dot_config/ntfy" | sed 's/#.*//' | grep 'funnel')" ]
 }
 
 @test "ntfy setup script sources the lib, carries the embedded hashes and CI guard" {
@@ -1966,12 +1967,24 @@ _gate_decision() {
   # the removed token-in-1Password / subscriber-token paths must not resurrect
   ! grep -qF 'credential[concealed]' "$l"
   ! grep -qF 'subscriber-token' "$l"
+  # R-008 interactive rotate guard (central safety design): the prompt reads
+  # /dev/tty and defaults to N without a tty. Pin the helpers so a regression
+  # that silently rotates live credentials is caught.
+  grep -qF 'ntfy_creds_exist' "$l"
+  grep -qF 'ntfy_prompt_yn' "$l"
+  grep -qF '/dev/tty' "$l"
+  # op read failures must be distinguished from an empty value (a swallowed
+  # error must not overwrite a real subscriber password → device lockout).
+  grep -qF 'op error' "$l"
 }
 
-@test "ntfy-setup command is on PATH, sources the lib, and rotates" {
+@test "ntfy-setup: deploys under ~/.local/bin, sources the lib, prompts before rotating, rotates" {
   local n="${HOME_DIR}/dot_local/bin/executable_ntfy-setup"
   [ -f "$n" ]
   bash -n "$n"
+  # It deploys to ~/.local/bin (already on PATH via dot_zshrc.tmpl) — the
+  # executable_ prefix + this path is the wiring; no separate PATH edit exists.
+  grep -qF '.local/bin/ntfy-setup' "${HOME_DIR}/.chezmoiignore"
   # sources the SSOT library rather than duplicating provisioning logic
   grep -qF '.config/ntfy/lib.sh' "$n"
   # full flow: brings the server up (not check-only) so it can restart a downed container
@@ -1981,8 +1994,13 @@ _gate_decision() {
   grep -qF -- '--rotate' "$n"
   grep -qF 'ntfy_rotate_publisher' "$n"
   grep -qF 'ntfy_rotate_subscriber' "$n"
-  # fail-clear: a distinct exit code when it cannot fix docker/tailscale itself
-  grep -qF 'EXIT_PREREQ' "$n"
+  # R-008: with no --rotate and live creds present, ask before rotating.
+  grep -qF 'ntfy_creds_exist' "$n"
+  grep -qF 'ntfy_prompt_yn' "$n"
+  # fail-clear: three DISTINCT exit codes (op error / usage / prereq), not collapsed.
+  grep -qE '^EXIT_ERR=1( |$)' "$n"
+  grep -qE '^EXIT_USAGE=2( |$)' "$n"
+  grep -qE '^EXIT_PREREQ=3( |$)' "$n"
   ! grep -qF 'set -x' "$n"
 }
 
@@ -2039,6 +2057,12 @@ _gate_decision() {
   ! _onepassword_item_list | grep -qF 'op://kryota.dev/Dotfiles - ntfy/'
   # server.yml no longer reads any ntfy field from 1Password.
   ! grep -qF 'onepasswordRead' "${HOME_DIR}/dot_config/ntfy/private_server.yml.tmpl"
+  # The base-url format-validation stanza (R-003) was removed from the validate
+  # gate too. If it is reintroduced, `op read` returns empty for the now-absent
+  # base-url and the stanza hard-fails every fresh `chezmoi apply` before the
+  # ntfy item is provisioned. Guard the removal.
+  ! grep -qF 'ts.net' "${HOME_DIR}/run_once_after_11-validate-1password.sh.tmpl"
+  ! grep -qE 'ntfy_(url|tok)=' "${HOME_DIR}/run_once_after_11-validate-1password.sh.tmpl"
 }
 
 @test "ntfy runtime state never lands in the chezmoi source tree" {
@@ -2054,4 +2078,31 @@ _gate_decision() {
   grep -qF '.config/ntfy' "${HOME_DIR}/.chezmoiignore"
   # the ntfy-setup command is macOS-only too (the server only runs on this Mac)
   grep -qF '.local/bin/ntfy-setup' "${HOME_DIR}/.chezmoiignore"
+}
+
+@test "ntfy templates render without a Go template parse error (#357 guard)" {
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+  # The template-stripped 'bash -n' checks above cannot catch a stray literal
+  # open-brace pair in a comment: sed deletes that very line before bash sees
+  # it, yet chezmoi would fail to render. Assert a real render — this is exactly
+  # the #357 parse-error regression the non-functional requirements forbid.
+  chezmoi execute-template --source "${HOME_DIR}" \
+    <"${HOME_DIR}/dot_config/ntfy/lib.sh.tmpl" >/dev/null
+  chezmoi execute-template --source "${HOME_DIR}" \
+    <"${HOME_DIR}/run_onchange_after_31-setup-ntfy.sh.tmpl" >/dev/null
+  chezmoi execute-template --source "${HOME_DIR}" \
+    <"${HOME_DIR}/dot_config/ntfy/private_server.yml.tmpl" >/dev/null
+}
+
+@test "install.sh points at ntfy-setup on darwin only, and never provisions at bootstrap" {
+  local s="${REPO_ROOT}/install/install.sh"
+  [ -f "$s" ]
+  bash -n "$s"
+  # R-009: bootstrap stays thin — it points at ntfy-setup for the two-phase
+  # setup but performs no provisioning (no docker/tailscale/op) itself.
+  grep -qF 'ntfy-setup' "$s"
+  grep -qF 'if [ "$OS" = "Darwin" ]; then' "$s"
+  ! grep -qF 'docker compose' "$s"
+  ! grep -qF 'tailscale serve' "$s"
+  ! grep -qF 'op item' "$s"
 }


### PR DESCRIPTION
## Summary

Follow-up to #350 / #357. Corrects the ntfy **device-auth model** and collapses setup +
key rotation into one re-runnable, two-phase-aware command backed by a shared library.

The trigger: the ntfy **iOS app cannot authenticate to the self-hosted server with a token** —
only a username/password login works (the phone docs describe the two app auth paths as
mutually exclusive: a configured *user* → auto Basic Auth, vs. a manual custom `Authorization`
header for tokens, which does not work on iOS). So the #350/#357 read-only **subscriber-token**
was never usable on a phone, and the subscriber user was created with a *throwaway* password
that was discarded. This PR fixes that.

## What changes

- **Device auth = subscriber username/password.** A read-only `subscriber` ntfy user gets a
  known, generated password; `Dotfiles - ntfy` stores `subscriber-username` + `subscriber-password`.
  Phones log in with those. The **publisher stays a Bearer token** in `~/.config/ntfy/notify-env`
  (local curl / API auth — unaffected by the app limitation). The subscriber-token is dropped.
- **One SSOT library** `~/.config/ntfy/lib.sh` (`home/dot_config/ntfy/lib.sh.tmpl`) drives the
  whole lifecycle. It is sourced by `run_onchange_after_31-setup-ntfy` (apply-time, **fail-open**)
  and by `~/.local/bin/ntfy-setup` (user command, **fail-clear**). `ntfy-setup` runs the full
  flow — `docker compose up -d` → `tailscale serve --bg` → provision/repair — and `--rotate
  publisher|subscriber|all`. It exits non-zero with guidance only when a prerequisite it cannot
  fix (Docker Desktop, `tailscale up`) is missing. This is also what restarts a container that
  went down after a reboot, which `chezmoi apply` alone cannot (run_onchange records exit-0).
- **`base-url` dropped everywhere** — it is optional for our use (only attachments / email need
  it, unused here; it does not affect the iOS `upstream-base-url` relay). Removed from
  `server.yml`, from the 1Password validate gate (both the ITEMS entry **and** the format-check
  stanza), so nothing ntfy blocks `chezmoi apply`. The MagicDNS URL is derived on demand only.
- **Two-phase aware.** At first setup Tailscale is not `up` and Docker is not running, so
  provisioning cannot finish during the first apply. `install.sh` notes this; `ntfy-setup` is
  the single command to run once both are available. The 1Password item is auto-created only
  when absent (never overwritten).
- **Rotation is correct.** Publisher: read the old token first → issue new → write notify-env →
  `ntfy token remove` the old one. Subscriber: `NTFY_PASSWORD=… ntfy user change-pass` (preserves
  ACLs) + update 1Password. Docs corrected: `ntfy token add` is additive, not invalidating.

## Backward compatibility

Non-destructive. The library never overwrites an existing item, so legacy `base-url` /
`credential` / `subscriber-token` fields are left harmless; `server.yml` re-renders without
base-url; `notify-env` is unchanged. Running `ntfy-setup` on this machine **repairs** the
subscriber user (throwaway → known password) and records username/password in 1Password.

## Verification

- `chezmoi execute-template` render + `bash -n` + `shellcheck` for the lib, script 31, server.yml,
  validate; `ntfy-setup` `bash -n` + `shellcheck`. Rendered notify-env / password writes carry
  the secret only through the heredoc / `NTFY_PASSWORD` env — never argv (except the documented
  `op item edit` trade-off), never `set -x`, never echoed.
- `make test` green (lint + 232 bats). FACT markers resynced (`onepassword-vault-item-count` 4;
  `ci-both-exclusion-count` 7) and a pre-existing `secrets-1password.md` CI-exclusion drift
  (listed 6, missing `server.yml`) fixed to 7 with a FACT marker.
- No tailnet MagicDNS name or client identifier literal in the repo.

## Design record

`.claude/prds/337-ntfy-setup-rotation.prd.md` (grill-me `--mode=auto`, adversarially verified).

## Post-merge (your environment)

Run `ntfy-setup` on this Mac (after `tailscale up` + Docker running) to repair the subscriber
login and store its username/password; then log the phone into the server with username
`subscriber` and the password from 1Password. Legacy `base-url` / `credential` /
`subscriber-token` fields on the item may be deleted manually (harmless if left).

---

_Process note: this large-tier change was run on Opus 4.8, below the Opus 5 floor the workflow
requests for large tier (per an explicit continue-anyway); the design deliberation / adversarial
verification may be below the Opus 5 baseline._
