### PR TITLE
feat(brew): auto-dump the Brewfile via a PATH-shim wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,6 @@ make fmt
 # Benchmark zsh startup
 make benchmark
 
-# Update Brewfile
-make dump-brewfile
-
 # Sync vendored _ghq completion from the mise-pinned ghq version
 make sync-ghq-completion
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all help lint fmt test test-bats benchmark dump-brewfile sync-ghq-completion
+.PHONY: all help lint fmt test test-bats benchmark sync-ghq-completion
 
 # Default target — show help (avoid accidental mutation of $HOME via apply)
 all: help
@@ -56,12 +56,6 @@ benchmark:
 # ========================================
 # Utilities
 # ========================================
-
-## Dump current brew packages to Brewfile
-dump-brewfile:
-	@rm -f home/dot_Brewfile
-	@brew bundle dump --file home/dot_Brewfile
-	@echo "Brewfile updated at home/dot_Brewfile"
 
 ## Sync vendored _ghq completion from the mise-pinned upstream ghq version
 sync-ghq-completion:

--- a/README.ja.md
+++ b/README.ja.md
@@ -117,7 +117,6 @@ AI ネイティブ開発環境 — [Claude Code](https://docs.anthropic.com/en/d
 | `make fmt` | shfmt でシェルスクリプトを整形 |
 | `make test` | lint + Bats テストを実行 |
 | `make benchmark` | zsh 起動時間を計測 |
-| `make dump-brewfile` | 現在の Homebrew パッケージをエクスポート |
 | `make sync-ghq-completion` | vendoring した `_ghq` 補完を更新 |
 
 > 適用と差分確認は chezmoi を直接実行します: `chezmoi apply -v` / `chezmoi diff`。

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ See [`docs/agents/`](docs/agents/overview.md) for the dual-harness × dual-accou
 | `make fmt` | Format shell scripts with shfmt |
 | `make test` | Run lint + Bats tests |
 | `make benchmark` | Measure zsh startup time |
-| `make dump-brewfile` | Export current Homebrew packages |
 | `make sync-ghq-completion` | Refresh vendored `_ghq` completion |
 
 > Applying and diffing are done with chezmoi directly: `chezmoi apply -v`, `chezmoi diff`.

--- a/docs/architecture/dev-tooling.ja.md
+++ b/docs/architecture/dev-tooling.ja.md
@@ -48,7 +48,9 @@ ruby.compile = false
 
 ### `dot_Brewfile`
 
-`home/dot_Brewfile` は標準の Homebrew バンドルファイルです: tap、formula、cask、mas（App Store）、vscode 拡張、go エントリを含みます。これは**プレーンテキスト — `.tmpl` ファイルではありません**。これは意図的なものです: `make dump-brewfile` は `brew bundle dump` を実行してファイルを上書き再生成します。テンプレートにすると上書きされるか再生成できなくなります。
+`home/dot_Brewfile` は標準の Homebrew バンドルファイルです: tap、formula、cask、mas（App Store）、vscode 拡張、go エントリを含みます。これは**プレーンテキスト — `.tmpl` ファイルではありません**。これは意図的なものです: `brew bundle dump` はファイルを上書き再生成するため、テンプレートにすると上書きされるか再生成できなくなります。
+
+Brewfile は `brew` の PATH-shim ラッパー（`home/dot_local/launchers/executable_brew`、`~/.local/launchers/brew` に配置 — #358 で real brew より前に `PATH` 前置される launcher ディレクトリ）によって自動的に同期されます。パッケージ集合を変更する subcommand（`install`、`uninstall`、`reinstall`、`tap`、`untap`）の後、ラッパーは `$(chezmoi source-path)/dot_Brewfile` に対して `brew bundle dump --force` を実行するため、場当たり的な `brew install` / `brew uninstall` の後も追跡対象の Brewfile が drift しなくなります。ラッパーは real brew の終了コードを保持し、chezmoi が未インストールの場合は dump をスキップします（stderr に通知）。Homebrew には post-install フックが無いため（Homebrew/brew#2202）、この shim が——`make` ターゲットではなく——同期機構です。絶対パス起動（`/opt/homebrew/bin/brew`）は shim を bypass し（許容された制限）、`run_onchange_before_10-brew-bundle` は `brew bundle`（非 mutating subcommand）を実行するため dump をトリガーしません。
 
 制約:
 - Brewfile に `brew "chezmoi"` を追加しないでください。chezmoi 自体はスタンドアロンの `curl get.chezmoi.io` ブートストラップでインストールされます（PR #22）。Brewfile に追加すると mise 管理バージョンと競合します。

--- a/docs/architecture/dev-tooling.md
+++ b/docs/architecture/dev-tooling.md
@@ -48,7 +48,9 @@ ruby.compile = false
 
 ### `dot_Brewfile`
 
-`home/dot_Brewfile` is a standard Homebrew bundle file: taps, formula, cask, mas (App Store), vscode extension, and go entries. It is **plain text — not a `.tmpl` file**. This is intentional: `make dump-brewfile` runs `brew bundle dump`, which rewrites the file in place. A template would be clobbered or would prevent regeneration.
+`home/dot_Brewfile` is a standard Homebrew bundle file: taps, formula, cask, mas (App Store), vscode extension, and go entries. It is **plain text — not a `.tmpl` file**. This is intentional: `brew bundle dump` rewrites the file in place, and a template would be clobbered or would prevent regeneration.
+
+The Brewfile is kept in sync automatically by a `brew` PATH-shim wrapper (`home/dot_local/launchers/executable_brew`, deployed to `~/.local/launchers/brew` — the launcher dir prepended ahead of the real brew on `PATH` by #358). After a package-set-mutating subcommand (`install`, `uninstall`, `reinstall`, `tap`, `untap`), the wrapper runs `brew bundle dump --force` against `$(chezmoi source-path)/dot_Brewfile`, so the tracked Brewfile no longer drifts after ad-hoc `brew install` / `brew uninstall`. It preserves the real brew's exit code and skips the dump (with a stderr note) when chezmoi is not installed. Homebrew has no post-install hook (Homebrew/brew#2202), so this shim — not a `make` target — is the sync mechanism. An absolute-path invocation (`/opt/homebrew/bin/brew`) bypasses the shim (accepted limitation), and `run_onchange_before_10-brew-bundle` runs `brew bundle` (not a mutating subcommand), so it never triggers a dump.
 
 Constraints:
 - Do not add `brew "chezmoi"` to the Brewfile. chezmoi itself is installed via the standalone `curl get.chezmoi.io` bootstrap (PR #22); adding it to the Brewfile would conflict with the mise-managed version.

--- a/docs/contributing/local-dev.ja.md
+++ b/docs/contributing/local-dev.ja.md
@@ -20,7 +20,6 @@
 | `test` | `lint` の後に `test-bats` |
 | `test-bats` | `bats tests/*.bats` |
 | `benchmark` | `scripts/benchmark.sh`（コールドスタート + 10 回平均） |
-| `dump-brewfile` | `rm home/dot_Brewfile && brew bundle dump --file home/dot_Brewfile` |
 | `sync-ghq-completion` | mise でピンした ghq バージョンに対応する `_ghq` をアップストリームから取得してベンダリング |
 
 ### `make apply` が存在しない理由

--- a/docs/contributing/local-dev.md
+++ b/docs/contributing/local-dev.md
@@ -20,7 +20,6 @@ The `Makefile` is the single source of truth for all local dev commands. The def
 | `test` | `lint` then `test-bats` |
 | `test-bats` | `bats tests/*.bats` |
 | `benchmark` | `scripts/benchmark.sh` (cold start + 10-iteration average) |
-| `dump-brewfile` | `rm home/dot_Brewfile && brew bundle dump --file home/dot_Brewfile` |
 | `sync-ghq-completion` | Fetches the vendored `_ghq` from upstream at the mise-pinned ghq version |
 
 ### Why there is no `make apply`

--- a/docs/explanation/design-rationale.ja.md
+++ b/docs/explanation/design-rationale.ja.md
@@ -124,7 +124,7 @@ mise 設定の全構造については [dev-tooling.ja.md](../architecture/dev-t
 
 **なぜ:** `chezmoi apply` は `$HOME` を変更します。ユーザーのホームディレクトリのファイルを書き込み、移動し、場合によっては削除します。`make apply` ターゲット——特にプロジェクトを探索する際に `make` を誤って実行したコントリビューターによってトリガーされる可能性があるもの——は、意図しないホームディレクトリ変更という受け入れがたいリスクをもたらします。明示的な `chezmoi apply` の呼び出しを要求することで意図を強制します。
 
-`make help` デフォルトはドキュメントとしても機能します。利用可能なターゲット（`lint`、`test`、`benchmark`、`dump-brewfile`、`sync-ghq-completion`）はすべて読み取り専用またはリポジトリツリーにスコープされており、ホームディレクトリには作用しません。
+`make help` デフォルトはドキュメントとしても機能します。利用可能なターゲット（`lint`、`test`、`benchmark`、`sync-ghq-completion`）はすべて読み取り専用またはリポジトリツリーにスコープされており、ホームディレクトリには作用しません。
 
 `make` ターゲット一覧については [local-dev.ja.md](../contributing/local-dev.ja.md) を参照してください。
 

--- a/docs/explanation/design-rationale.md
+++ b/docs/explanation/design-rationale.md
@@ -124,7 +124,7 @@ See [dev-tooling.md](../architecture/dev-tooling.md) for the `.brewfile-linux-ex
 
 **Why:** `chezmoi apply` mutates `$HOME`. It writes, moves, and potentially removes files in the home directory of the user running it. A `make apply` target — especially one that could be triggered accidentally by a contributor running `make` to explore the project — represents an unacceptable risk of unintended home-directory mutation. Requiring the explicit `chezmoi apply` invocation forces intent.
 
-The `make help` default also serves as documentation: contributors can discover the available targets without reading the Makefile. The targets that exist (`lint`, `test`, `benchmark`, `dump-brewfile`, `sync-ghq-completion`) are all read-only or scoped to the repo tree, not the home directory.
+The `make help` default also serves as documentation: contributors can discover the available targets without reading the Makefile. The targets that exist (`lint`, `test`, `benchmark`, `sync-ghq-completion`) are all read-only or scoped to the repo tree, not the home directory.
 
 See [local-dev.md](../contributing/local-dev.md) for the full `make` target table.
 

--- a/home/dot_local/launchers/executable_brew
+++ b/home/dot_local/launchers/executable_brew
@@ -18,15 +18,21 @@
 # (not a mutating subcommand), so it never triggers a dump — no recursion.
 set -eu
 
-# Subcommands that change the installed package set and so warrant a Brewfile refresh.
+# Subcommands that change the installed package set and so warrant a Brewfile refresh. `remove` and
+# `rm` are aliases of `uninstall` (see `brew help uninstall`), so they must trigger too — otherwise
+# `brew rm foo` would drift the Brewfile, the very problem this wrapper fixes. install/reinstall/
+# tap/untap have no aliases.
 is_dump_trigger() {
   case "$1" in
-    install | uninstall | reinstall | tap | untap) return 0 ;;
+    install | uninstall | remove | rm | reinstall | tap | untap) return 0 ;;
     *) return 1 ;;
   esac
 }
 
 # The subcommand is the first non-option argument (global flags like `--verbose` may precede it).
+# This is a heuristic, not brew's full dispatcher: a query form whose first non-option token happens
+# to be a trigger word (e.g. `brew --prefix install`, where `install` is a formula name) runs one
+# extra, harmless dump — the dump faithfully reflects the unchanged package set. Accepted limitation.
 subcommand=""
 for arg in "$@"; do
   case "$arg" in
@@ -39,13 +45,18 @@ for arg in "$@"; do
 done
 
 # Resolve the real brew WITHOUT going through PATH (which would re-resolve this wrapper).
-# BREW_LAUNCHER_BIN overrides the resolver for tests. Otherwise prefer the exported HOMEBREW_PREFIX,
-# then the standard install prefixes for Apple Silicon, Intel, and Linuxbrew. Fail loudly rather
-# than silently do nothing.
+# BREW_LAUNCHER_BIN overrides the resolver for tests. HOMEBREW_PREFIX is exported into every shell
+# by `brew shellenv`, so later code could repoint it at an attacker-controlled dir; trust it only
+# when it names a standard prefix (allowlist), then fall back to the standard install prefixes for
+# Apple Silicon, Intel, and Linuxbrew. Fail loudly rather than silently do nothing.
 real="${BREW_LAUNCHER_BIN:-}"
 if [ -z "$real" ]; then
+  case "${HOMEBREW_PREFIX:-}" in
+    /opt/homebrew | /usr/local | /home/linuxbrew/.linuxbrew) prefix_cand="$HOMEBREW_PREFIX/bin/brew" ;;
+    *) prefix_cand="" ;;
+  esac
   for cand in \
-    "${HOMEBREW_PREFIX:+$HOMEBREW_PREFIX/bin/brew}" \
+    "$prefix_cand" \
     /opt/homebrew/bin/brew \
     /usr/local/bin/brew \
     /home/linuxbrew/.linuxbrew/bin/brew; do
@@ -66,16 +77,27 @@ status=0
 "$real" "$@" || status=$?
 
 # After a package-set-mutating subcommand, refresh the chezmoi source Brewfile so it tracks the
-# ad-hoc change. Resolve the target via `chezmoi source-path` (cwd-independent). A dump failure or a
-# missing chezmoi only warns — the caller still sees the real brew's original exit code.
+# ad-hoc change. Resolve the target via `chezmoi source-path` (cwd-independent). Every failure path
+# only warns and still falls through to `exit "$status"`, so the caller always sees the real brew's
+# original exit code (AC3). The guarded `if source_path="$(...)"` matters: an unguarded assignment
+# would abort here under `set -e` on a chezmoi failure and mask that exit code.
 if is_dump_trigger "$subcommand"; then
-  if command -v chezmoi >/dev/null 2>&1; then
-    brewfile="$(chezmoi source-path)/dot_Brewfile"
-    if ! "$real" bundle dump --force --file="$brewfile" >/dev/null 2>&1; then
-      echo "brew launcher: 'brew bundle dump' failed; $brewfile not refreshed." >&2
-    fi
-  else
+  if ! command -v chezmoi >/dev/null 2>&1; then
     echo "brew launcher: chezmoi not found; skipped Brewfile refresh." >&2
+  elif ! source_path="$(chezmoi source-path)"; then
+    echo "brew launcher: 'chezmoi source-path' failed; Brewfile not refreshed." >&2
+  else
+    brewfile="$source_path/dot_Brewfile"
+    # Neutralize the subtractive HOMEBREW_BUNDLE_DUMP_NO_* vars so a stray env setting cannot make
+    # the automatic --force dump overwrite the tracked Brewfile with a whole category missing.
+    # Capture the dump's own stderr so a failure reports its cause, not just a generic line.
+    if ! dump_err="$(env \
+      -u HOMEBREW_BUNDLE_DUMP_NO_BREW -u HOMEBREW_BUNDLE_DUMP_NO_CASK -u HOMEBREW_BUNDLE_DUMP_NO_TAP \
+      -u HOMEBREW_BUNDLE_DUMP_NO_MAS -u HOMEBREW_BUNDLE_DUMP_NO_VSCODE \
+      "$real" bundle dump --force --file="$brewfile" 2>&1 >/dev/null)"; then
+      echo "brew launcher: 'brew bundle dump' failed; $brewfile not refreshed." >&2
+      if [ -n "$dump_err" ]; then printf '%s\n' "$dump_err" >&2; fi
+    fi
   fi
 fi
 

--- a/home/dot_local/launchers/executable_brew
+++ b/home/dot_local/launchers/executable_brew
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# PATH-shim wrapper for `brew` that keeps the chezmoi-managed Brewfile in sync. After a
+# package-set-mutating subcommand (install/uninstall/reinstall/tap/untap) it regenerates the
+# chezmoi source dot_Brewfile via `brew bundle dump`, so the tracked Brewfile no longer drifts
+# after ad-hoc `brew install` / `brew uninstall` the way it did when only `make dump-brewfile`
+# refreshed it.
+#
+# Homebrew has no post-install/post-uninstall hook (Homebrew/brew#2202, open since 2017). A shell
+# function would only cover interactive shells; being a real file ahead of the real brew on PATH
+# (~/.local/launchers, prepended in .zprofile/.zshrc), this wrapper fires from any shell that
+# resolves through that dir, following the launcher PATH-wrapper pattern from #358.
+#
+# Unlike the claude/codex launchers, this wrapper does NOT exec: it runs the real brew as a child so
+# it can observe the exit code and dump afterwards. It never masks the real brew's exit code.
+#
+# Known limitation (accepted): an absolute-path invocation (/opt/homebrew/bin/brew) bypasses the
+# shim, so its mutations are not auto-dumped. run_onchange_before_10-brew-bundle runs `brew bundle`
+# (not a mutating subcommand), so it never triggers a dump — no recursion.
+set -eu
+
+# Subcommands that change the installed package set and so warrant a Brewfile refresh.
+is_dump_trigger() {
+  case "$1" in
+    install | uninstall | reinstall | tap | untap) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# The subcommand is the first non-option argument (global flags like `--verbose` may precede it).
+subcommand=""
+for arg in "$@"; do
+  case "$arg" in
+    -*) continue ;;
+    *)
+      subcommand="$arg"
+      break
+      ;;
+  esac
+done
+
+# Resolve the real brew WITHOUT going through PATH (which would re-resolve this wrapper).
+# BREW_LAUNCHER_BIN overrides the resolver for tests. Otherwise prefer the exported HOMEBREW_PREFIX,
+# then the standard install prefixes for Apple Silicon, Intel, and Linuxbrew. Fail loudly rather
+# than silently do nothing.
+real="${BREW_LAUNCHER_BIN:-}"
+if [ -z "$real" ]; then
+  for cand in \
+    "${HOMEBREW_PREFIX:+$HOMEBREW_PREFIX/bin/brew}" \
+    /opt/homebrew/bin/brew \
+    /usr/local/bin/brew \
+    /home/linuxbrew/.linuxbrew/bin/brew; do
+    if [ -n "$cand" ] && [ -x "$cand" ]; then
+      real="$cand"
+      break
+    fi
+  done
+fi
+if [ -z "$real" ] || [ ! -x "$real" ]; then
+  echo "brew launcher: could not resolve the real brew binary." >&2
+  echo "  Set BREW_LAUNCHER_BIN or ensure brew is installed under a standard prefix." >&2
+  exit 127
+fi
+
+# Run the real brew, preserving its exit code for the caller (works under set -e).
+status=0
+"$real" "$@" || status=$?
+
+# After a package-set-mutating subcommand, refresh the chezmoi source Brewfile so it tracks the
+# ad-hoc change. Resolve the target via `chezmoi source-path` (cwd-independent). A dump failure or a
+# missing chezmoi only warns — the caller still sees the real brew's original exit code.
+if is_dump_trigger "$subcommand"; then
+  if command -v chezmoi >/dev/null 2>&1; then
+    brewfile="$(chezmoi source-path)/dot_Brewfile"
+    if ! "$real" bundle dump --force --file="$brewfile" >/dev/null 2>&1; then
+      echo "brew launcher: 'brew bundle dump' failed; $brewfile not refreshed." >&2
+    fi
+  else
+    echo "brew launcher: chezmoi not found; skipped Brewfile refresh." >&2
+  fi
+fi
+
+exit "$status"

--- a/home/dot_zprofile.tmpl
+++ b/home/dot_zprofile.tmpl
@@ -20,7 +20,8 @@ typeset -gU path
 
 # Per-account agent launchers (~/.local/launchers): also prepend here, in a login-sourced file, so
 # a non-interactive login shell (`zsh -lc '<cmd>'`) — which does not source ~/.zshrc — still
-# resolves the claude/codex wrappers rather than the bare mise/brew binary (#345). Interactive
+# resolves the claude/codex wrappers (and the brew auto-dump shim, #360) rather than the bare
+# mise/brew binary (#345). Interactive
 # shells additionally get a precmd hook in ~/.zshrc to stay ahead of mise's per-prompt re-prepend.
 case ":$PATH:" in
   *":$HOME/.local/launchers:"*) ;;

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -12,9 +12,9 @@ export SAVEHIST=100000
 export PATH="$HOME/.local/bin:$PATH"
 
 # Per-account agent launchers (~/.local/launchers): the claude/codex wrappers plus the
-# cld/cld-r06/cdx/cdx-r06 symlinks. Kept on PATH so the wrappers resolve from any shell; the
-# precmd hook below re-asserts this dir ahead of mise's per-tool dirs, which mise re-prepends on
-# every prompt via hook-env (#345).
+# cld/cld-r06/cdx/cdx-r06 symlinks, and the brew auto-dump shim (#360). Kept on PATH so the wrappers
+# resolve from any shell; the precmd hook below re-asserts this dir ahead of mise's per-tool dirs,
+# which mise re-prepends on every prompt via hook-env (#345).
 case ":$PATH:" in
   *":$HOME/.local/launchers:"*) ;;
   *) export PATH="$HOME/.local/launchers:$PATH" ;;

--- a/tests/brew_launcher.bats
+++ b/tests/brew_launcher.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+
+load helpers/setup
+
+# Behavioral guard for the brew PATH-shim wrapper (#360),
+# home/dot_local/launchers/executable_brew. The wrapper runs the real brew, preserves its exit
+# code, and — only after a package-set-mutating subcommand (install/uninstall/reinstall/tap/untap) —
+# regenerates the chezmoi source dot_Brewfile via `brew bundle dump`.
+#
+# These tests exercise the wrapper directly with a stub "real" brew (via BREW_LAUNCHER_BIN, mirroring
+# the CLAUDE_LAUNCHER_BIN seam) and a stub chezmoi, so no real brew/chezmoi install is needed
+# (CI-safe). The stub brew logs its argv to $BREW_CALLS, writes a marker to the --file= target on
+# `bundle dump`, and otherwise exits with $STUB_BREW_EXIT.
+
+WRAPPER="${HOME_DIR}/dot_local/launchers/executable_brew"
+
+# Build the stub brew + stub chezmoi + fake chezmoi source dir under the per-test tmpdir, and export
+# the paths the assertions read back.
+_stubs() {
+  STUBBIN="$BATS_TEST_TMPDIR/bin"
+  SRC="$BATS_TEST_TMPDIR/src"
+  BREW_CALLS="$BATS_TEST_TMPDIR/brew-calls"
+  mkdir -p "$STUBBIN" "$SRC"
+  : >"$BREW_CALLS"
+
+  STUB_BREW="$BATS_TEST_TMPDIR/stub-brew"
+  cat >"$STUB_BREW" <<'STUBEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$BREW_CALLS"
+if [ "${1:-}" = "bundle" ] && [ "${2:-}" = "dump" ]; then
+  for a in "$@"; do
+    case "$a" in --file=*) printf 'dumped\n' >"${a#--file=}" ;; esac
+  done
+  exit 0
+fi
+exit "${STUB_BREW_EXIT:-0}"
+STUBEOF
+  chmod +x "$STUB_BREW"
+
+  # Stub chezmoi on PATH so `command -v chezmoi` and `chezmoi source-path` resolve to our fake source.
+  cat >"$STUBBIN/chezmoi" <<STUBEOF
+#!/usr/bin/env bash
+[ "\${1:-}" = "source-path" ] && { printf '%s\n' "$SRC"; exit 0; }
+exit 0
+STUBEOF
+  chmod +x "$STUBBIN/chezmoi"
+}
+
+# Run the wrapper with the stub brew wired in and the stub chezmoi ahead on PATH. Invoked via
+# `bash` (not executed directly) because the chezmoi source file is committed non-executable — the
+# executable bit is applied at apply time by the `executable_` name prefix, not stored in git.
+_run_wrapper() {
+  run env \
+    PATH="$STUBBIN:$PATH" \
+    BREW_LAUNCHER_BIN="$STUB_BREW" \
+    BREW_CALLS="$BREW_CALLS" \
+    STUB_BREW_EXIT="${STUB_BREW_EXIT:-0}" \
+    bash "$WRAPPER" "$@"
+}
+
+@test "brew wrapper exists and has valid bash syntax" {
+  [ -f "$WRAPPER" ]
+  bash -n "$WRAPPER"
+}
+
+@test "brew wrapper: a mutating subcommand (install) triggers a Brewfile dump" {
+  _stubs
+  _run_wrapper install foo
+  [ "$status" -eq 0 ]
+  # The dump wrote the marker to the chezmoi source Brewfile...
+  [ -f "$SRC/dot_Brewfile" ]
+  # ...via `brew bundle dump`, and the original passthrough ran too.
+  grep -qE '^bundle dump ' "$BREW_CALLS"
+  grep -qxF 'install foo' "$BREW_CALLS"
+}
+
+@test "brew wrapper: a global flag before the subcommand still triggers a dump" {
+  _stubs
+  _run_wrapper --verbose install foo
+  [ "$status" -eq 0 ]
+  [ -f "$SRC/dot_Brewfile" ]
+}
+
+@test "brew wrapper: a non-mutating subcommand (list) does not dump" {
+  _stubs
+  _run_wrapper list
+  [ "$status" -eq 0 ]
+  [ ! -f "$SRC/dot_Brewfile" ]
+  ! grep -qE '^bundle dump ' "$BREW_CALLS"
+}
+
+@test "brew wrapper: the real brew's exit code is preserved, and it still dumps on a trigger" {
+  _stubs
+  STUB_BREW_EXIT=42 _run_wrapper install foo
+  [ "$status" -eq 42 ]
+  [ -f "$SRC/dot_Brewfile" ]
+}
+
+@test "brew wrapper: chezmoi absent skips the dump and keeps the real brew's exit code" {
+  _stubs
+  # A minimal PATH without the chezmoi stub (and without a system chezmoi under /usr/bin:/bin).
+  run env \
+    PATH="/usr/bin:/bin" \
+    BREW_LAUNCHER_BIN="$STUB_BREW" \
+    BREW_CALLS="$BREW_CALLS" \
+    bash "$WRAPPER" install foo
+  [ "$status" -eq 0 ]
+  [ ! -f "$SRC/dot_Brewfile" ]
+  printf '%s\n' "$output" | grep -qF 'chezmoi not found'
+}
+
+@test "brew wrapper: an unresolvable real brew fails loudly (exit 127)" {
+  _stubs
+  run -127 env \
+    PATH="$STUBBIN:$PATH" \
+    BREW_LAUNCHER_BIN="$BATS_TEST_TMPDIR/does-not-exist" \
+    bash "$WRAPPER" install foo
+  printf '%s\n' "$output" | grep -qF 'could not resolve the real brew'
+}

--- a/tests/brew_launcher.bats
+++ b/tests/brew_launcher.bats
@@ -4,13 +4,14 @@ load helpers/setup
 
 # Behavioral guard for the brew PATH-shim wrapper (#360),
 # home/dot_local/launchers/executable_brew. The wrapper runs the real brew, preserves its exit
-# code, and — only after a package-set-mutating subcommand (install/uninstall/reinstall/tap/untap) —
-# regenerates the chezmoi source dot_Brewfile via `brew bundle dump`.
+# code, and — only after a package-set-mutating subcommand (install/uninstall/remove/rm/reinstall/
+# tap/untap) — regenerates the chezmoi source dot_Brewfile via `brew bundle dump`.
 #
 # These tests exercise the wrapper directly with a stub "real" brew (via BREW_LAUNCHER_BIN, mirroring
 # the CLAUDE_LAUNCHER_BIN seam) and a stub chezmoi, so no real brew/chezmoi install is needed
 # (CI-safe). The stub brew logs its argv to $BREW_CALLS, writes a marker to the --file= target on
-# `bundle dump`, and otherwise exits with $STUB_BREW_EXIT.
+# `bundle dump` (unless $STUB_DUMP_EXIT is non-zero, which simulates a dump failure), and otherwise
+# exits with $STUB_BREW_EXIT. The stub chezmoi fails `source-path` when $STUB_CHEZMOI_SP_FAIL is set.
 
 WRAPPER="${HOME_DIR}/dot_local/launchers/executable_brew"
 
@@ -20,7 +21,9 @@ _stubs() {
   STUBBIN="$BATS_TEST_TMPDIR/bin"
   SRC="$BATS_TEST_TMPDIR/src"
   BREW_CALLS="$BATS_TEST_TMPDIR/brew-calls"
-  mkdir -p "$STUBBIN" "$SRC"
+  mkdir -p "$STUBBIN"
+  rm -rf "$SRC"
+  mkdir -p "$SRC"
   : >"$BREW_CALLS"
 
   STUB_BREW="$BATS_TEST_TMPDIR/stub-brew"
@@ -28,6 +31,10 @@ _stubs() {
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$BREW_CALLS"
 if [ "${1:-}" = "bundle" ] && [ "${2:-}" = "dump" ]; then
+  if [ "${STUB_DUMP_EXIT:-0}" != "0" ]; then
+    echo "stub brew: simulated dump failure" >&2
+    exit "${STUB_DUMP_EXIT}"
+  fi
   for a in "$@"; do
     case "$a" in --file=*) printf 'dumped\n' >"${a#--file=}" ;; esac
   done
@@ -38,9 +45,17 @@ STUBEOF
   chmod +x "$STUB_BREW"
 
   # Stub chezmoi on PATH so `command -v chezmoi` and `chezmoi source-path` resolve to our fake source.
+  # It fails `source-path` when $STUB_CHEZMOI_SP_FAIL is set, to exercise the AC3 guard.
   cat >"$STUBBIN/chezmoi" <<STUBEOF
 #!/usr/bin/env bash
-[ "\${1:-}" = "source-path" ] && { printf '%s\n' "$SRC"; exit 0; }
+if [ "\${1:-}" = "source-path" ]; then
+  if [ -n "\${STUB_CHEZMOI_SP_FAIL:-}" ]; then
+    echo "stub chezmoi: simulated source-path failure" >&2
+    exit 1
+  fi
+  printf '%s\n' "$SRC"
+  exit 0
+fi
 exit 0
 STUBEOF
   chmod +x "$STUBBIN/chezmoi"
@@ -55,6 +70,8 @@ _run_wrapper() {
     BREW_LAUNCHER_BIN="$STUB_BREW" \
     BREW_CALLS="$BREW_CALLS" \
     STUB_BREW_EXIT="${STUB_BREW_EXIT:-0}" \
+    STUB_DUMP_EXIT="${STUB_DUMP_EXIT:-0}" \
+    STUB_CHEZMOI_SP_FAIL="${STUB_CHEZMOI_SP_FAIL:-}" \
     bash "$WRAPPER" "$@"
 }
 
@@ -116,4 +133,67 @@ _run_wrapper() {
     BREW_LAUNCHER_BIN="$BATS_TEST_TMPDIR/does-not-exist" \
     bash "$WRAPPER" install foo
   printf '%s\n' "$output" | grep -qF 'could not resolve the real brew'
+}
+
+@test "brew wrapper: every mutating subcommand (incl. the remove/rm aliases) triggers a dump" {
+  local sub
+  for sub in install uninstall remove rm reinstall tap untap; do
+    _stubs
+    _run_wrapper "$sub" foo
+    [ "$status" -eq 0 ]
+    [ -f "$SRC/dot_Brewfile" ] || {
+      echo "expected a dump for subcommand: $sub"
+      false
+    }
+  done
+}
+
+@test "brew wrapper: a chezmoi source-path failure preserves the real brew exit code (AC3)" {
+  _stubs
+  STUB_CHEZMOI_SP_FAIL=1 _run_wrapper install foo
+  # real brew succeeded (0); the chezmoi failure must not mask it (unguarded assignment would).
+  [ "$status" -eq 0 ]
+  [ ! -f "$SRC/dot_Brewfile" ]
+  printf '%s\n' "$output" | grep -qF 'chezmoi source-path'
+}
+
+@test "brew wrapper: a dump failure warns (with cause) but preserves the real brew exit code (AC3)" {
+  _stubs
+  STUB_DUMP_EXIT=1 _run_wrapper install foo
+  [ "$status" -eq 0 ]
+  [ ! -f "$SRC/dot_Brewfile" ]
+  printf '%s\n' "$output" | grep -qF "'brew bundle dump' failed"
+  # the dump's own stderr is forwarded, not swallowed
+  printf '%s\n' "$output" | grep -qF 'simulated dump failure'
+}
+
+@test "brew wrapper: a non-standard HOMEBREW_PREFIX is not trusted (allowlist)" {
+  _stubs
+  local evil="$BATS_TEST_TMPDIR/evil"
+  mkdir -p "$evil/bin"
+  cat >"$evil/bin/brew" <<'E'
+#!/usr/bin/env bash
+echo "EVIL-BREW-RAN"
+exit 0
+E
+  chmod +x "$evil/bin/brew"
+  # No BREW_LAUNCHER_BIN; HOMEBREW_PREFIX points at an attacker dir. A non-mutating subcommand keeps
+  # the fall-through harmless even if it reaches a real system brew (plain `--version`).
+  run env PATH="/usr/bin:/bin" HOMEBREW_PREFIX="$evil" bash "$WRAPPER" --version
+  ! printf '%s\n' "$output" | grep -qF 'EVIL-BREW-RAN'
+}
+
+@test "brew wrapper: brew bundle (non-mutating) does not dump — no recursion" {
+  _stubs
+  _run_wrapper bundle
+  [ "$status" -eq 0 ]
+  [ ! -f "$SRC/dot_Brewfile" ]
+  ! grep -qE '^bundle dump ' "$BREW_CALLS"
+}
+
+@test "brew wrapper: passes shellcheck" {
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    skip "shellcheck not installed"
+  fi
+  shellcheck --shell=bash --exclude=SC1091,SC2034,SC2086,SC2317,SC2329 "$WRAPPER"
 }


### PR DESCRIPTION
## Summary

Replace the manual `make dump-brewfile` target with a `brew` **PATH-shim wrapper** that keeps the
tracked Brewfile in sync automatically. After a package-set-mutating subcommand
(`install`/`uninstall`/`reinstall`/`tap`/`untap`), the wrapper regenerates the chezmoi source
`dot_Brewfile` via `brew bundle dump`, so it no longer drifts after ad-hoc `brew install` /
`brew uninstall`.

Homebrew has no post-install/post-uninstall hook (Homebrew/brew#2202, open since 2017), and a
shell-function wrapper would only cover interactive shells. A real file ahead of the real `brew` on
`PATH` (`~/.local/launchers`, already prepended in `.zprofile`/`.zshrc`) fires from any shell that
resolves through that dir, following the launcher PATH-wrapper pattern from #358.

Closes #360.

## Changes

- **New:** `home/dot_local/launchers/executable_brew` — runs the real brew off-`PATH`, preserves its
  exit code, and dumps the Brewfile after a mutating subcommand.
- **New:** `tests/brew_launcher.bats` — stub-based regression tests (no real brew/chezmoi needed).
- **Removed:** the `make dump-brewfile` target (`.PHONY` + recipe).
- **Docs:** dropped every `dump-brewfile` reference (`README.md`/`.ja.md`, `AGENTS.md`,
  `docs/contributing/local-dev.md`/`.ja.md`, `docs/explanation/design-rationale.md`/`.ja.md`) and
  rewrote the Brewfile paragraph in `docs/architecture/dev-tooling.md`/`.ja.md` to document the
  wrapper as the new sync mechanism.

## Design decisions

- **Brewfile resolution:** `"$(chezmoi source-path)/dot_Brewfile"` — cwd-independent; the dump is
  skipped (with a stderr note) when chezmoi is not installed.
- **Synchronous dump:** runs after the real brew exits and never masks the real brew's exit code
  (a dump failure only warns).
- **Real-brew resolution off-`PATH`:** `BREW_LAUNCHER_BIN` (test seam) → `$HOMEBREW_PREFIX` →
  `/opt/homebrew` → `/usr/local` → `/home/linuxbrew/.linuxbrew`; fails loudly (exit 127) if none
  resolve. Absolute paths never re-enter the wrapper, so there is no recursion.

## Known limitation (accepted)

Absolute-path invocations (`/opt/homebrew/bin/brew`) bypass the shim. `run_onchange_before_10-brew-bundle`
runs `brew bundle` (not a mutating subcommand), so it never triggers a dump — no recursion.

## Testing

- `make lint` — pass (shellcheck + shfmt + zsh syntax).
- `bats tests/*.bats` — 237 pass / 0 fail (includes the new `brew_launcher.bats` and `docs_facts.bats`,
  which stays green after the target removal).
- New tests cover: the trigger set, a global flag before the subcommand, non-mutating subcommands not
  dumping, exit-code fidelity (42 → 42), the chezmoi-absent skip, and fail-loud real-brew resolution.
