### PR TITLE
fix(ntfy): restore base-url (required by upstream-base-url) + auth env for the CLI

### DIFF
--- a/home/dot_config/ntfy/compose.yaml.tmpl
+++ b/home/dot_config/ntfy/compose.yaml.tmpl
@@ -14,6 +14,23 @@ services:
   ntfy:
     image: binwiederhier/ntfy:v2.26.3@sha256:081b53dbb20674fcfe05fdb4eb8af9036a2645ef979543d16f7f80803af467b1
     command: serve
+    environment:
+      # The `ntfy user`/`access`/`token` MANAGEMENT subcommands (run via
+      # `docker compose exec` from ~/.config/ntfy/lib.sh) do NOT read
+      # /etc/ntfy/server.yml — only `serve` does. They read the auth backend
+      # from these env vars, so provisioning / rotation fails with
+      # "auth-file not set" without them. Keep in sync with server.yml's
+      # auth-file / auth-default-access.
+      NTFY_AUTH_FILE: /var/lib/ntfy/user.db
+      NTFY_AUTH_DEFAULT_ACCESS: deny-all
+      # ntfy REQUIRES base-url when upstream-base-url (the iOS instant-push
+      # relay) is set. base-url is the tailnet MagicDNS HTTPS URL, which must
+      # not be committed to this repo — the lib derives it at server start and
+      # writes it to ~/.config/ntfy/.env (runtime state, docker-compose auto-
+      # loads it). Empty until derived: on a fresh machine where Tailscale is
+      # not up yet, the server simply is not started (two-phase; ntfy-setup
+      # completes it).
+      NTFY_BASE_URL: ${NTFY_BASE_URL:-}
     restart: unless-stopped
     ports:
       # Loopback-only on the host; tailnet exposure happens exclusively via

--- a/home/dot_config/ntfy/lib.sh.tmpl
+++ b/home/dot_config/ntfy/lib.sh.tmpl
@@ -24,6 +24,9 @@ ntfy_topic_done="{{ .ntfy.topic_done }}"
 
 ntfy_compose_cfg="$HOME/.config/ntfy/compose.yaml"
 ntfy_env_file="$HOME/.config/ntfy/notify-env"
+# docker-compose .env (auto-loaded): carries NTFY_BASE_URL (the tailnet MagicDNS
+# URL), derived at start and never committed — runtime state like notify-env.
+ntfy_compose_env_file="$HOME/.config/ntfy/.env"
 ntfy_state_dir="$HOME/Library/Application Support/ntfy"
 ntfy_serve_target="http://127.0.0.1:${ntfy_port:-}"
 ntfy_op_item="Dotfiles - ntfy"
@@ -88,8 +91,33 @@ ntfy_magicdns() {
 
 # --- Server bring-up ---------------------------------------------------------
 
+# Write the docker-compose .env (0600 via umask) carrying NTFY_BASE_URL. ntfy
+# REQUIRES base-url whenever upstream-base-url (the iOS instant-push relay) is
+# set, and base-url is the tailnet MagicDNS URL — kept out of the repo, derived
+# here and written as runtime state that compose auto-loads.
+ntfy_write_compose_env() {
+  (
+    umask 077
+    printf 'NTFY_BASE_URL=%s\n' "$1" >"$ntfy_compose_env_file"
+  )
+}
+
 ntfy_start_server() {
   ntfy_ensure_state_dir
+  # base-url must be set (upstream-base-url is configured), and it is the tailnet
+  # MagicDNS URL, so the server cannot start until Tailscale is up. Derive it,
+  # write the compose .env, then start. Failing here is the correct two-phase
+  # behaviour: the caller (fail-open apply / fail-clear ntfy-setup) reports it.
+  local dns
+  dns="$(ntfy_magicdns || true)"
+  if [ -z "$dns" ]; then
+    ntfy_warn "cannot derive the tailnet MagicDNS name (is Tailscale up?); not starting ntfy — base-url is required."
+    return 1
+  fi
+  ntfy_write_compose_env "https://${dns}" || {
+    ntfy_warn "failed to write the compose .env (base-url)."
+    return 1
+  }
   docker compose -f "$ntfy_compose_cfg" up -d --remove-orphans
 }
 

--- a/home/dot_config/ntfy/private_server.yml.tmpl
+++ b/home/dot_config/ntfy/private_server.yml.tmpl
@@ -1,16 +1,20 @@
 # ntfy server configuration (kryota-dev/dotfiles#337). Deployed 0600; mounted
 # read-only into the ntfy container at /etc/ntfy/server.yml (paths below are
 # container paths). This file is kept on the "Exclude CI-incompatible files"
-# list in setup-validation.yml; it no longer reads from 1Password (base-url was
-# dropped — see below), but staying excluded avoids CI rendering a 0600 config
-# full of container-only paths.
+# list in setup-validation.yml; it reads nothing from 1Password (base-url is
+# injected at runtime, see below), but staying excluded avoids CI rendering a
+# 0600 config full of container-only paths.
 
-# NOTE: `base-url` is intentionally NOT set. It is optional for core messaging
-# (only attachments / email footer links need it, none of which this setup
-# uses), it does not affect the iOS `upstream-base-url` relay, and deriving the
-# tailnet MagicDNS name at apply time would couple `chezmoi apply` to Tailscale
-# being up. The MagicDNS URL is derived on demand (device login / smoke test)
-# by ntfy-setup instead, and never stored.
+# NOTE: `base-url` is not set HERE (in the committed config) because it is the
+# tailnet MagicDNS URL, which must not live in this public repo. But ntfy
+# REQUIRES base-url whenever `upstream-base-url` (the iOS relay below) is set —
+# the server refuses to start otherwise ("if upstream-base-url is set, base-url
+# must also be set"). So the shared library derives the MagicDNS URL at server
+# start and injects it via the `NTFY_BASE_URL` env (written to
+# ~/.config/ntfy/.env, runtime state, docker-compose auto-loads it, never
+# committed). Consequence: the server cannot start until Tailscale is up — the
+# intended two-phase behaviour; run_onchange fails open and ntfy-setup completes
+# it once Tailscale/Docker are available.
 
 # iOS instant push relay (user-approved at the #337 PRD gate). NOTE: per
 # docs.ntfy.sh/config this publishes a poll request to ntfy.sh for EVERY

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1899,6 +1899,17 @@ _gate_decision() {
   # `tailscale serve`, never a direct bind.
   grep -qF '"127.0.0.1:{{ .ntfy.port }}:80"' "$c"
   ! grep -q '0\.0\.0\.0' "$c"
+  # The `ntfy user`/`access`/`token` management subcommands (run via
+  # `docker compose exec` from lib.sh) read the auth backend from env, NOT from
+  # the mounted server.yml — without these, provisioning fails "auth-file not
+  # set". Pin them so that regression can't return.
+  grep -qF 'NTFY_AUTH_FILE: /var/lib/ntfy/user.db' "$c"
+  grep -qF 'NTFY_AUTH_DEFAULT_ACCESS: deny-all' "$c"
+  # base-url is REQUIRED (upstream-base-url is set) and is the tailnet MagicDNS
+  # URL — injected at runtime via this env from ~/.config/ntfy/.env, never a
+  # repo literal. The value must stay an env reference, not a hardcoded URL.
+  grep -qF 'NTFY_BASE_URL: ${NTFY_BASE_URL:-}' "$c"
+  ! grep -qE 'NTFY_BASE_URL:.*https://' "$c"
 }
 
 @test "ntfy server config enforces deny-all auth and persistent cache" {
@@ -1976,6 +1987,12 @@ _gate_decision() {
   # op read failures must be distinguished from an empty value (a swallowed
   # error must not overwrite a real subscriber password → device lockout).
   grep -qF 'op error' "$l"
+  # base-url is required (upstream-base-url) and is the tailnet MagicDNS URL:
+  # derived at server start and written to the compose .env as runtime state,
+  # never a repo literal (no *.ts.net in the source).
+  grep -qF 'ntfy_write_compose_env' "$l"
+  grep -qF 'NTFY_BASE_URL' "$l"
+  ! grep -qE '\.ts\.net' "$l"
 }
 
 @test "ntfy-setup: deploys under ~/.local/bin, sources the lib, prompts before rotating, rotates" {


### PR DESCRIPTION
## Summary

Follow-up to #359. That PR's ntfy config **could not start the server**, and its provisioning **could not manage users** — two runtime bugs that structural (grep) tests and template rendering could not catch. Both were reproduced and fixed against the live container.

## The two bugs

### 1. `base-url` is REQUIRED, not optional (server would not start)

#359 dropped `base-url` entirely, on the premise (from the design deliberation) that it is *optional for core messaging and independent of the iOS `upstream-base-url` relay*. **That premise was factually wrong.** ntfy refuses to start when `upstream-base-url` is set without `base-url`:

```
if upstream-base-url is set, base-url must also be set
```

This setup keeps `upstream-base-url: "https://ntfy.sh"` (the iOS instant-push relay, approved at the #350 gate), so the server crash-loops. (#359 appeared to work only because the pre-existing container — started from the *old* config that still had base-url — was not recreated during that apply; recreating it surfaces the crash.)

`base-url` is the **tailnet MagicDNS URL**, which must not be committed to this public repo. So the shared library now:
- derives the MagicDNS URL at server start (`ntfy_magicdns`),
- writes it to `~/.config/ntfy/.env` as `NTFY_BASE_URL=…` (runtime state, 0600, docker-compose auto-loads it — never committed),
- and `compose.yaml` references `NTFY_BASE_URL: ${NTFY_BASE_URL:-}`.

Consequence: the server cannot start until Tailscale is up — the intended **two-phase** behaviour. `run_onchange_after_31` fails open; `ntfy-setup` completes it once Tailscale/Docker are available.

### 2. `ntfy user`/`access`/`token` need auth env (provisioning failed "auth-file not set")

The ntfy management subcommands, run via `docker compose exec` from the library, do **not** read `/etc/ntfy/server.yml` — only `serve` does. Without `NTFY_AUTH_FILE` / `NTFY_AUTH_DEFAULT_ACCESS` in the container env, every `ntfy user add` / `access` / `token add` fails with `auth-file not set`, so provisioning and rotation never worked. Added both to the compose environment (kept in sync with server.yml).

## Verification

Both fixes reproduced and confirmed on the running container:
- Before: server crash-loops (`base-url must also be set`); `ntfy user list` → `auth-file not set`.
- After: container `running restarting=false`; `ntfy user list` lists publisher/subscriber with correct ACLs; a real authenticated publish to the loopback returns **200**.

`make test` green (lint + bats). Tests pin the new compose env, that `NTFY_BASE_URL` stays an env reference (never a hardcoded URL), and that no `*.ts.net` literal enters the source. server.yml comments corrected.

## Process note

The #359 pipeline (grill-me design deliberation → multi-review → adversarial verify) accepted the "base-url is optional" premise without an integration test that actually starts the container, so neither the design phase nor the review phase caught it. This follow-up adds the missing runtime-truth checks; a container smoke test in CI remains a candidate future hardening. Run on Opus 4.8 (below the Opus 5 floor the workflow requests for this tier).
