### PR TITLE
feat(morning-radar): deliver the brief as a tailnet URL with ntfy (#361)

### DIFF
--- a/.claude/prds/361-brief-url-ntfy.prd.md
+++ b/.claude/prds/361-brief-url-ntfy.prd.md
@@ -28,43 +28,62 @@ spike も**スコープ外**（配信手段として使わないため検証不�
 
 # Acceptance Criteria
 
-- **AC-001**: 平日朝の成功実行が、**モバイルから到達可能な tailnet URL**（`https://<magicdns>/…`）
-  を含む ntfy 通知を配信する。通知タップで brief 全文が読める。brief 内容は tailnet 外へ出ない。
+- **AC-001**: 平日朝の成功実行が、**モバイルから読める tailnet ntfy メッセージ**として brief を
+  配信する（`claude-brief` topic、`markdown: true`、本文＝brief 全文。ntfy web app が Markdown を
+  レンダリング、モバイルアプリは raw Markdown 表示）。通知を開けば brief 全文が読める。brief 内容は
+  tailnet 外へ出ない。〔改訂: 当初は tailscale serve 静的ページ = URL 配信だったが、macOS の
+  standalone/App 版 tailscale がディレクトリ配信不可（ポートのみ）とレビューで判明し、ntfy
+  メッセージ配信へ pivot（下記 decision log 参照）。〕
 - **AC-002**: `executable_morning-radar.sh` に **osascript 通知経路が一切残らない**（成功・
   各エラー経路すべて）。`osascript` / `display notification` の文字列が wrapper に存在しない
   ことを bats で検証する。
 - **AC-003**: 通知配信は **fail-open**。ntfy サーバー / tailscale serve が不達でも wrapper は
   クラッシュせず、失敗を log に残す（既存 ntfy-notify.sh と同じ許容度）。同日 guard の
   `last-run` stamp は「成功時のみ」書く既存挙動を壊さない。
-- **AC-004**: **graceful degradation** — brief ページ URL が用意できない場合でも、ntfy 通知は
-  少なくとも `HEADLINE`（既存の 1 行サマリー）を届ける（URL は click として付けられるときだけ付与）。
+- **AC-004**: brief は 1 通の Markdown メッセージ（title=HEADLINE、body=brief 全文）として配信する。
+  message-size-limit を引き上げ、上限超過による添付ファイル化を避ける。〔改訂: 旧「URL 縮退」は
+  ntfy メッセージ配信への pivot で不要になった。配信失敗時の挙動は AC-003 の fail-open が担保する。〕
 - **AC-005**: エラー経路（claude 不在 / timeout / 非 0 exit / brief ファイル欠落）は ntfy の
   **attention 系 topic**（高 priority）で通知する。成功の brief 配信とは topic / priority で区別する。
 - **AC-006**: publisher token は **argv に露出しない**（`curl -K` config file 経由。既存
   ntfy-notify.sh と同じ hygiene）。bats で argv 非露出を検証する。
-- **AC-007**: 新規 serve マウント / topic / runtime state は既存 ntfy の provisioning・serve
-  マッピング（443 root = ntfy）と**衝突しない**。`tailscale funnel` は使わない（tailnet-only 維持）。
+- **AC-007**: 新規 topic / runtime state（notify-env）は既存 ntfy の provisioning と**衝突しない**。
+  serve マッピングは変更しない（tailscale serve は既存の ntfy root proxy のみ）。`tailscale funnel`
+  は使わない（tailnet-only 維持）。既存インストールの upgrade でも notify-env に新 topic が反映される。
 - **AC-008**: 変更で追加/改名した chezmoi 管理ファイルは `tests/files.bats` に宣言し、
   `make lint` / `make test` が green。docs（notifications.md ＋ `.ja.md`）に brief 配信経路を追記。
 
 # Considered Alternatives / Rejection Rationale
+
+> **改訂（post-review pivot, #379 レビュー）**: 当初 tailscale serve 静的ページ（URL 配信）を採用し
+> 実装したが、multi-review で codex が「macOS の standalone/App 版 tailscale はディレクトリ/ファイルを
+> serve できない（ポートのみ）」と指摘。一次ソース（[Tailscale Serve KB 1242](https://tailscale.com/kb/1242/tailscale-serve)）で
+> 確定し、当マシンが system-extension 版であることも確認。→ **tailscale serve 静的ページを却下し、
+> 下記「ntfy message body(markdown)」を採用**（当初 sidecar port-proxy 案も検討したが、user が最も
+> シンプルな ntfy メッセージ配信を選択）。これにより pandoc raw-HTML XSS リスクも同時に消滅した。
 
 - **[却下] Artifact(claude.ai) を primary 配信**（Issue #361 原案）: brief 内容が tailnet 外の
   第三者クラウドへ出る。Artifact tool 仕様上「削除してもキャッシュ/インデックスされうる」。
   既存 ntfy の tailnet-only posture・client 固有名を publish しないポリシーと衝突。**user が
   tailnet-only 維持を選択**したため却下。付随して headless Artifact spike も不要（AC-001 で担保する
   配信手段に Artifact を使わない）。
-- **[却下候補/要確認] brief を ntfy message body(markdown) で配信**: ntfy app の markdown 描画に
-  依存。default `message-size-limit`(4KB) を brief が超えうる。durable な URL にならない
-  （履歴 168h で消える）。→ 「URL 配信」という AC-001 の要件に対し弱い。**推奨: 却下**。
+- **[採用（post-review pivot）] brief を ntfy message body(markdown) で配信**: brief 全文を
+  `markdown: true` の 1 メッセージ本文として publish。web app が Markdown をレンダリング（モバイル
+  アプリは raw Markdown 表示だが可読）。`message-size-limit` を 32KB に引き上げ 4KB 超の添付化を回避。
+  serve マウント・HTML 生成・URL・pandoc をすべて排し最もシンプル。tailnet-only を維持し、
+  brief は ntfy の cache.db（既存の 168h plaintext residency、#337 で承認済み）に載る。当初は
+  「URL でない/168h で消える」を理由に却下候補としたが、macOS serve 制約の判明で URL 前提が崩れ、
+  user 判断で本案を採用した。
 - **[却下候補/要確認] brief を ntfy attachment で配信**: 既存 serve マッピング（ntfy root）を
   そのまま再利用でき `https://<magicdns>/file/…` が得られる利点。ただし server.yml に
   `attachment-cache-dir` 追加（現在未設定＝添付無効）＋ cache disk 常駐が増える。HTML 添付の
   in-app 描画挙動が不確実。→ 次善。**採用は sdd 設計で再評価**。
-- **[採用（推奨）] brief を `tailscale serve` の静的ページとして配信**（Issue #361 の fallback を
-  実質 primary 化）: 既存 tailscale（ntfy 用に稼働中）と MagicDNS 派生 helper（`ntfy_magicdns`）を
-  再利用。durable な tailnet URL。マウント衝突を避けるため **専用パス（`--set-path /brief`）or
-  専用ポート（例 `--https=8443`）**で ntfy root（443）と分離する（どちらにするかは Open Questions）。
+- **[却下（当初採用→撤回）] brief を `tailscale serve` の静的ページとして配信**: MagicDNS 由来の
+  durable な tailnet URL が得られる利点で当初採用・実装した。しかし **macOS の standalone/App 版
+  tailscale はディレクトリ/ファイルを serve できない**（KB 1242、当マシンが該当）ため `--set-path
+  /brief <dir>` が機能せず撤回。ポートプロキシする static server sidecar 案（compose にコンテナ追加）
+  も検討したが、user が ntfy メッセージ配信を選択したため不採用。付随して pandoc raw-HTML XSS
+  （`-f gfm` が `<script>` 素通し）と mount 失敗時の縮退不整合も pivot で解消された。
 - **[却下] 送信ロジックを ntfy-notify.sh から共有 helper へ即リファクタ**: 稼働中の hook wrapper を
   触るリスク＋スコープ拡大。house rule「重複が実在してから DRY 化」に反する先回り抽象化。
   → morning-radar 側に **self-contained な publish**（ntfy-notify.sh の token hygiene を踏襲）を

--- a/.claude/prds/361-brief-url-ntfy.prd.md
+++ b/.claude/prds/361-brief-url-ntfy.prd.md
@@ -1,0 +1,105 @@
+---
+slug: 361-brief-url-ntfy
+feature: Deliver the morning brief as a tailnet URL with ntfy notification
+created_at: 2026-07-26T23:39:53+09:00
+grill_session: 2cedd4fc-b28d-4d15-83a0-a77921d6078e
+status: finalized
+---
+
+# Background
+
+morning brief は現在 `~/dotfiles/.kryota-dev/morning-brief/<YYYY-MM-DD>.md`（global gitignore
+済・repo 非追跡）に書かれ、`executable_morning-radar.sh` の `notify_user()` が osascript で
+デスクトップ通知するだけ。この通知は文書へリンクできず、モバイルにも届かないため brief が
+読まれない。平日自動実行（launchd `dev.kryota.morning-radar`、平日 9:00 JST、#257）は既にあり、
+残るギャップは「配信」。#357 で publisher-token ベースの ntfy 送信基盤（tailnet-only）が入った。
+
+**確定した privacy 境界（user 承認済み・本 PRD の前提を規定）**: 既存 ntfy は意図的に
+tailnet-only（`tailscale funnel` を明示禁止）。brief は work/client 文脈を含みうるため、
+**brief 内容を claude.ai(Artifact) 等の第三者クラウドへ出さず、配信は tailnet 内で完結する**。
+→ Issue #361 が primary としていた Artifact 経路は**不採用**。Artifact の headless 実現性
+spike も**スコープ外**（配信手段として使わないため検証不要）。
+
+# User Story
+
+平日朝、launchd が morning brief を生成したら、私はモバイル端末で ntfy 通知を受け取り、
+通知をタップすると tailnet 経由で brief 全文を読める。通知経路は macOS ローカルの osascript
+ではなく ntfy に一本化され、外出先（tailnet 接続時）でも brief が届く。
+
+# Acceptance Criteria
+
+- **AC-001**: 平日朝の成功実行が、**モバイルから到達可能な tailnet URL**（`https://<magicdns>/…`）
+  を含む ntfy 通知を配信する。通知タップで brief 全文が読める。brief 内容は tailnet 外へ出ない。
+- **AC-002**: `executable_morning-radar.sh` に **osascript 通知経路が一切残らない**（成功・
+  各エラー経路すべて）。`osascript` / `display notification` の文字列が wrapper に存在しない
+  ことを bats で検証する。
+- **AC-003**: 通知配信は **fail-open**。ntfy サーバー / tailscale serve が不達でも wrapper は
+  クラッシュせず、失敗を log に残す（既存 ntfy-notify.sh と同じ許容度）。同日 guard の
+  `last-run` stamp は「成功時のみ」書く既存挙動を壊さない。
+- **AC-004**: **graceful degradation** — brief ページ URL が用意できない場合でも、ntfy 通知は
+  少なくとも `HEADLINE`（既存の 1 行サマリー）を届ける（URL は click として付けられるときだけ付与）。
+- **AC-005**: エラー経路（claude 不在 / timeout / 非 0 exit / brief ファイル欠落）は ntfy の
+  **attention 系 topic**（高 priority）で通知する。成功の brief 配信とは topic / priority で区別する。
+- **AC-006**: publisher token は **argv に露出しない**（`curl -K` config file 経由。既存
+  ntfy-notify.sh と同じ hygiene）。bats で argv 非露出を検証する。
+- **AC-007**: 新規 serve マウント / topic / runtime state は既存 ntfy の provisioning・serve
+  マッピング（443 root = ntfy）と**衝突しない**。`tailscale funnel` は使わない（tailnet-only 維持）。
+- **AC-008**: 変更で追加/改名した chezmoi 管理ファイルは `tests/files.bats` に宣言し、
+  `make lint` / `make test` が green。docs（notifications.md ＋ `.ja.md`）に brief 配信経路を追記。
+
+# Considered Alternatives / Rejection Rationale
+
+- **[却下] Artifact(claude.ai) を primary 配信**（Issue #361 原案）: brief 内容が tailnet 外の
+  第三者クラウドへ出る。Artifact tool 仕様上「削除してもキャッシュ/インデックスされうる」。
+  既存 ntfy の tailnet-only posture・client 固有名を publish しないポリシーと衝突。**user が
+  tailnet-only 維持を選択**したため却下。付随して headless Artifact spike も不要（AC-001 で担保する
+  配信手段に Artifact を使わない）。
+- **[却下候補/要確認] brief を ntfy message body(markdown) で配信**: ntfy app の markdown 描画に
+  依存。default `message-size-limit`(4KB) を brief が超えうる。durable な URL にならない
+  （履歴 168h で消える）。→ 「URL 配信」という AC-001 の要件に対し弱い。**推奨: 却下**。
+- **[却下候補/要確認] brief を ntfy attachment で配信**: 既存 serve マッピング（ntfy root）を
+  そのまま再利用でき `https://<magicdns>/file/…` が得られる利点。ただし server.yml に
+  `attachment-cache-dir` 追加（現在未設定＝添付無効）＋ cache disk 常駐が増える。HTML 添付の
+  in-app 描画挙動が不確実。→ 次善。**採用は sdd 設計で再評価**。
+- **[採用（推奨）] brief を `tailscale serve` の静的ページとして配信**（Issue #361 の fallback を
+  実質 primary 化）: 既存 tailscale（ntfy 用に稼働中）と MagicDNS 派生 helper（`ntfy_magicdns`）を
+  再利用。durable な tailnet URL。マウント衝突を避けるため **専用パス（`--set-path /brief`）or
+  専用ポート（例 `--https=8443`）**で ntfy root（443）と分離する（どちらにするかは Open Questions）。
+- **[却下] 送信ロジックを ntfy-notify.sh から共有 helper へ即リファクタ**: 稼働中の hook wrapper を
+  触るリスク＋スコープ拡大。house rule「重複が実在してから DRY 化」に反する先回り抽象化。
+  → morning-radar 側に **self-contained な publish**（ntfy-notify.sh の token hygiene を踏襲）を
+  置く。重複が問題化した時点で lib.sh への helper 抽出を別 issue 化。
+- **[採用（推奨）] brief 配信用の専用 topic を新設**（例 `topic_brief`）: agent-completed 用の
+  `claude-done` に混ぜず、独立に mute/subscribe 可能にする。`.chezmoidata.toml [ntfy]` に SSOT 追加、
+  ACL grant ループ・notify-env に反映。**却下代替**: `claude-done` 流用（実装は最小だが日次 brief で
+  agent 完了ストリームが騒がしくなる）。
+
+# Out of Scope
+
+- Artifact / claude.ai 配信、および headless Artifact の spike。
+- ntfy-notify.sh（既存 hook wrapper）のリファクタ / 共有 helper 抽出。
+- brief 履歴のダッシュボード化（#371 が別途）。
+- brief 生成ロジック（morning-brief skill）の内容変更。配信のみ扱う。
+- Linux 対応の新規配信（morning-radar は Darwin 限定。`[ "$(uname)" = "Darwin" ]` 既存 guard を維持）。
+
+# Open Questions
+
+- **OQ-1（serve 分離方式）**: brief ページを `--set-path /brief`（443 に相乗り）か専用ポート
+  `--https=8443` か。前者は ntfy の topic route `/brief` と longest-prefix で共存できる想定だが
+  実挙動の検証が要る。後者は衝突ゼロだが URL に `:8443` が付く。→ sdd 設計 + smoke test で確定。
+- **OQ-2（brief の HTML 描画）**: 生 markdown を serve するとモバイル browser では text/plain 表示。
+  可読性のため HTML 化するか（変換手段: 既存ツール有無を要調査／最小 HTML shell／MVP は生 md）。
+  → AC-001「読める」を満たす最小手段を sdd で決定。
+- **OQ-3（serve マウントの provisioning 場所）**: brief serve を morning-radar 実行時に都度
+  assert するか、ntfy の setup（run_onchange_after_31 / ntfy-setup / lib.sh）に相乗りさせるか。
+  後者は ntfy provisioning と結合するが serve マッピングの一元管理になる。→ sdd 設計で確定。
+- **OQ-4（新規 topic のスモーク/ACL）**: `topic_brief` 新設時、publisher の write ACL grant と
+  端末側 subscribe 手順を docs に追記する範囲。
+
+# Assumptions（auto 審議で自律解決した前提。承認時に検分）
+
+- brief dir は global gitignore 済で repo 非追跡 → tailnet serve しても repo へは漏れない。
+- publish は既存どおり loopback(`http://127.0.0.1:2586`)へ、click URL のみ MagicDNS。
+- morning-radar は「dependency-free な self-contained wrapper」設計を維持（lib.sh を source しない）。
+- 新規 serve マウント追加は tailnet-only posture の範囲内（funnel を使わない限り privacy 境界を
+  越えない）ため、privacy 面の追加エスカレートは不要と判断（越境判断は既に user 承認済み）。

--- a/.claude/prds/361-brief-url-ntfy.prd.md
+++ b/.claude/prds/361-brief-url-ntfy.prd.md
@@ -28,21 +28,19 @@ spike も**スコープ外**（配信手段として使わないため検証不�
 
 # Acceptance Criteria
 
-- **AC-001**: 平日朝の成功実行が、**モバイルから読める tailnet ntfy メッセージ**として brief を
-  配信する（`claude-brief` topic、`markdown: true`、本文＝brief 全文。ntfy web app が Markdown を
-  レンダリング、モバイルアプリは raw Markdown 表示）。通知を開けば brief 全文が読める。brief 内容は
-  tailnet 外へ出ない。〔改訂: 当初は tailscale serve 静的ページ = URL 配信だったが、macOS の
-  standalone/App 版 tailscale がディレクトリ配信不可（ポートのみ）とレビューで判明し、ntfy
-  メッセージ配信へ pivot（下記 decision log 参照）。〕
+- **AC-001**: 平日朝の成功実行が、**モバイルから到達可能な tailnet URL**（`https://<magicdns>:8443/<date>.html`）
+  を `click` に持つ ntfy 通知（`claude-brief` topic）を配信する。通知タップでモバイルブラウザが brief の
+  HTML ページをネイティブレンダリングする。brief 内容は tailnet 外へ出ない。〔改訂 2 段階（decision log
+  参照）: tailscale serve ディレクトリ配信（macOS 不可）→ ntfy メッセージ（モバイル未レンダリング）→
+  **静的サーバー sidecar を port-proxy した HTML ページ配信**に確定。〕
 - **AC-002**: `executable_morning-radar.sh` に **osascript 通知経路が一切残らない**（成功・
   各エラー経路すべて）。`osascript` / `display notification` の文字列が wrapper に存在しない
   ことを bats で検証する。
 - **AC-003**: 通知配信は **fail-open**。ntfy サーバー / tailscale serve が不達でも wrapper は
   クラッシュせず、失敗を log に残す（既存 ntfy-notify.sh と同じ許容度）。同日 guard の
   `last-run` stamp は「成功時のみ」書く既存挙動を壊さない。
-- **AC-004**: brief は 1 通の Markdown メッセージ（title=HEADLINE、body=brief 全文）として配信する。
-  message-size-limit を引き上げ、上限超過による添付ファイル化を避ける。〔改訂: 旧「URL 縮退」は
-  ntfy メッセージ配信への pivot で不要になった。配信失敗時の挙動は AC-003 の fail-open が担保する。〕
+- **AC-004**: **graceful degradation** — HTML render 失敗またはベース URL 未設定（MagicDNS 導出不可）
+  の場合でも、ntfy 通知は少なくとも `HEADLINE` を届ける（`click` は付けられるときだけ付与）。
 - **AC-005**: エラー経路（claude 不在 / timeout / 非 0 exit / brief ファイル欠落）は ntfy の
   **attention 系 topic**（高 priority）で通知する。成功の brief 配信とは topic / priority で区別する。
 - **AC-006**: publisher token は **argv に露出しない**（`curl -K` config file 経由。既存
@@ -55,25 +53,36 @@ spike も**スコープ外**（配信手段として使わないため検証不�
 
 # Considered Alternatives / Rejection Rationale
 
-> **改訂（post-review pivot, #379 レビュー）**: 当初 tailscale serve 静的ページ（URL 配信）を採用し
-> 実装したが、multi-review で codex が「macOS の standalone/App 版 tailscale はディレクトリ/ファイルを
-> serve できない（ポートのみ）」と指摘。一次ソース（[Tailscale Serve KB 1242](https://tailscale.com/kb/1242/tailscale-serve)）で
-> 確定し、当マシンが system-extension 版であることも確認。→ **tailscale serve 静的ページを却下し、
-> 下記「ntfy message body(markdown)」を採用**（当初 sidecar port-proxy 案も検討したが、user が最も
-> シンプルな ntfy メッセージ配信を選択）。これにより pandoc raw-HTML XSS リスクも同時に消滅した。
+> **改訂（post-review pivot, #379 レビュー — 2 段階）**:
+> 1. 当初 **tailscale serve 静的ページ（ディレクトリ serve）** を採用・実装したが、multi-review で
+>    codex が「macOS の standalone/App 版 tailscale はディレクトリ/ファイルを serve できない（ポート
+>    のみ）」と指摘。一次ソース（[Tailscale Serve KB 1242](https://tailscale.com/kb/1242/tailscale-serve)）
+>    で確定（当マシンが system-extension 版）。→ ディレクトリ serve を却下。
+> 2. 次に **ntfy message body(markdown)** に一旦 pivot したが、一次ソース（docs.ntfy.sh: Markdown は
+>    "web app only for now"、リリースノートにもモバイルアプリの Markdown レンダリング追加なし）で
+>    **iOS/Android アプリは Markdown 非レンダリング = モバイル UX 不良**と判明。→ message 案も却下。
+> 3. **最終採用: 静的サーバー sidecar を port-proxy した HTML ページ配信**（下記）。loopback の
+>    nginx sidecar を `tailscale serve --https`（ポートプロキシ = macOS でも動作）で front し、通知の
+>    click でモバイルブラウザが HTML をネイティブレンダリング。pandoc は `-f markdown-raw_html` で
+>    raw HTML をエスケープし XSS を封じる。
 
 - **[却下] Artifact(claude.ai) を primary 配信**（Issue #361 原案）: brief 内容が tailnet 外の
   第三者クラウドへ出る。Artifact tool 仕様上「削除してもキャッシュ/インデックスされうる」。
   既存 ntfy の tailnet-only posture・client 固有名を publish しないポリシーと衝突。**user が
   tailnet-only 維持を選択**したため却下。付随して headless Artifact spike も不要（AC-001 で担保する
   配信手段に Artifact を使わない）。
-- **[採用（post-review pivot）] brief を ntfy message body(markdown) で配信**: brief 全文を
-  `markdown: true` の 1 メッセージ本文として publish。web app が Markdown をレンダリング（モバイル
-  アプリは raw Markdown 表示だが可読）。`message-size-limit` を 32KB に引き上げ 4KB 超の添付化を回避。
-  serve マウント・HTML 生成・URL・pandoc をすべて排し最もシンプル。tailnet-only を維持し、
-  brief は ntfy の cache.db（既存の 168h plaintext residency、#337 で承認済み）に載る。当初は
-  「URL でない/168h で消える」を理由に却下候補としたが、macOS serve 制約の判明で URL 前提が崩れ、
-  user 判断で本案を採用した。
+- **[却下（一旦採用→撤回）] brief を ntfy message body(markdown) で配信**: serve/HTML/URL を排せる
+  最もシンプルな案として一旦採用したが、一次ソース（docs.ntfy.sh「Markdown は web app only for now」、
+  リリースノートにモバイルアプリの Markdown 対応追加なし）で **iOS/Android アプリは Markdown を
+  レンダリングせず raw 表示**と判明。モバイルで読む前提だと UX 不良のため撤回。
+- **[採用（最終）] 静的サーバー sidecar を port-proxy した HTML ページ配信**: loopback の nginx
+  sidecar（ntfy compose に `brief-page` サービス追加、brief dir を read-only mount）を
+  `tailscale serve --https 8443`（**ポートプロキシは macOS でも動作**）で front。通知 click →
+  `https://<magicdns>:8443/<date>.html` → モバイルブラウザが HTML をネイティブレンダリング（ntfy
+  認証不要）。pandoc `-f markdown-raw_html` で未信頼 brief 内容の raw HTML をエスケープし XSS を封じる
+  （fallback は `<pre>` エスケープ）。専用 HTTPS ポートで serve の path-strip 曖昧性を回避（ntfy root
+  443 と独立）。Docker は ntfy で既に必須なので追加インフラは container 1 つのみ。nginx image は
+  Renovate regex manager で pin。
 - **[却下候補/要確認] brief を ntfy attachment で配信**: 既存 serve マッピング（ntfy root）を
   そのまま再利用でき `https://<magicdns>/file/…` が得られる利点。ただし server.yml に
   `attachment-cache-dir` 追加（現在未設定＝添付無効）＋ cache disk 常駐が増える。HTML 添付の

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -119,6 +119,19 @@
       depNameTemplate: 'binwiederhier/ntfy',
       datasourceTemplate: 'docker',
     },
+    {
+      // Brief-page static-file sidecar image (#361), pinned literally in the
+      // same compose template — tracked with a regex manager like ntfy above.
+      customType: 'regex',
+      managerFilePatterns: [
+        '/home/dot_config/ntfy/compose\\.yaml\\.tmpl$/',
+      ],
+      matchStrings: [
+        'image: nginx:(?<currentValue>[0-9.]+-alpine)@(?<currentDigest>sha256:[a-f0-9]+)',
+      ],
+      depNameTemplate: 'nginx',
+      datasourceTemplate: 'docker',
+    },
   ],
   mise: {
     managerFilePatterns: [

--- a/docs/agents/claude-code.ja.md
+++ b/docs/agents/claude-code.ja.md
@@ -429,7 +429,7 @@ kryota-dev/dotfiles#257: launchd LaunchAgent が平日朝に `/morning-brief` �
 - **スケジュール挙動。** スリープ中に跨いだ発火は復帰時に 1 回へ coalesce され、電源オフの日はスキップされます。`~/.local/state/morning-radar/` の日付マーカーで課金実行を 1 日 1 回に制限し、手動再実行は `~/.claude/morning-radar.sh --force` で行います。
 - **縮退モード。** claude.ai の Gmail/Calendar コネクタは headless で OAuth を完了できないため、brief は取得失敗を明記して GitHub + ローカルコンテキストへ縮退します（morning-brief SKILL.md に記載の挙動）。
 - **権限とコスト。** wrapper は明示的な `--allowedTools` allowlist（read-only の `gh`/`git` とファイル読み取り、`Write` は brief 出力先のみ）を渡し、`--dangerously-skip-permissions` は使いません。モデルは `sonnet` に固定、`--max-turns` でターン上限、600 秒の watchdog が課金バックストップです。平日 5 回/週の費用は #257 で事前承認済みです。
-- **出力契約。** brief は `~/dotfiles/.kryota-dev/morning-brief/<YYYY-MM-DD>.md` に保存され、最終応答は `HEADLINE:` の 1 行のみ。wrapper がそれを ntfy 通知のタイトルとし、brief 全文の markdown をメッセージ本文として publish します（tailnet-only、#361 — [notifications](../architecture/notifications.ja.md#朝ブリーフの配信-361) 参照）。
+- **出力契約。** brief は `~/dotfiles/.kryota-dev/morning-brief/<YYYY-MM-DD>.md` に保存され、最終応答は `HEADLINE:` の 1 行のみ。wrapper がそれを ntfy 通知に載せ、click で tailnet 上に serve された brief ページを開きます（tailnet-only、#361 — [notifications](../architecture/notifications.ja.md#朝ブリーフの配信-361) 参照）。
 
 ---
 

--- a/docs/agents/claude-code.ja.md
+++ b/docs/agents/claude-code.ja.md
@@ -429,7 +429,7 @@ kryota-dev/dotfiles#257: launchd LaunchAgent が平日朝に `/morning-brief` �
 - **スケジュール挙動。** スリープ中に跨いだ発火は復帰時に 1 回へ coalesce され、電源オフの日はスキップされます。`~/.local/state/morning-radar/` の日付マーカーで課金実行を 1 日 1 回に制限し、手動再実行は `~/.claude/morning-radar.sh --force` で行います。
 - **縮退モード。** claude.ai の Gmail/Calendar コネクタは headless で OAuth を完了できないため、brief は取得失敗を明記して GitHub + ローカルコンテキストへ縮退します（morning-brief SKILL.md に記載の挙動）。
 - **権限とコスト。** wrapper は明示的な `--allowedTools` allowlist（read-only の `gh`/`git` とファイル読み取り、`Write` は brief 出力先のみ）を渡し、`--dangerously-skip-permissions` は使いません。モデルは `sonnet` に固定、`--max-turns` でターン上限、600 秒の watchdog が課金バックストップです。平日 5 回/週の費用は #257 で事前承認済みです。
-- **出力契約。** brief は `~/dotfiles/.kryota-dev/morning-brief/<YYYY-MM-DD>.md` に保存され、最終応答は `HEADLINE:` の 1 行のみ。wrapper がそれを通知へ転載します（osascript へは argv 渡し — AppleScript への文字列補間はしません）。
+- **出力契約。** brief は `~/dotfiles/.kryota-dev/morning-brief/<YYYY-MM-DD>.md` に保存され、最終応答は `HEADLINE:` の 1 行のみ。wrapper がそれを ntfy 通知のタイトルとし、brief 全文の markdown をメッセージ本文として publish します（tailnet-only、#361 — [notifications](../architecture/notifications.ja.md#朝ブリーフの配信-361) 参照）。
 
 ---
 

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -431,7 +431,7 @@ Issue kryota-dev/dotfiles#257: a launchd LaunchAgent runs `/morning-brief` headl
 - **Schedule semantics.** launchd coalesces fires missed while asleep into one run on wake; days the Mac is powered off are skipped. A date marker under `~/.local/state/morning-radar/` caps execution at one billed run per day; `~/.claude/morning-radar.sh --force` bypasses it for manual reruns.
 - **Degraded mode.** The claude.ai Gmail/Calendar connectors cannot complete OAuth headless, so the brief degrades to GitHub + local context with an explicit fetch-failure note — the behavior documented in morning-brief SKILL.md.
 - **Permissions & cost.** The wrapper passes an explicit `--allowedTools` allowlist (read-only `gh`/`git` and file reads; `Write` scoped to the brief output dir) and never uses `--dangerously-skip-permissions`. The model is pinned to `sonnet`, turns are capped with `--max-turns`, and a 600 s watchdog is the billing backstop. The weekday 5-runs/week spend was pre-approved on #257.
-- **Output contract.** The brief lands in `~/dotfiles/.kryota-dev/morning-brief/<YYYY-MM-DD>.md`; the final response is a single `HEADLINE:` line the wrapper uses as the ntfy notification title, publishing the full brief markdown as the message body (tailnet-only, #361 — see [notifications](../architecture/notifications.md#morning-brief-delivery-361)).
+- **Output contract.** The brief lands in `~/dotfiles/.kryota-dev/morning-brief/<YYYY-MM-DD>.md`; the final response is a single `HEADLINE:` line the wrapper puts in an ntfy notification whose click opens the rendered brief page served on the tailnet (tailnet-only, #361 — see [notifications](../architecture/notifications.md#morning-brief-delivery-361)).
 
 ---
 

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -431,7 +431,7 @@ Issue kryota-dev/dotfiles#257: a launchd LaunchAgent runs `/morning-brief` headl
 - **Schedule semantics.** launchd coalesces fires missed while asleep into one run on wake; days the Mac is powered off are skipped. A date marker under `~/.local/state/morning-radar/` caps execution at one billed run per day; `~/.claude/morning-radar.sh --force` bypasses it for manual reruns.
 - **Degraded mode.** The claude.ai Gmail/Calendar connectors cannot complete OAuth headless, so the brief degrades to GitHub + local context with an explicit fetch-failure note — the behavior documented in morning-brief SKILL.md.
 - **Permissions & cost.** The wrapper passes an explicit `--allowedTools` allowlist (read-only `gh`/`git` and file reads; `Write` scoped to the brief output dir) and never uses `--dangerously-skip-permissions`. The model is pinned to `sonnet`, turns are capped with `--max-turns`, and a 600 s watchdog is the billing backstop. The weekday 5-runs/week spend was pre-approved on #257.
-- **Output contract.** The brief lands in `~/dotfiles/.kryota-dev/morning-brief/<YYYY-MM-DD>.md`; the final response is a single `HEADLINE:` line the wrapper relays into the notification (argv-passed to osascript — no AppleScript string interpolation).
+- **Output contract.** The brief lands in `~/dotfiles/.kryota-dev/morning-brief/<YYYY-MM-DD>.md`; the final response is a single `HEADLINE:` line the wrapper uses as the ntfy notification title, publishing the full brief markdown as the message body (tailnet-only, #361 — see [notifications](../architecture/notifications.md#morning-brief-delivery-361)).
 
 ---
 

--- a/docs/architecture/notifications.ja.md
+++ b/docs/architecture/notifications.ja.md
@@ -16,7 +16,7 @@ ntfy への経路に加え、平日朝ブリーフの配信（#361）です。�
 （SessionStart、instinct クラスターのレビュー促し）と `notify` zsh エイリアス（可聴チャイム。
 本システムの wrapper も失敗時のアラート音として再利用しています）。`morning-radar.sh`
 （launchd、平日ブリーフ）は以前はローカル `osascript` で通知していましたが、現在はブリーフを
-Markdown の ntfy メッセージとして publish します —— 下記
+tailnet の HTML ページにレンダリングし、それにリンクする ntfy 通知を送ります —— 下記
 [朝ブリーフの配信](#朝ブリーフの配信-361)を参照。
 
 ## アーキテクチャ
@@ -82,37 +82,43 @@ phones/tablets on the tailnet (username/password login)
 
 平日の `morning-radar.sh` wrapper（launchd `dev.kryota.morning-radar`、#257）は、以前は
 ローカル `osascript` 通知でブリーフを知らせていましたが、この通知は文書を運べず、モバイルにも
-届きませんでした。現在はブリーフを **Markdown の ntfy メッセージ**として、本システムと同じ
-tailnet-only の境界で配信します —— **ブリーフ内容が tailnet 外へ出ることはありません**。2 つの
+届きませんでした。現在はブリーフをモバイル可読な HTML ページにレンダリングし、その**ページを開く
+click** を持つ ntfy 通知を送ります —— **ブリーフ内容が tailnet 外へ出ることはありません**。2 つの
 代替案は却下しました（`.claude/prds/361-brief-url-ntfy.prd.md` の決定ログ参照）: Artifact/claude.ai
-ページ（内容が第三者へ出る）と、`tailscale serve` の静的ページ（macOS の standalone/App 版
-Tailscale は **ポートは serve できてもファイル/ディレクトリは serve できない**ため、この Mac では
-ディレクトリマウントが機能しない）。
+ページ（内容が第三者へ出る）と、ブリーフを ntfy **メッセージ**として配信する案（ntfy の iOS/Android
+アプリは Markdown をレンダリングせず web app のみ対応のため、モバイルでは raw Markdown 表示になる）。
+serve した HTML ページはブラウザがネイティブにレンダリングします。
 
-- **配信**: 成功時、wrapper は `claude-brief` トピックへ、1 行の `HEADLINE` を通知タイトル、
-  **ブリーフ全文の Markdown をメッセージ本文**（`markdown: true`）として publish します。通知を
-  開くとブリーフが表示され、ntfy の **web app は Markdown をレンダリング**します（iOS/Android
-  アプリは現状 raw Markdown 表示ですが可読です）。エラー経路（claude 不在 / timeout / 非 0 exit /
-  ブリーフファイル欠落）は `claude-attention` へ高 priority で publish します。headless の claude
-  セッションには `Artifact` ツールを**付与しません**。
-- **メッセージサイズ**: ブリーフは 1 メッセージなので、`server.yml` の `message-size-limit` を
-  32 KB に引き上げます —— 上限超過のメッセージは ntfy が黙って添付ファイルに変換し、アプリは
-  インライン描画しないためです。
-- **token hygiene**: write-only publisher トークンは `curl -K` config file 経由で渡され
-  （argv には出ません）、subshell 内でのみ source するため claude の環境にも入りません。env
-  ファイルは owner-only（0600/0400）でなければ fail-open します（`ntfy-notify.sh` と同じガード）。
-- **fail-open**: publish の失敗は log に残すだけで、実行や同日 stamp を中断しません（stamp は
-  ブリーフ成功時、配信の前に書かれます）。
+- **レンダリング**: `render_brief_html` が `~/dotfiles/.kryota-dev/morning-brief/<date>.html` を
+  pandoc（`-f markdown-raw_html`。未信頼のブリーフ内容中の **raw HTML をエスケープ**し —— GitHub
+  タイトル由来の `<script>` がページ上で実行されない —— GFM テーブルは保持）または self-contained
+  でモバイル可読な `<pre>` フォールバックで生成します。headless の claude セッションには `Artifact`
+  ツールを**付与しません**。
+- **serve**: loopback の **nginx sidecar**（`compose.yaml` の `brief-page` サービス）が brief dir を
+  `ntfy_brief_port` で配信し、tailnet 側は `tailscale serve --https 8443` の**ポートプロキシ**が front
+  します —— macOS の standalone/App 版 Tailscale は**ポートは proxy できてもファイル/ディレクトリは
+  serve できない**ためです。専用 HTTPS ポートで ntfy root（443）と独立。tailnet-only、`funnel` は
+  使いません。`NTFY_BRIEF_BASE_URL`（`https://<magicdns>:8443`）はプロビジョニング時に導出され
+  notify-env に書かれ、wrapper が `/<date>.html` を付加します。
+- **通知**: 成功時、wrapper は `claude-brief` へ `HEADLINE` とページ URL を `click` として publish
+  します。エラー経路（claude 不在 / timeout / 非 0 exit / ブリーフファイル欠落）は `claude-attention`
+  へ高 priority で publish。publisher トークンは `curl -K` config file 経由（argv には出ず）、subshell
+  内でのみ source。env ファイルは owner-only（0600/0400）でなければ fail-open します。
+- **fail-open / 縮退**: publish の失敗は log に残すだけで、実行や同日 stamp を中断しません（stamp は
+  ブリーフ成功時、配信の前に書かれます）。render やベース URL が使えない場合でも通知は `HEADLINE` を
+  届けます（リンクなし）。
 
 既存トピック（`claude-attention`/`claude-done`）も `markdown: true` で publish するようになり、
-本文が web app でレンダリングされます。
+本文が ntfy web app でレンダリングされます。
 
 Smoke test（オンデマンドでブリーフを publish）:
 
 ```bash
-~/.claude/morning-radar.sh --force   # 課金される実行 1 回。claude-brief へ publish
-# subscribe 済みデバイスで claude-brief トピックを開いてブリーフを読む。
-tailscale funnel status              # 期待: 何も serve していない（tailnet-only）
+~/.claude/morning-radar.sh --force   # 課金される実行 1 回。claude-brief にリンク付きで通知
+# tailnet デバイスで通知のリンクを開く（または）:
+BASE="https://$(tailscale status --json | jq -r .Self.DNSName | sed 's/\.$//'):8443"
+curl -sI "$BASE/$(date +%F).html" | head -1   # 期待: HTTP/… 200
+tailscale funnel status                        # 期待: 何も serve していない（tailnet-only）
 ```
 
 ## セットアップ手順（初回のみ）

--- a/docs/architecture/notifications.ja.md
+++ b/docs/architecture/notifications.ja.md
@@ -15,8 +15,8 @@ ntfy への経路に加え、平日朝ブリーフの配信（#361）です。�
 いない独立したローカル限定の通知経路が他に2つあります: `clv2-session-notify.sh`
 （SessionStart、instinct クラスターのレビュー促し）と `notify` zsh エイリアス（可聴チャイム。
 本システムの wrapper も失敗時のアラート音として再利用しています）。`morning-radar.sh`
-（launchd、平日ブリーフ）は以前はローカル `osascript` で通知していましたが、現在は ntfy へ
-publish し、ブリーフページを tailnet 経由で serve します —— 下記
+（launchd、平日ブリーフ）は以前はローカル `osascript` で通知していましたが、現在はブリーフを
+Markdown の ntfy メッセージとして publish します —— 下記
 [朝ブリーフの配信](#朝ブリーフの配信-361)を参照。
 
 ## アーキテクチャ
@@ -81,38 +81,38 @@ phones/tablets on the tailnet (username/password login)
 ## 朝ブリーフの配信 (#361)
 
 平日の `morning-radar.sh` wrapper（launchd `dev.kryota.morning-radar`、#257）は、以前は
-ローカル `osascript` 通知でブリーフを知らせていましたが、この通知は文書へリンクできず、
-モバイルにも届きませんでした。現在は本システムと同じ tailnet-only の境界で配信します ——
-**ブリーフ内容が tailnet 外へ出ることはありません**（Artifact/claude.ai 経路は検討のうえ却下。
-`.claude/prds/361-brief-url-ntfy.prd.md` の決定ログ参照）:
+ローカル `osascript` 通知でブリーフを知らせていましたが、この通知は文書を運べず、モバイルにも
+届きませんでした。現在はブリーフを **Markdown の ntfy メッセージ**として、本システムと同じ
+tailnet-only の境界で配信します —— **ブリーフ内容が tailnet 外へ出ることはありません**。2 つの
+代替案は却下しました（`.claude/prds/361-brief-url-ntfy.prd.md` の決定ログ参照）: Artifact/claude.ai
+ページ（内容が第三者へ出る）と、`tailscale serve` の静的ページ（macOS の standalone/App 版
+Tailscale は **ポートは serve できてもファイル/ディレクトリは serve できない**ため、この Mac では
+ディレクトリマウントが機能しない）。
 
-- **serve マウント**: `ntfy_assert_brief_serve`（`~/.config/ntfy/lib.sh` 内。
-  `run_onchange_after_31-setup-ntfy` と `ntfy-setup` の両方が検証）が、ブリーフディレクトリ
-  （`~/dotfiles/.kryota-dev/morning-brief/`）を静的ファイルとして serve する 2 つ目の
-  `tailscale serve --bg --set-path /brief` ハンドラを追加します。`tailscale serve` のパス
-  ハンドラは加算的かつ独立なので、`/brief` はルート `/` → ntfy proxy と共存し、どちらの
-  再検証も相手を上書きしません。tailnet-only を維持 —— `funnel` は使いません。
-- **URL**: tailnet のベース URL（`https://<magicdns>/brief`）はプロビジョニング時に導出され、
-  `~/.config/ntfy/notify-env` に `NTFY_BRIEF_BASE_URL` として書き出されます。wrapper が
-  `/<date>.html` を付加します。ブリーフの markdown はこの HTML へ wrapper がレンダリングします
-  （利用可能なら pandoc、なければ self-contained でモバイル可読な `<pre>` フォールバック）——
-  headless の claude セッションには `Artifact` ツールを**付与しません**。
-- **通知**: 成功時、wrapper は 1 行の `HEADLINE` を `claude-brief` トピックへ、ページ URL を
-  ntfy の `click` アクションとして publish します。エラー経路（claude 不在 / timeout /
-  非 0 exit / ブリーフファイル欠落）は `claude-attention` へ高 priority・リンクなしで publish
-  します。publisher トークンは `curl -K` config file 経由で渡され（argv には出ません）、
-  `ntfy-notify.sh` と同じ扱いです。
-- **fail-open / 縮退**: publish の失敗は log に残すだけで、実行や同日 stamp を中断しません。
-  HTML レンダリングやベース URL が利用できない場合でも、通知は `HEADLINE` を届けます（click なし）。
+- **配信**: 成功時、wrapper は `claude-brief` トピックへ、1 行の `HEADLINE` を通知タイトル、
+  **ブリーフ全文の Markdown をメッセージ本文**（`markdown: true`）として publish します。通知を
+  開くとブリーフが表示され、ntfy の **web app は Markdown をレンダリング**します（iOS/Android
+  アプリは現状 raw Markdown 表示ですが可読です）。エラー経路（claude 不在 / timeout / 非 0 exit /
+  ブリーフファイル欠落）は `claude-attention` へ高 priority で publish します。headless の claude
+  セッションには `Artifact` ツールを**付与しません**。
+- **メッセージサイズ**: ブリーフは 1 メッセージなので、`server.yml` の `message-size-limit` を
+  32 KB に引き上げます —— 上限超過のメッセージは ntfy が黙って添付ファイルに変換し、アプリは
+  インライン描画しないためです。
+- **token hygiene**: write-only publisher トークンは `curl -K` config file 経由で渡され
+  （argv には出ません）、subshell 内でのみ source するため claude の環境にも入りません。env
+  ファイルは owner-only（0600/0400）でなければ fail-open します（`ntfy-notify.sh` と同じガード）。
+- **fail-open**: publish の失敗は log に残すだけで、実行や同日 stamp を中断しません（stamp は
+  ブリーフ成功時、配信の前に書かれます）。
 
-Smoke test（オンデマンドでブリーフを実行し、tailnet ページと通知を確認）:
+既存トピック（`claude-attention`/`claude-done`）も `markdown: true` で publish するようになり、
+本文が web app でレンダリングされます。
+
+Smoke test（オンデマンドでブリーフを publish）:
 
 ```bash
-~/.claude/morning-radar.sh --force          # 課金される実行 1 回。claude-brief へ publish
-# tailnet デバイスから、表示された URL を開く（または）:
-BASE="https://$(tailscale status --json | jq -r .Self.DNSName | sed 's/\.$//')"
-curl -sI "$BASE/brief/$(date +%F).html" | head -1   # 期待: HTTP/… 200
-tailscale funnel status                              # 期待: 何も serve していない（tailnet-only）
+~/.claude/morning-radar.sh --force   # 課金される実行 1 回。claude-brief へ publish
+# subscribe 済みデバイスで claude-brief トピックを開いてブリーフを読む。
+tailscale funnel status              # 期待: 何も serve していない（tailnet-only）
 ```
 
 ## セットアップ手順（初回のみ）

--- a/docs/architecture/notifications.ja.md
+++ b/docs/architecture/notifications.ja.md
@@ -11,11 +11,13 @@ tailnet 上のデバイスから subscribe されます（kryota-dev/dotfiles#33
 `.claude/prds/337-ntfy-tailscale.prd.md` にあります。
 
 **スコープの境界**: このページが扱うのは Claude Code の `Notification`/`Stop` フックから
-ntfy への経路のみです。リポジトリには、本システムが意図的に手を付けていない独立した
-ローカル限定の通知経路が他に3つあります: `clv2-session-notify.sh`（SessionStart、
-instinct クラスターのレビュー促し）、`morning-radar.sh`（launchd、osascript による
-朝ブリーフ）、`notify` zsh エイリアス（可聴チャイム。本システムの wrapper も失敗時の
-アラート音として再利用しています）。
+ntfy への経路に加え、平日朝ブリーフの配信（#361）です。本システムが意図的に手を付けて
+いない独立したローカル限定の通知経路が他に2つあります: `clv2-session-notify.sh`
+（SessionStart、instinct クラスターのレビュー促し）と `notify` zsh エイリアス（可聴チャイム。
+本システムの wrapper も失敗時のアラート音として再利用しています）。`morning-radar.sh`
+（launchd、平日ブリーフ）は以前はローカル `osascript` で通知していましたが、現在は ntfy へ
+publish し、ブリーフページを tailnet 経由で serve します —— 下記
+[朝ブリーフの配信](#朝ブリーフの配信-361)を参照。
 
 ## アーキテクチャ
 
@@ -66,6 +68,7 @@ phones/tablets on the tailnet (username/password login)
 |-------|--------|----------|------------------------|
 | `claude-attention` | permission_prompt, idle_prompt, agent_needs_input | high (4) | sound/vibrate on |
 | `claude-done` | agent_completed, Stop | default (3) | silent delivery |
+| `claude-brief` | weekday morning brief (morning-radar, #361) | default (3) | mute optional |
 | `claude-test` | manual smoke tests | — | mute after testing |
 
 帰属情報（repo、branch、account `default`/`r06`、8文字のセッション id、イベント種別）はタイトルと
@@ -74,6 +77,43 @@ phones/tablets on the tailnet (username/password login)
 名前スクラブであり、**secret/PII 検出器ではありません** — 切り詰めが主たる防御手段です）。
 許容済み残存リスク（#337 PRD）: プロンプトインジェクションを受けたアシスタントメッセージが
 200 文字の窓内に短い secret 断片を含む可能性は残ります — 汎用 secret 検出は明示的にスコープ外です。
+
+## 朝ブリーフの配信 (#361)
+
+平日の `morning-radar.sh` wrapper（launchd `dev.kryota.morning-radar`、#257）は、以前は
+ローカル `osascript` 通知でブリーフを知らせていましたが、この通知は文書へリンクできず、
+モバイルにも届きませんでした。現在は本システムと同じ tailnet-only の境界で配信します ——
+**ブリーフ内容が tailnet 外へ出ることはありません**（Artifact/claude.ai 経路は検討のうえ却下。
+`.claude/prds/361-brief-url-ntfy.prd.md` の決定ログ参照）:
+
+- **serve マウント**: `ntfy_assert_brief_serve`（`~/.config/ntfy/lib.sh` 内。
+  `run_onchange_after_31-setup-ntfy` と `ntfy-setup` の両方が検証）が、ブリーフディレクトリ
+  （`~/dotfiles/.kryota-dev/morning-brief/`）を静的ファイルとして serve する 2 つ目の
+  `tailscale serve --bg --set-path /brief` ハンドラを追加します。`tailscale serve` のパス
+  ハンドラは加算的かつ独立なので、`/brief` はルート `/` → ntfy proxy と共存し、どちらの
+  再検証も相手を上書きしません。tailnet-only を維持 —— `funnel` は使いません。
+- **URL**: tailnet のベース URL（`https://<magicdns>/brief`）はプロビジョニング時に導出され、
+  `~/.config/ntfy/notify-env` に `NTFY_BRIEF_BASE_URL` として書き出されます。wrapper が
+  `/<date>.html` を付加します。ブリーフの markdown はこの HTML へ wrapper がレンダリングします
+  （利用可能なら pandoc、なければ self-contained でモバイル可読な `<pre>` フォールバック）——
+  headless の claude セッションには `Artifact` ツールを**付与しません**。
+- **通知**: 成功時、wrapper は 1 行の `HEADLINE` を `claude-brief` トピックへ、ページ URL を
+  ntfy の `click` アクションとして publish します。エラー経路（claude 不在 / timeout /
+  非 0 exit / ブリーフファイル欠落）は `claude-attention` へ高 priority・リンクなしで publish
+  します。publisher トークンは `curl -K` config file 経由で渡され（argv には出ません）、
+  `ntfy-notify.sh` と同じ扱いです。
+- **fail-open / 縮退**: publish の失敗は log に残すだけで、実行や同日 stamp を中断しません。
+  HTML レンダリングやベース URL が利用できない場合でも、通知は `HEADLINE` を届けます（click なし）。
+
+Smoke test（オンデマンドでブリーフを実行し、tailnet ページと通知を確認）:
+
+```bash
+~/.claude/morning-radar.sh --force          # 課金される実行 1 回。claude-brief へ publish
+# tailnet デバイスから、表示された URL を開く（または）:
+BASE="https://$(tailscale status --json | jq -r .Self.DNSName | sed 's/\.$//')"
+curl -sI "$BASE/brief/$(date +%F).html" | head -1   # 期待: HTTP/… 200
+tailscale funnel status                              # 期待: 何も serve していない（tailnet-only）
+```
 
 ## セットアップ手順（初回のみ）
 
@@ -112,7 +152,7 @@ phones/tablets on the tailnet (username/password login)
    docker compose exec ntfy ntfy user add publisher     # publisher, write-only
    NTFY_PASSWORD='<choose-a-strong-password>' \
      docker compose exec -T -e NTFY_PASSWORD ntfy ntfy user add subscriber   # devices, read-only
-   for t in claude-attention claude-done claude-test; do
+   for t in claude-attention claude-done claude-brief claude-test; do
      docker compose exec ntfy ntfy access publisher "$t" write-only
      docker compose exec ntfy ntfy access subscriber "$t" read-only
    done
@@ -128,7 +168,8 @@ phones/tablets on the tailnet (username/password login)
 4. **デバイスの subscribe** — ntfy アプリ（iOS/Android）→ *別のサーバーを使う* → サーバー URL
    （`ntfy-setup` が表示します。または `tailscale status --json | jq -r .Self.DNSName` で
    自分で導出し、末尾のドットを除去して `https://` を前置します）→ username `subscriber` と
-   `Dotfiles - ntfy` 1Password アイテムのパスワードでログイン → 2 つのトピックを購読します。
+   `Dotfiles - ntfy` 1Password アイテムのパスワードでログイン → トピック（`claude-attention`、
+   `claude-done`、および平日ブリーフ用の `claude-brief`）を購読します。
 
 ## Smoke test
 

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -8,12 +8,14 @@ subscribed from tailnet devices (kryota-dev/dotfiles#337). This replaces the ECC
 persistent, remotely subscribable notifications. The finalized decision record lives
 in `.claude/prds/337-ntfy-tailscale.prd.md`.
 
-**Scope boundary**: this page covers only the Claude Code `Notification`/`Stop`
-hook → ntfy path. The repo has three other, independent local-only notification
-paths that this system deliberately does not touch: `clv2-session-notify.sh`
-(SessionStart, instinct-cluster review nudge), `morning-radar.sh` (launchd,
-osascript morning brief), and the `notify` zsh alias (audible chime, also reused
-by this system's wrapper as its failure alert sound).
+**Scope boundary**: this page covers the Claude Code `Notification`/`Stop`
+hook → ntfy path plus the weekday morning-brief delivery (#361). Two other
+independent local-only notification paths are deliberately left untouched:
+`clv2-session-notify.sh` (SessionStart, instinct-cluster review nudge) and the
+`notify` zsh alias (audible chime, also reused by this system's wrapper as its
+failure alert sound). `morning-radar.sh` (launchd, weekday brief) used to notify
+via local `osascript`; it now publishes to ntfy and serves the brief page over
+the tailnet — see [Morning-brief delivery](#morning-brief-delivery-361) below.
 
 ## Architecture
 
@@ -65,6 +67,7 @@ phones/tablets on the tailnet (username/password login)
 |-------|--------|----------|------------------------|
 | `claude-attention` | permission_prompt, idle_prompt, agent_needs_input | high (4) | sound/vibrate on |
 | `claude-done` | agent_completed, Stop | default (3) | silent delivery |
+| `claude-brief` | weekday morning brief (morning-radar, #361) | default (3) | mute optional |
 | `claude-test` | manual smoke tests | — | mute after testing |
 
 Attribution (repo, branch, account `default`/`r06`, 8-char session id, event type)
@@ -74,6 +77,46 @@ chars and scrubbed with the client-identifier pattern from
 detector; truncation is the primary defense). Accepted residual risk (#337 PRD): a
 prompt-injected assistant message could still surface short secret fragments within
 the 200-char window — general secret detection is explicitly out of scope.
+
+## Morning-brief delivery (#361)
+
+The weekday `morning-radar.sh` wrapper (launchd `dev.kryota.morning-radar`, #257)
+used to announce the brief with a local `osascript` notification that could not
+link to the document and never reached mobile. It now delivers over the same
+tailnet-only boundary as the rest of this system — **no brief content ever leaves
+the tailnet** (the Artifact/claude.ai path was considered and rejected; see the
+`.claude/prds/361-brief-url-ntfy.prd.md` decision log):
+
+- **Serve mount**: `ntfy_assert_brief_serve` (in `~/.config/ntfy/lib.sh`, asserted
+  by both `run_onchange_after_31-setup-ntfy` and `ntfy-setup`) adds a second
+  `tailscale serve --bg --set-path /brief` handler that serves the brief directory
+  (`~/dotfiles/.kryota-dev/morning-brief/`) as static files. `tailscale serve`
+  path handlers are additive and independent, so `/brief` coexists with the root
+  `/` → ntfy proxy and neither re-assert clobbers the other. Still tailnet-only —
+  never `funnel`.
+- **URL**: the tailnet base URL (`https://<magicdns>/brief`) is derived at provision
+  time and written to `~/.config/ntfy/notify-env` as `NTFY_BRIEF_BASE_URL`; the
+  wrapper appends `/<date>.html`. The brief markdown is rendered to that HTML by the
+  wrapper (pandoc when available, else a self-contained mobile-readable `<pre>`
+  fallback) — the headless claude session is **not** granted the `Artifact` tool.
+- **Notification**: on success the wrapper publishes the 1-line `HEADLINE` to the
+  `claude-brief` topic with the page URL as the ntfy `click` action; error paths
+  (claude missing / timeout / non-zero exit / brief file missing) publish to
+  `claude-attention` at high priority with no link. The publisher token travels via
+  a `curl -K` config file (never argv), exactly as `ntfy-notify.sh` does.
+- **Fail-open / degradation**: any publish failure is logged and never aborts the
+  run or the same-day stamp; if the HTML render or the base URL is unavailable, the
+  notification still carries the `HEADLINE` (no click).
+
+Smoke test (run the brief on demand and confirm the tailnet page + notification):
+
+```bash
+~/.claude/morning-radar.sh --force          # one billed run; publishes to claude-brief
+# From a tailnet device, open the printed URL (or):
+BASE="https://$(tailscale status --json | jq -r .Self.DNSName | sed 's/\.$//')"
+curl -sI "$BASE/brief/$(date +%F).html" | head -1   # expect: HTTP/… 200
+tailscale funnel status                              # expect: nothing served (tailnet-only)
+```
 
 ## Setup runbook (one-time)
 
@@ -115,7 +158,7 @@ hand.
    docker compose exec ntfy ntfy user add publisher     # publisher, write-only
    NTFY_PASSWORD='<choose-a-strong-password>' \
      docker compose exec -T -e NTFY_PASSWORD ntfy ntfy user add subscriber   # devices, read-only
-   for t in claude-attention claude-done claude-test; do
+   for t in claude-attention claude-done claude-brief claude-test; do
      docker compose exec ntfy ntfy access publisher "$t" write-only
      docker compose exec ntfy ntfy access subscriber "$t" read-only
    done
@@ -131,7 +174,9 @@ hand.
    server URL (`ntfy-setup` prints it; or derive it yourself with
    `tailscale status --json | jq -r .Self.DNSName`, strip the trailing dot,
    prepend `https://`) → log in with username `subscriber` and the password from
-   the `Dotfiles - ntfy` 1Password item → subscribe to the two topics.
+   the `Dotfiles - ntfy` 1Password item → subscribe to the topics
+   (`claude-attention`, `claude-done`, and — for the weekday brief —
+   `claude-brief`).
 
 ## Smoke test
 

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -14,8 +14,8 @@ independent local-only notification paths are deliberately left untouched:
 `clv2-session-notify.sh` (SessionStart, instinct-cluster review nudge) and the
 `notify` zsh alias (audible chime, also reused by this system's wrapper as its
 failure alert sound). `morning-radar.sh` (launchd, weekday brief) used to notify
-via local `osascript`; it now publishes to ntfy and serves the brief page over
-the tailnet — see [Morning-brief delivery](#morning-brief-delivery-361) below.
+via local `osascript`; it now publishes the brief as a Markdown ntfy message —
+see [Morning-brief delivery](#morning-brief-delivery-361) below.
 
 ## Architecture
 
@@ -82,40 +82,41 @@ the 200-char window — general secret detection is explicitly out of scope.
 
 The weekday `morning-radar.sh` wrapper (launchd `dev.kryota.morning-radar`, #257)
 used to announce the brief with a local `osascript` notification that could not
-link to the document and never reached mobile. It now delivers over the same
-tailnet-only boundary as the rest of this system — **no brief content ever leaves
-the tailnet** (the Artifact/claude.ai path was considered and rejected; see the
-`.claude/prds/361-brief-url-ntfy.prd.md` decision log):
+carry the document and never reached mobile. It now delivers the brief as a
+**Markdown ntfy message** over the same tailnet-only boundary as the rest of this
+system — **no brief content ever leaves the tailnet**. Two alternatives were
+rejected (see the `.claude/prds/361-brief-url-ntfy.prd.md` decision log): an
+Artifact/claude.ai page (moves brief content to a third party), and a
+`tailscale serve` static page (the macOS standalone/App Tailscale variant can serve
+**ports but not files or directories**, so the directory mount would never work on
+this Mac).
 
-- **Serve mount**: `ntfy_assert_brief_serve` (in `~/.config/ntfy/lib.sh`, asserted
-  by both `run_onchange_after_31-setup-ntfy` and `ntfy-setup`) adds a second
-  `tailscale serve --bg --set-path /brief` handler that serves the brief directory
-  (`~/dotfiles/.kryota-dev/morning-brief/`) as static files. `tailscale serve`
-  path handlers are additive and independent, so `/brief` coexists with the root
-  `/` → ntfy proxy and neither re-assert clobbers the other. Still tailnet-only —
-  never `funnel`.
-- **URL**: the tailnet base URL (`https://<magicdns>/brief`) is derived at provision
-  time and written to `~/.config/ntfy/notify-env` as `NTFY_BRIEF_BASE_URL`; the
-  wrapper appends `/<date>.html`. The brief markdown is rendered to that HTML by the
-  wrapper (pandoc when available, else a self-contained mobile-readable `<pre>`
-  fallback) — the headless claude session is **not** granted the `Artifact` tool.
-- **Notification**: on success the wrapper publishes the 1-line `HEADLINE` to the
-  `claude-brief` topic with the page URL as the ntfy `click` action; error paths
-  (claude missing / timeout / non-zero exit / brief file missing) publish to
-  `claude-attention` at high priority with no link. The publisher token travels via
-  a `curl -K` config file (never argv), exactly as `ntfy-notify.sh` does.
-- **Fail-open / degradation**: any publish failure is logged and never aborts the
-  run or the same-day stamp; if the HTML render or the base URL is unavailable, the
-  notification still carries the `HEADLINE` (no click).
+- **Delivery**: on success the wrapper publishes to the `claude-brief` topic with
+  the 1-line `HEADLINE` as the notification title and the **full brief Markdown as
+  the message body** (`markdown: true`). Opening the notification shows the brief:
+  the ntfy **web app renders the Markdown**, while the iOS/Android apps currently
+  show it as raw (still readable) Markdown. Error paths (claude missing / timeout /
+  non-zero exit / brief file missing) publish to `claude-attention` at high priority.
+  The headless claude session is **not** granted the `Artifact` tool.
+- **Message size**: the brief is one message, so `server.yml` raises
+  `message-size-limit` to 32 KB — ntfy silently converts an over-limit message to a
+  downloadable attachment, which the apps do not render inline.
+- **Token hygiene**: the write-only publisher token travels via a `curl -K` config
+  file (never argv), sourced in a subshell so it never enters the claude env; the
+  env file must be owner-only (0600/0400) or delivery fails open (same guard as
+  `ntfy-notify.sh`).
+- **Fail-open**: any publish failure is logged and never aborts the run or the
+  same-day stamp (the stamp is written on brief success, before delivery).
 
-Smoke test (run the brief on demand and confirm the tailnet page + notification):
+Existing topics (`claude-attention`/`claude-done`) also now publish with
+`markdown: true`, so their bodies render in the web app too.
+
+Smoke test (publish the current brief on demand):
 
 ```bash
-~/.claude/morning-radar.sh --force          # one billed run; publishes to claude-brief
-# From a tailnet device, open the printed URL (or):
-BASE="https://$(tailscale status --json | jq -r .Self.DNSName | sed 's/\.$//')"
-curl -sI "$BASE/brief/$(date +%F).html" | head -1   # expect: HTTP/… 200
-tailscale funnel status                              # expect: nothing served (tailnet-only)
+~/.claude/morning-radar.sh --force   # one billed run; publishes to claude-brief
+# On a subscribed device, open the claude-brief topic to read the brief.
+tailscale funnel status              # expect: nothing served (tailnet-only)
 ```
 
 ## Setup runbook (one-time)

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -14,7 +14,8 @@ independent local-only notification paths are deliberately left untouched:
 `clv2-session-notify.sh` (SessionStart, instinct-cluster review nudge) and the
 `notify` zsh alias (audible chime, also reused by this system's wrapper as its
 failure alert sound). `morning-radar.sh` (launchd, weekday brief) used to notify
-via local `osascript`; it now publishes the brief as a Markdown ntfy message —
+via local `osascript`; it now renders the brief to a tailnet HTML page and sends
+an ntfy notification that links to it —
 see [Morning-brief delivery](#morning-brief-delivery-361) below.
 
 ## Architecture
@@ -82,41 +83,50 @@ the 200-char window — general secret detection is explicitly out of scope.
 
 The weekday `morning-radar.sh` wrapper (launchd `dev.kryota.morning-radar`, #257)
 used to announce the brief with a local `osascript` notification that could not
-carry the document and never reached mobile. It now delivers the brief as a
-**Markdown ntfy message** over the same tailnet-only boundary as the rest of this
-system — **no brief content ever leaves the tailnet**. Two alternatives were
-rejected (see the `.claude/prds/361-brief-url-ntfy.prd.md` decision log): an
-Artifact/claude.ai page (moves brief content to a third party), and a
-`tailscale serve` static page (the macOS standalone/App Tailscale variant can serve
-**ports but not files or directories**, so the directory mount would never work on
-this Mac).
+carry the document and never reached mobile. It now renders the brief to a
+mobile-readable HTML page and sends an ntfy notification whose **click opens that
+page** over the tailnet — **no brief content ever leaves the tailnet**. Two
+alternatives were rejected (see the `.claude/prds/361-brief-url-ntfy.prd.md`
+decision log): an Artifact/claude.ai page (moves brief content to a third party),
+and delivering the brief as an ntfy **message** (the ntfy iOS/Android apps do not
+render Markdown — only the web app does — so the brief would show as raw Markdown
+on mobile). A browser renders the served HTML page natively.
 
-- **Delivery**: on success the wrapper publishes to the `claude-brief` topic with
-  the 1-line `HEADLINE` as the notification title and the **full brief Markdown as
-  the message body** (`markdown: true`). Opening the notification shows the brief:
-  the ntfy **web app renders the Markdown**, while the iOS/Android apps currently
-  show it as raw (still readable) Markdown. Error paths (claude missing / timeout /
-  non-zero exit / brief file missing) publish to `claude-attention` at high priority.
-  The headless claude session is **not** granted the `Artifact` tool.
-- **Message size**: the brief is one message, so `server.yml` raises
-  `message-size-limit` to 32 KB — ntfy silently converts an over-limit message to a
-  downloadable attachment, which the apps do not render inline.
-- **Token hygiene**: the write-only publisher token travels via a `curl -K` config
-  file (never argv), sourced in a subshell so it never enters the claude env; the
-  env file must be owner-only (0600/0400) or delivery fails open (same guard as
-  `ntfy-notify.sh`).
-- **Fail-open**: any publish failure is logged and never aborts the run or the
-  same-day stamp (the stamp is written on brief success, before delivery).
+- **Rendering**: `render_brief_html` writes `~/dotfiles/.kryota-dev/morning-brief/
+  <date>.html` with pandoc (`-f markdown-raw_html`, which **escapes any raw HTML**
+  in the untrusted brief content — a `<script>` from a GitHub title cannot execute
+  on the page — while keeping GFM tables), or a self-contained mobile-readable
+  `<pre>` fallback. The headless claude session is **not** granted the `Artifact` tool.
+- **Serving**: a loopback **nginx sidecar** (the `brief-page` service in
+  `compose.yaml`) serves the brief dir on `ntfy_brief_port`, fronted on the tailnet
+  by `tailscale serve --https 8443` — a **port proxy**, because the macOS
+  standalone/App Tailscale variant can proxy ports but **cannot serve files or
+  directories**. A dedicated HTTPS port keeps it independent of the ntfy root (443).
+  Tailnet-only — never `funnel`. `NTFY_BRIEF_BASE_URL` (`https://<magicdns>:8443`)
+  is derived at provision time and written to notify-env; the wrapper appends
+  `/<date>.html`.
+- **Notification**: on success the wrapper publishes to `claude-brief` with the
+  `HEADLINE` and the page URL as the ntfy `click`; error paths (claude missing /
+  timeout / non-zero exit / brief file missing) publish to `claude-attention` at
+  high priority. The publisher token travels via a `curl -K` config file (never
+  argv), sourced in a subshell; the env file must be owner-only (0600/0400) or
+  delivery fails open (same guard as `ntfy-notify.sh`).
+- **Fail-open / degradation**: any publish failure is logged and never aborts the
+  run or the same-day stamp (written on brief success, before delivery); if the
+  render or the base URL is unavailable, the notification still carries the
+  `HEADLINE` (no link).
 
 Existing topics (`claude-attention`/`claude-done`) also now publish with
-`markdown: true`, so their bodies render in the web app too.
+`markdown: true`, so their bodies render in the ntfy web app.
 
 Smoke test (publish the current brief on demand):
 
 ```bash
-~/.claude/morning-radar.sh --force   # one billed run; publishes to claude-brief
-# On a subscribed device, open the claude-brief topic to read the brief.
-tailscale funnel status              # expect: nothing served (tailnet-only)
+~/.claude/morning-radar.sh --force   # one billed run; notifies claude-brief with a link
+# On a tailnet device, open the notification's link (or):
+BASE="https://$(tailscale status --json | jq -r .Self.DNSName | sed 's/\.$//'):8443"
+curl -sI "$BASE/$(date +%F).html" | head -1   # expect: HTTP/… 200
+tailscale funnel status                        # expect: nothing served (tailnet-only)
 ```
 
 ## Setup runbook (one-time)

--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -179,3 +179,7 @@ ghq_user = "kryota-dev"
   # intentionally not declared here.
   topic_attention = "claude-attention"
   topic_done = "claude-done"
+  # Weekday morning-brief delivery (kryota-dev/dotfiles#361). Distinct from the
+  # agent-completed stream so the daily brief can be muted/subscribed on its own;
+  # the notification's click opens the brief page served on the tailnet.
+  topic_brief = "claude-brief"

--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -183,3 +183,7 @@ ghq_user = "kryota-dev"
   # agent-completed stream so the daily brief can be muted/subscribed on its own;
   # the notification's click opens the brief page served on the tailnet.
   topic_brief = "claude-brief"
+  # Loopback port for the brief static-file sidecar (#361), fronted on the
+  # tailnet by `tailscale serve --https=8443` (a port proxy — macOS cannot serve
+  # files/directories directly). Distinct from the ntfy port above.
+  brief_port = 2587

--- a/home/dot_claude/executable_morning-radar.sh
+++ b/home/dot_claude/executable_morning-radar.sh
@@ -2,13 +2,13 @@
 # Weekday-morning radar wrapper (kryota-dev/dotfiles#257, delivery #361).
 # Launched by the dev.kryota.morning-radar LaunchAgent on weekday mornings.
 # Runs /morning-brief headless (degraded mode) on the personal Claude Code
-# account, saves the brief to a dated file, and delivers it as a Markdown ntfy
-# message (#361): the brief's full text is the message body (rendered as
-# Markdown in the ntfy web app; the mobile apps show it as raw-but-readable
-# Markdown for now), the HEADLINE is the notification title. Detection + notify
-# only: no downstream skill dispatch. Delivery is tailnet-only — the brief is
-# published to the self-hosted ntfy server (loopback), never to a third party
-# (no Artifact/claude.ai path).
+# account, saves the brief to a dated file, renders a mobile-readable HTML page,
+# and sends an ntfy notification whose click opens that page over the tailnet
+# (#361). The page is served by a loopback nginx sidecar fronted by
+# `tailscale serve --https` (a port proxy — macOS cannot serve files directly);
+# a mobile browser renders the HTML natively (the ntfy apps do not render
+# Markdown). Detection + notify only: no downstream skill dispatch. Delivery is
+# tailnet-only — the page never leaves the tailnet, no Artifact/claude.ai path.
 #
 # Source-safe: side effects live in main(), guarded by the BASH_SOURCE check at
 # the end, so tests can source this file and exercise ntfy_publish without
@@ -64,7 +64,7 @@ log() {
 # The env file must be owner-only (0600/0400) — sourcing it is code execution,
 # so a group/other-accessible file fails open (same guard as ntfy-notify.sh).
 ntfy_publish() {
-  local kind="$1" priority="$2" title="$3" message="$4"
+  local kind="$1" priority="$2" title="$3" message="$4" click="${5:-}"
   local env_mode
   [ -f "$ENV_FILE" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
@@ -93,13 +93,21 @@ ntfy_publish() {
       *) exit 0 ;;
     esac
     [ -n "$topic" ] || exit 0
-    # markdown:true renders the body as Markdown in the ntfy web app (the mobile
-    # apps currently show raw Markdown, still readable). tags carry the emoji.
-    payload="$(jq -n --arg topic "$topic" --arg title "$title" \
-      --arg message "$message" --arg emoji "$emoji" \
-      --argjson priority "$priority" \
-      '{topic: $topic, title: $title, message: $message, priority: $priority,
-        markdown: true, tags: [$emoji, "morning-radar"]}')" || exit 0
+    # click (when present) opens the rendered brief page on the tailnet; omit it
+    # when unavailable so a broken link is never sent (graceful degradation).
+    if [ -n "$click" ]; then
+      payload="$(jq -n --arg topic "$topic" --arg title "$title" \
+        --arg message "$message" --arg emoji "$emoji" --arg click "$click" \
+        --argjson priority "$priority" \
+        '{topic: $topic, title: $title, message: $message, priority: $priority,
+          click: $click, tags: [$emoji, "morning-radar"]}')" || exit 0
+    else
+      payload="$(jq -n --arg topic "$topic" --arg title "$title" \
+        --arg message "$message" --arg emoji "$emoji" \
+        --argjson priority "$priority" \
+        '{topic: $topic, title: $title, message: $message, priority: $priority,
+          tags: [$emoji, "morning-radar"]}')" || exit 0
+    fi
     curl_cfg="$(mktemp "${TMPDIR:-/tmp}/morning-radar-ntfy.XXXXXX")" || exit 0
     # EXIT alone misses signal deaths (the watchdog may kill us); cover the
     # catchable signals so the token file never lingers.
@@ -112,9 +120,52 @@ ntfy_publish() {
   ) || true
 }
 
-# Error notification helper: high-priority attention topic, no brief body.
+# Error notification helper: high-priority attention topic, no link.
 notify_error() {
   ntfy_publish attention 5 "Morning Radar" "$1"
+}
+
+# Render the brief markdown as a mobile-readable HTML page at $2. Prefer pandoc;
+# `-f markdown-raw_html` escapes any raw HTML in the brief (GitHub issue titles
+# etc. are untrusted) while keeping GFM pipe tables, so a `<script>` in brief
+# content cannot execute on the served page. On pandoc absence/failure, fall
+# back to a self-contained shell that shows the markdown verbatim in a wrapping
+# <pre>, HTML-escaping & < >. Returns non-zero if no page could be produced.
+render_brief_html() {
+  local md="$1" html="$2" title="$3"
+  [ -s "$md" ] || return 1
+  if command -v pandoc >/dev/null 2>&1 &&
+    pandoc -s -f markdown-raw_html -t html --metadata title="$title" \
+      --metadata lang=ja -o "$html" "$md" 2>>"$LOG_FILE"; then
+    return 0
+  fi
+  {
+    printf '<!doctype html><html lang="ja"><head><meta charset="utf-8">'
+    printf '<meta name="viewport" content="width=device-width, initial-scale=1">'
+    printf '<meta name="color-scheme" content="light dark">'
+    printf '<title>%s</title>' "$title"
+    printf '<style>body{margin:0;padding:1rem;font:16px/1.6 -apple-system,system-ui,sans-serif;color:#1a1a1a;background:#fff}@media(prefers-color-scheme:dark){body{color:#e6e6e6;background:#111}}pre{white-space:pre-wrap;word-wrap:break-word;margin:0}</style>'
+    printf '</head><body><pre>'
+    sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' "$md"
+    printf '</pre></body></html>'
+  } >"$html" 2>/dev/null || return 1
+  return 0
+}
+
+# Build the tailnet click URL for the given date, or empty when the brief base
+# URL was not provisioned (MagicDNS underivable). Sourced in a subshell so only
+# the (non-secret) base URL is read out — the token never enters this env.
+ntfy_brief_url() {
+  local today="$1" base
+  [ -f "$ENV_FILE" ] || return 0
+  [ -O "$ENV_FILE" ] || return 0
+  base="$(
+    # shellcheck source=/dev/null
+    . "$ENV_FILE" 2>/dev/null || true
+    printf '%s' "${NTFY_BRIEF_BASE_URL:-}"
+  )"
+  [ -n "$base" ] || return 0
+  printf '%s/%s.html' "$base" "$today"
 }
 
 main() {
@@ -248,11 +299,19 @@ EOF
   # day can be retried manually (the approved budget is one successful run/day).
   printf '%s\n' "$TODAY" >"$STATE_DIR/last-run"
 
-  # Deliver the brief as a Markdown ntfy message: HEADLINE is the notification
-  # title (preview), the full brief markdown is the body (rendered on open).
+  # Render the mobile page and build the tailnet click URL. If either is
+  # unavailable, the notification still carries the HEADLINE (no link).
   # publish is fail-open, so a delivery failure never affects the stamp above.
+  click=""
+  if render_brief_html "$BRIEF_FILE" "$BRIEF_DIR/$TODAY.html" "Morning brief — $TODAY"; then
+    click="$(ntfy_brief_url "$TODAY")"
+    [ -n "$click" ] || log "warn: brief base URL unavailable; notifying without a link"
+  else
+    log "warn: brief HTML render failed; notifying without a link"
+  fi
+
   log "done: $HEADLINE"
-  ntfy_publish brief 3 "$HEADLINE" "$(cat "$BRIEF_FILE")"
+  ntfy_publish brief 3 "Morning brief" "$HEADLINE" "$click"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/home/dot_claude/executable_morning-radar.sh
+++ b/home/dot_claude/executable_morning-radar.sh
@@ -1,21 +1,27 @@
 #!/bin/bash
-# Weekday-morning radar wrapper (kryota-dev/dotfiles#257).
+# Weekday-morning radar wrapper (kryota-dev/dotfiles#257, delivery #361).
 # Launched by the dev.kryota.morning-radar LaunchAgent on weekday mornings.
 # Runs /morning-brief headless (degraded mode) on the personal Claude Code
-# account, saves the brief to a dated file, and hands the result off as a
-# macOS notification. Detection + notify only: no downstream skill dispatch.
+# account, saves the brief to a dated file, renders a mobile-readable HTML view,
+# and hands the result off as an ntfy notification whose click opens the brief
+# page served on the tailnet (#361). Detection + notify only: no downstream
+# skill dispatch. All delivery stays tailnet-only — brief content never leaves
+# the tailnet (no Artifact/claude.ai path); the notification carries only the
+# 1-line HEADLINE plus the tailnet URL.
+#
+# Source-safe: side effects live in main(), guarded by the BASH_SOURCE check at
+# the end, so tests can source this file and exercise ntfy_publish /
+# render_brief_html without launching claude.
 set -euo pipefail
 
-# launchd provides a minimal environment; build PATH ourselves so the claude wrapper, the
-# mise-managed binaries, and gh resolve. ~/.local/launchers is first so `claude` hits the
-# per-account wrapper (#345); the mise shims dir follows so gh/jq resolve headless, the same
-# hand-built-PATH approach statusline.sh uses for its own headless launchd/hook context.
-export PATH="$HOME/.local/launchers:$HOME/.local/share/mise/shims:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-
 LABEL="dev.kryota.morning-radar"
-LOG_FILE="$HOME/Library/Logs/${LABEL}.log"
+LOG_FILE="${MORNING_RADAR_LOG_FILE:-$HOME/Library/Logs/${LABEL}.log}"
 STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/morning-radar"
 BRIEF_DIR="$HOME/dotfiles/.kryota-dev/morning-brief"
+# Publisher credentials + brief topic/base-URL, written 0600 by ~/.config/ntfy/
+# lib.sh (#337/#357/#361). Overridable for tests. Sourced only inside a subshell
+# so the token never enters this script's (or claude's) environment.
+ENV_FILE="${MORNING_RADAR_NTFY_ENV_FILE:-$HOME/.config/ntfy/notify-env}"
 TIMEOUT_SECONDS=600
 MAX_TURNS=50
 # Pinned model keeps the pre-approved weekday recurring cost predictable even
@@ -33,149 +39,266 @@ CLAUDE_MODEL="sonnet"
 # since Claude Code v2.1.210 the file permission checks match only Edit(path)
 # and Read(path), and one Edit rule covers every file-editing tool (Write and
 # NotebookEdit included). The Write(path) form it replaced was accepted but
-# never matched, so it granted nothing while warning at every startup.
-# Everything else (edits outside that dir, WebFetch/WebSearch, Agent, mcp
-# tools, other Bash commands) stays auto-denied in print mode.
+# never matched, so it granted nothing while warning at every startup. Note:
+# Artifact is deliberately NOT granted — brief delivery is tailnet-only (#361),
+# so the HTML view is rendered locally by this wrapper, not published to
+# claude.ai. Everything else (edits outside that dir, WebFetch/WebSearch, Agent,
+# mcp tools, other Bash commands) stays auto-denied in print mode.
 ALLOWED_TOOLS="Bash(gh search:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh api graphql:*),Bash(git log:*),Bash(git status:*),Bash(git diff:*),Bash(git show:*),Bash(git branch:*),Bash(ls:*),Bash(cat:*),Bash(date:*),Bash(jq:*),Bash(find:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Read,Glob,Grep,Skill(morning-brief),Skill(repo-radar),Skill(gmail-triage),Edit(~/dotfiles/.kryota-dev/morning-brief/**)"
 
-notify_user() {
-  # Argv-passing keeps claude-derived text out of the AppleScript source
-  # (no string interpolation -> no AppleScript injection). Notification
-  # failures never fail the run (same tolerance as clv2-session-notify.sh).
-  osascript \
-    -e 'on run argv' \
-    -e 'display notification (item 1 of argv) with title (item 2 of argv) sound name "Glass"' \
-    -e 'end run' \
-    -- "$1" "$2" >/dev/null 2>&1 || true
-}
-
 log() {
-  printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >>"$LOG_FILE"
+  printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >>"$LOG_FILE" 2>/dev/null || true
 }
 
-[ "$(uname)" = "Darwin" ] || exit 0
+# Publish an ntfy notification. Fail-open: a broken/absent ntfy provisioning is a
+# silent no-op and no failure ever aborts the run.
+#   ntfy_publish <kind> <priority> <message> [click]
+#   kind: brief -> NTFY_TOPIC_BRIEF (success)   attention -> NTFY_TOPIC_ATTENTION (errors)
+# The env file is sourced inside a subshell so NTFY_TOKEN never lands in this
+# script's environment (and thus never in the claude subprocess); the token
+# reaches curl only through a 0600 `curl -K` config file, never argv/stdout/
+# trace (mirrors home/dot_claude/executable_ntfy-notify.sh; bats asserts this).
+ntfy_publish() {
+  local kind="$1" priority="$2" message="$3" click="${4:-}"
+  [ -f "$ENV_FILE" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  # Sourcing is code execution: only accept a file we own (the lib-written file
+  # is 0600). Anything else fails open.
+  [ -O "$ENV_FILE" ] || return 0
+  (
+    umask 077
+    # shellcheck source=/dev/null
+    . "$ENV_FILE" 2>/dev/null || exit 0
+    { [ -n "${NTFY_URL:-}" ] && [ -n "${NTFY_TOKEN:-}" ]; } || exit 0
+    case "$kind" in
+      brief)
+        topic="${NTFY_TOPIC_BRIEF:-}"
+        emoji="newspaper"
+        ;;
+      attention)
+        topic="${NTFY_TOPIC_ATTENTION:-}"
+        emoji="rotating_light"
+        ;;
+      *) exit 0 ;;
+    esac
+    [ -n "$topic" ] || exit 0
+    if [ -n "$click" ]; then
+      payload="$(jq -n --arg topic "$topic" --arg title "Morning Radar" \
+        --arg message "$message" --arg emoji "$emoji" --arg click "$click" \
+        --argjson priority "$priority" \
+        '{topic: $topic, title: $title, message: $message, priority: $priority,
+          click: $click, tags: [$emoji, "morning-radar"]}')" || exit 0
+    else
+      payload="$(jq -n --arg topic "$topic" --arg title "Morning Radar" \
+        --arg message "$message" --arg emoji "$emoji" \
+        --argjson priority "$priority" \
+        '{topic: $topic, title: $title, message: $message, priority: $priority,
+          tags: [$emoji, "morning-radar"]}')" || exit 0
+    fi
+    umask 077
+    curl_cfg="$(mktemp "${TMPDIR:-/tmp}/morning-radar-ntfy.XXXXXX")" || exit 0
+    # EXIT alone misses signal deaths (the watchdog may kill us); cover the
+    # catchable signals so the token file never lingers.
+    trap 'rm -f "$curl_cfg"' EXIT INT TERM HUP
+    printf 'header = "Authorization: Bearer %s"\n' "$NTFY_TOKEN" >"$curl_cfg"
+    if ! printf '%s' "$payload" | curl -fs -K "$curl_cfg" --max-time 3 \
+      -o /dev/null -d @- "$NTFY_URL" 2>/dev/null; then
+      log "ntfy publish failed: kind=${kind} topic=${topic} url=${NTFY_URL}"
+    fi
+  ) || true
+}
 
-mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR" "$BRIEF_DIR"
+# Error notification helper: high-priority attention topic, no link.
+notify_error() {
+  ntfy_publish attention 5 "$1"
+}
 
-# Run claude with the dotfiles repo as cwd (project trust + local context);
-# direct invocations then behave identically to launchd's WorkingDirectory.
-cd "$HOME/dotfiles"
+# Render the brief markdown as a mobile-readable HTML page at $2. Prefer pandoc
+# (rich rendering; mise-pinned, on the launchd PATH); on absence or any failure,
+# fall back to a self-contained shell that shows the markdown verbatim in a
+# wrapping <pre>. HTML-escape & < > so brief content cannot inject markup.
+# Returns non-zero if no readable page could be produced (caller then degrades
+# to a headline-only notification).
+render_brief_html() {
+  local md="$1" html="$2" title="$3"
+  [ -s "$md" ] || return 1
+  if command -v pandoc >/dev/null 2>&1 &&
+    pandoc -s -f gfm -t html --metadata title="$title" -o "$html" "$md" 2>>"$LOG_FILE"; then
+    return 0
+  fi
+  {
+    printf '<!doctype html><html lang="ja"><head><meta charset="utf-8">'
+    printf '<meta name="viewport" content="width=device-width, initial-scale=1">'
+    printf '<title>%s</title>' "$title"
+    printf '<style>body{margin:0;padding:1rem;font:16px/1.6 -apple-system,system-ui,sans-serif;color:#1a1a1a;background:#fff}@media(prefers-color-scheme:dark){body{color:#e6e6e6;background:#111}}pre{white-space:pre-wrap;word-wrap:break-word;margin:0}</style>'
+    printf '</head><body><pre>'
+    sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' "$md"
+    printf '</pre></body></html>'
+  } >"$html" 2>/dev/null || return 1
+  return 0
+}
 
-# Rotate the log once it exceeds 1 MiB (daily appends stay small).
-if [ -f "$LOG_FILE" ] && [ "$(stat -f%z "$LOG_FILE")" -gt 1048576 ]; then
-  mv "$LOG_FILE" "${LOG_FILE}.old"
-fi
+# Build the tailnet click URL for the given date, or empty when the brief base
+# URL was not provisioned (MagicDNS underivable at provision time -> degrade).
+# Sourced in a subshell so only the (non-secret) base URL is read out.
+ntfy_brief_url() {
+  local today="$1" base
+  [ -f "$ENV_FILE" ] || return 0
+  [ -O "$ENV_FILE" ] || return 0
+  base="$(
+    # shellcheck source=/dev/null
+    . "$ENV_FILE" 2>/dev/null || true
+    printf '%s' "${NTFY_BRIEF_BASE_URL:-}"
+  )"
+  [ -n "$base" ] || return 0
+  printf '%s/%s.html' "$base" "$today"
+}
 
-# Same-day guard: launchd coalesces missed fires on wake, and kickstart can
-# re-fire manually; one billed run per day is the approved budget (#257).
-# --force bypasses for smoke tests and deliberate manual reruns.
-TODAY="$(date +%F)"
-if [ "${1:-}" != "--force" ] && [ -f "$STATE_DIR/last-run" ] &&
-  [ "$(cat "$STATE_DIR/last-run")" = "$TODAY" ]; then
-  log "skip: already ran today ($TODAY)"
-  exit 0
-fi
+main() {
+  # launchd provides a minimal environment; build PATH ourselves so the claude wrapper, the
+  # mise-managed binaries (pandoc/gh/jq), and curl resolve. ~/.local/launchers is first so
+  # `claude` hits the per-account wrapper (#345); the mise shims dir follows, the same
+  # hand-built-PATH approach statusline.sh uses for its own headless launchd/hook context.
+  export PATH="$HOME/.local/launchers:$HOME/.local/share/mise/shims:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
-if ! command -v claude >/dev/null 2>&1; then
-  log "error: claude not found on PATH"
-  notify_user "Morning radar failed: claude not found on PATH — log: $LOG_FILE" "Morning Radar"
-  exit 1
-fi
+  [ "$(uname)" = "Darwin" ] || exit 0
 
-BRIEF_FILE="$BRIEF_DIR/$TODAY.md"
-# Prompt is Japanese to match the skill-steering language policy (the brief
-# itself is a Japanese artifact). Output contract mirrors the 運用メモ section
-# of morning-brief SKILL.md — keep the two in sync.
-PROMPT=$(
-  cat <<EOF
+  mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR" "$BRIEF_DIR"
+
+  # Run claude with the dotfiles repo as cwd (project trust + local context);
+  # direct invocations then behave identically to launchd's WorkingDirectory.
+  cd "$HOME/dotfiles"
+
+  # Rotate the log once it exceeds 1 MiB (daily appends stay small).
+  if [ -f "$LOG_FILE" ] && [ "$(stat -f%z "$LOG_FILE")" -gt 1048576 ]; then
+    mv "$LOG_FILE" "${LOG_FILE}.old"
+  fi
+
+  # Same-day guard: launchd coalesces missed fires on wake, and kickstart can
+  # re-fire manually; one billed run per day is the approved budget (#257).
+  # --force bypasses for smoke tests and deliberate manual reruns.
+  TODAY="$(date +%F)"
+  if [ "${1:-}" != "--force" ] && [ -f "$STATE_DIR/last-run" ] &&
+    [ "$(cat "$STATE_DIR/last-run")" = "$TODAY" ]; then
+    log "skip: already ran today ($TODAY)"
+    exit 0
+  fi
+
+  if ! command -v claude >/dev/null 2>&1; then
+    log "error: claude not found on PATH"
+    notify_error "Morning radar failed: claude not found on PATH — log: $LOG_FILE"
+    exit 1
+  fi
+
+  BRIEF_FILE="$BRIEF_DIR/$TODAY.md"
+  # Prompt is Japanese to match the skill-steering language policy (the brief
+  # itself is a Japanese artifact). Output contract mirrors the 運用メモ section
+  # of morning-brief SKILL.md — keep the two in sync.
+  PROMPT=$(
+    cat <<EOF
 /morning-brief を headless の縮退モード前提で実行してください。
 - Gmail / Calendar の MCP コネクタが使えない場合は、該当セクションに「取得失敗（headless 実行）」と明記して続行する（SKILL.md の縮退挙動）。
 - --post は使わない。GitHub への書き込み・下流 skill（issue-fleet / renovate-sweep / review-fleet）の起動は一切しない。
 - ブリーフ全文を $BRIEF_FILE に Write で保存する。同日ファイルが既に存在する場合（--force 再実行時）も、Read してから全文を上書き保存する。
 - 最終応答は「HEADLINE: <P1 n件 / 要対応 m件 / 定点観測 k件>」形式の 1 行のみとする。
 EOF
-)
+  )
 
-STDOUT_FILE="$(mktemp -t morning-radar)"
-trap 'rm -f "$STDOUT_FILE"' EXIT
+  STDOUT_FILE="$(mktemp -t morning-radar)"
+  trap 'rm -f "$STDOUT_FILE"' EXIT
 
-CLAUDE_ARGS=(--model "$CLAUDE_MODEL" --max-turns "$MAX_TURNS")
-# Let the brief read other repos' session summaries under the ghq root.
-if [ -d "$HOME/ghq" ]; then
-  CLAUDE_ARGS+=(--add-dir "$HOME/ghq")
-fi
-# --allowedTools is variadic and would swallow a trailing positional prompt,
-# so it stays a single comma-joined value and the prompt binds to -p below.
-CLAUDE_ARGS+=(--allowedTools "$ALLOWED_TOOLS")
-
-log "start: claude -p /morning-brief (model=$CLAUDE_MODEL, max-turns=$MAX_TURNS)"
-
-# Launch through the claude wrapper (~/.local/launchers/claude, first on PATH above). It injects
-# the personal account's isolation env — CLAUDE_CONFIG_DIR/ECC_AGENT_DATA_HOME, the
-# CLV2_HOMUNCULUS_DIR that deliberately sits outside the config dir (Claude Code treats paths under
-# it as sensitive files that no headless session can approve a write to, #336), and the observer
-# knobs (clock gate off, turn ceiling 100 — the lazy-started PreToolUse observer inherits this env
-# for its whole lifetime). That injection used to be hand-copied here and could drift (#345); now
-# there is one source. Setting CLAUDE_CONFIG_DIR explicitly pins the personal account (the wrapper
-# keeps an explicit value via its fill-gaps rule). Exporting empty EXA/FIRECRAWL keys opts out of
-# web search — the wrapper's `+x` guard then skips sourcing the MCP-keys file — since the brief
-# does not need them and the MCP servers tolerate missing keys.
-CLAUDE_CONFIG_DIR="$HOME/.claude" \
-  EXA_API_KEY="" \
-  FIRECRAWL_API_KEY="" \
-  claude "${CLAUDE_ARGS[@]}" -p "$PROMPT" >"$STDOUT_FILE" 2>>"$LOG_FILE" &
-CLAUDE_PID=$!
-
-# Watchdog: TERM after TIMEOUT_SECONDS, KILL 10s later (runaway-billing
-# guard on top of --max-turns).
-(
-  sleep "$TIMEOUT_SECONDS"
-  if kill -0 "$CLAUDE_PID" 2>/dev/null; then
-    kill "$CLAUDE_PID" 2>/dev/null || true
-    sleep 10
-    kill -9 "$CLAUDE_PID" 2>/dev/null || true
+  CLAUDE_ARGS=(--model "$CLAUDE_MODEL" --max-turns "$MAX_TURNS")
+  # Let the brief read other repos' session summaries under the ghq root.
+  if [ -d "$HOME/ghq" ]; then
+    CLAUDE_ARGS+=(--add-dir "$HOME/ghq")
   fi
-) &
-WATCHDOG_PID=$!
+  # --allowedTools is variadic and would swallow a trailing positional prompt,
+  # so it stays a single comma-joined value and the prompt binds to -p below.
+  CLAUDE_ARGS+=(--allowedTools "$ALLOWED_TOOLS")
 
-STATUS=0
-wait "$CLAUDE_PID" || STATUS=$?
-kill "$WATCHDOG_PID" 2>/dev/null || true
+  log "start: claude -p /morning-brief (model=$CLAUDE_MODEL, max-turns=$MAX_TURNS)"
 
-cat "$STDOUT_FILE" >>"$LOG_FILE"
+  # Launch through the claude wrapper (~/.local/launchers/claude, first on PATH above). It injects
+  # the personal account's isolation env — CLAUDE_CONFIG_DIR/ECC_AGENT_DATA_HOME, the
+  # CLV2_HOMUNCULUS_DIR that deliberately sits outside the config dir (Claude Code treats paths under
+  # it as sensitive files that no headless session can approve a write to, #336), and the observer
+  # knobs (clock gate off, turn ceiling 100 — the lazy-started PreToolUse observer inherits this env
+  # for its whole lifetime). That injection used to be hand-copied here and could drift (#345); now
+  # there is one source. Setting CLAUDE_CONFIG_DIR explicitly pins the personal account (the wrapper
+  # keeps an explicit value via its fill-gaps rule). Exporting empty EXA/FIRECRAWL keys opts out of
+  # web search — the wrapper's `+x` guard then skips sourcing the MCP-keys file — since the brief
+  # does not need them and the MCP servers tolerate missing keys.
+  CLAUDE_CONFIG_DIR="$HOME/.claude" \
+    EXA_API_KEY="" \
+    FIRECRAWL_API_KEY="" \
+    claude "${CLAUDE_ARGS[@]}" -p "$PROMPT" >"$STDOUT_FILE" 2>>"$LOG_FILE" &
+  CLAUDE_PID=$!
 
-if [ "$STATUS" -ne 0 ]; then
-  # 143 = SIGTERM, 137 = SIGKILL: treat both as the watchdog timeout.
-  if [ "$STATUS" -eq 143 ] || [ "$STATUS" -eq 137 ]; then
-    log "error: claude timed out after ${TIMEOUT_SECONDS}s (exit $STATUS)"
-    notify_user "Morning radar timed out (${TIMEOUT_SECONDS}s) — log: $LOG_FILE" "Morning Radar"
+  # Watchdog: TERM after TIMEOUT_SECONDS, KILL 10s later (runaway-billing
+  # guard on top of --max-turns).
+  (
+    sleep "$TIMEOUT_SECONDS"
+    if kill -0 "$CLAUDE_PID" 2>/dev/null; then
+      kill "$CLAUDE_PID" 2>/dev/null || true
+      sleep 10
+      kill -9 "$CLAUDE_PID" 2>/dev/null || true
+    fi
+  ) &
+  WATCHDOG_PID=$!
+
+  STATUS=0
+  wait "$CLAUDE_PID" || STATUS=$?
+  kill "$WATCHDOG_PID" 2>/dev/null || true
+
+  cat "$STDOUT_FILE" >>"$LOG_FILE"
+
+  if [ "$STATUS" -ne 0 ]; then
+    # 143 = SIGTERM, 137 = SIGKILL: treat both as the watchdog timeout.
+    if [ "$STATUS" -eq 143 ] || [ "$STATUS" -eq 137 ]; then
+      log "error: claude timed out after ${TIMEOUT_SECONDS}s (exit $STATUS)"
+      notify_error "Morning radar timed out (${TIMEOUT_SECONDS}s) — log: $LOG_FILE"
+    else
+      log "error: claude exited $STATUS"
+      notify_error "Morning radar failed (exit $STATUS) — log: $LOG_FILE"
+    fi
+    exit 1
+  fi
+
+  # Trailing `|| true` keeps a missing HEADLINE line from aborting the script
+  # here: grep exits 1 on no match, which pipefail + set -e would turn into a
+  # script-level exit, skipping the fallback and the notification below.
+  HEADLINE="$(grep -E '^HEADLINE:' "$STDOUT_FILE" | tail -1 | sed 's/^HEADLINE:[[:space:]]*//' || true)"
+  if [ -z "$HEADLINE" ]; then
+    HEADLINE="brief generated (no headline)"
+  fi
+
+  # Verify the brief before stamping the day done: a missing/empty file means the
+  # run broke its output contract, so treat it as a failure (notify + exit 1) and
+  # leave the stamp absent so the day stays retryable.
+  if [ ! -s "$BRIEF_FILE" ]; then
+    log "error: brief file missing or empty at $BRIEF_FILE"
+    notify_error "Morning radar failed: brief file missing — log: $LOG_FILE"
+    exit 1
+  fi
+
+  # Written only on success: a failed run leaves the stamp absent so the same
+  # day can be retried manually (the approved budget is one successful run/day).
+  printf '%s\n' "$TODAY" >"$STATE_DIR/last-run"
+
+  # Render the mobile view and build the tailnet click URL. If either is
+  # unavailable, publish still carries the HEADLINE (graceful degradation).
+  click=""
+  if render_brief_html "$BRIEF_FILE" "$BRIEF_DIR/$TODAY.html" "Morning brief — $TODAY"; then
+    click="$(ntfy_brief_url "$TODAY")"
   else
-    log "error: claude exited $STATUS"
-    notify_user "Morning radar failed (exit $STATUS) — log: $LOG_FILE" "Morning Radar"
+    log "warn: brief HTML render failed; notifying without a link"
   fi
-  exit 1
+
+  log "done: $HEADLINE"
+  ntfy_publish brief 3 "$HEADLINE" "$click"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi
-
-# Trailing `|| true` keeps a missing HEADLINE line from aborting the script
-# here: grep exits 1 on no match, which pipefail + set -e would turn into a
-# script-level exit, skipping the fallback and the notification below.
-HEADLINE="$(grep -E '^HEADLINE:' "$STDOUT_FILE" | tail -1 | sed 's/^HEADLINE:[[:space:]]*//' || true)"
-if [ -z "$HEADLINE" ]; then
-  HEADLINE="brief generated (no headline)"
-fi
-
-# Verify the brief before stamping the day done: a missing/empty file means the
-# run broke its output contract, so treat it as a failure (notify + exit 1) and
-# leave the stamp absent so the day stays retryable.
-if [ ! -s "$BRIEF_FILE" ]; then
-  log "error: brief file missing or empty at $BRIEF_FILE"
-  notify_user "Morning radar failed: brief file missing — log: $LOG_FILE" "Morning Radar"
-  exit 1
-fi
-
-# Written only on success: a failed run leaves the stamp absent so the same
-# day can be retried manually (the approved budget is one successful run/day).
-printf '%s\n' "$TODAY" >"$STATE_DIR/last-run"
-
-log "done: $HEADLINE"
-notify_user "$HEADLINE — $BRIEF_FILE" "Morning Radar"

--- a/home/dot_claude/executable_morning-radar.sh
+++ b/home/dot_claude/executable_morning-radar.sh
@@ -2,27 +2,30 @@
 # Weekday-morning radar wrapper (kryota-dev/dotfiles#257, delivery #361).
 # Launched by the dev.kryota.morning-radar LaunchAgent on weekday mornings.
 # Runs /morning-brief headless (degraded mode) on the personal Claude Code
-# account, saves the brief to a dated file, renders a mobile-readable HTML view,
-# and hands the result off as an ntfy notification whose click opens the brief
-# page served on the tailnet (#361). Detection + notify only: no downstream
-# skill dispatch. All delivery stays tailnet-only — brief content never leaves
-# the tailnet (no Artifact/claude.ai path); the notification carries only the
-# 1-line HEADLINE plus the tailnet URL.
+# account, saves the brief to a dated file, and delivers it as a Markdown ntfy
+# message (#361): the brief's full text is the message body (rendered as
+# Markdown in the ntfy web app; the mobile apps show it as raw-but-readable
+# Markdown for now), the HEADLINE is the notification title. Detection + notify
+# only: no downstream skill dispatch. Delivery is tailnet-only — the brief is
+# published to the self-hosted ntfy server (loopback), never to a third party
+# (no Artifact/claude.ai path).
 #
 # Source-safe: side effects live in main(), guarded by the BASH_SOURCE check at
-# the end, so tests can source this file and exercise ntfy_publish /
-# render_brief_html without launching claude.
+# the end, so tests can source this file and exercise ntfy_publish without
+# launching claude.
 set -euo pipefail
 
 LABEL="dev.kryota.morning-radar"
 LOG_FILE="${MORNING_RADAR_LOG_FILE:-$HOME/Library/Logs/${LABEL}.log}"
 STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/morning-radar"
 BRIEF_DIR="$HOME/dotfiles/.kryota-dev/morning-brief"
-# Publisher credentials + brief topic/base-URL, written 0600 by ~/.config/ntfy/
-# lib.sh (#337/#357/#361). Overridable for tests. Sourced only inside a subshell
-# so the token never enters this script's (or claude's) environment.
+# Publisher credentials + brief topic, written 0600 by ~/.config/ntfy/lib.sh
+# (#337/#357/#361). Overridable for tests. Sourced only inside a subshell so the
+# token never enters this script's (or claude's) environment.
 ENV_FILE="${MORNING_RADAR_NTFY_ENV_FILE:-$HOME/.config/ntfy/notify-env}"
-TIMEOUT_SECONDS=600
+# Overridable only so the bats main() integration tests can shorten the watchdog
+# (its backgrounded sleep would otherwise outlive the run); 600s in production.
+TIMEOUT_SECONDS="${MORNING_RADAR_TIMEOUT_SECONDS:-600}"
 MAX_TURNS=50
 # Pinned model keeps the pre-approved weekday recurring cost predictable even
 # when the account's default model changes.
@@ -41,31 +44,38 @@ CLAUDE_MODEL="sonnet"
 # NotebookEdit included). The Write(path) form it replaced was accepted but
 # never matched, so it granted nothing while warning at every startup. Note:
 # Artifact is deliberately NOT granted — brief delivery is tailnet-only (#361),
-# so the HTML view is rendered locally by this wrapper, not published to
-# claude.ai. Everything else (edits outside that dir, WebFetch/WebSearch, Agent,
-# mcp tools, other Bash commands) stays auto-denied in print mode.
+# so the brief is published to the self-hosted ntfy server, not to claude.ai.
+# Everything else (edits outside that dir, WebFetch/WebSearch, Agent, mcp
+# tools, other Bash commands) stays auto-denied in print mode.
 ALLOWED_TOOLS="Bash(gh search:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh api graphql:*),Bash(git log:*),Bash(git status:*),Bash(git diff:*),Bash(git show:*),Bash(git branch:*),Bash(ls:*),Bash(cat:*),Bash(date:*),Bash(jq:*),Bash(find:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Read,Glob,Grep,Skill(morning-brief),Skill(repo-radar),Skill(gmail-triage),Edit(~/dotfiles/.kryota-dev/morning-brief/**)"
 
 log() {
   printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >>"$LOG_FILE" 2>/dev/null || true
 }
 
-# Publish an ntfy notification. Fail-open: a broken/absent ntfy provisioning is a
-# silent no-op and no failure ever aborts the run.
-#   ntfy_publish <kind> <priority> <message> [click]
+# Publish a Markdown ntfy notification. Fail-open: a broken/absent ntfy
+# provisioning is a silent no-op and no failure ever aborts the run.
+#   ntfy_publish <kind> <priority> <title> <message>
 #   kind: brief -> NTFY_TOPIC_BRIEF (success)   attention -> NTFY_TOPIC_ATTENTION (errors)
 # The env file is sourced inside a subshell so NTFY_TOKEN never lands in this
 # script's environment (and thus never in the claude subprocess); the token
 # reaches curl only through a 0600 `curl -K` config file, never argv/stdout/
 # trace (mirrors home/dot_claude/executable_ntfy-notify.sh; bats asserts this).
+# The env file must be owner-only (0600/0400) — sourcing it is code execution,
+# so a group/other-accessible file fails open (same guard as ntfy-notify.sh).
 ntfy_publish() {
-  local kind="$1" priority="$2" message="$3" click="${4:-}"
+  local kind="$1" priority="$2" title="$3" message="$4"
+  local env_mode
   [ -f "$ENV_FILE" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
   command -v curl >/dev/null 2>&1 || return 0
-  # Sourcing is code execution: only accept a file we own (the lib-written file
-  # is 0600). Anything else fails open.
   [ -O "$ENV_FILE" ] || return 0
+  if stat --version >/dev/null 2>&1; then
+    env_mode="$(stat -c '%a' "$ENV_FILE" 2>/dev/null || true)"
+  else
+    env_mode="$(stat -f '%Lp' "$ENV_FILE" 2>/dev/null || true)"
+  fi
+  case "$env_mode" in 600 | 400) ;; *) return 0 ;; esac
   (
     umask 077
     # shellcheck source=/dev/null
@@ -83,83 +93,35 @@ ntfy_publish() {
       *) exit 0 ;;
     esac
     [ -n "$topic" ] || exit 0
-    if [ -n "$click" ]; then
-      payload="$(jq -n --arg topic "$topic" --arg title "Morning Radar" \
-        --arg message "$message" --arg emoji "$emoji" --arg click "$click" \
-        --argjson priority "$priority" \
-        '{topic: $topic, title: $title, message: $message, priority: $priority,
-          click: $click, tags: [$emoji, "morning-radar"]}')" || exit 0
-    else
-      payload="$(jq -n --arg topic "$topic" --arg title "Morning Radar" \
-        --arg message "$message" --arg emoji "$emoji" \
-        --argjson priority "$priority" \
-        '{topic: $topic, title: $title, message: $message, priority: $priority,
-          tags: [$emoji, "morning-radar"]}')" || exit 0
-    fi
-    umask 077
+    # markdown:true renders the body as Markdown in the ntfy web app (the mobile
+    # apps currently show raw Markdown, still readable). tags carry the emoji.
+    payload="$(jq -n --arg topic "$topic" --arg title "$title" \
+      --arg message "$message" --arg emoji "$emoji" \
+      --argjson priority "$priority" \
+      '{topic: $topic, title: $title, message: $message, priority: $priority,
+        markdown: true, tags: [$emoji, "morning-radar"]}')" || exit 0
     curl_cfg="$(mktemp "${TMPDIR:-/tmp}/morning-radar-ntfy.XXXXXX")" || exit 0
     # EXIT alone misses signal deaths (the watchdog may kill us); cover the
     # catchable signals so the token file never lingers.
     trap 'rm -f "$curl_cfg"' EXIT INT TERM HUP
     printf 'header = "Authorization: Bearer %s"\n' "$NTFY_TOKEN" >"$curl_cfg"
-    if ! printf '%s' "$payload" | curl -fs -K "$curl_cfg" --max-time 3 \
+    if ! printf '%s' "$payload" | curl -fs -K "$curl_cfg" --max-time 5 \
       -o /dev/null -d @- "$NTFY_URL" 2>/dev/null; then
       log "ntfy publish failed: kind=${kind} topic=${topic} url=${NTFY_URL}"
     fi
   ) || true
 }
 
-# Error notification helper: high-priority attention topic, no link.
+# Error notification helper: high-priority attention topic, no brief body.
 notify_error() {
-  ntfy_publish attention 5 "$1"
-}
-
-# Render the brief markdown as a mobile-readable HTML page at $2. Prefer pandoc
-# (rich rendering; mise-pinned, on the launchd PATH); on absence or any failure,
-# fall back to a self-contained shell that shows the markdown verbatim in a
-# wrapping <pre>. HTML-escape & < > so brief content cannot inject markup.
-# Returns non-zero if no readable page could be produced (caller then degrades
-# to a headline-only notification).
-render_brief_html() {
-  local md="$1" html="$2" title="$3"
-  [ -s "$md" ] || return 1
-  if command -v pandoc >/dev/null 2>&1 &&
-    pandoc -s -f gfm -t html --metadata title="$title" -o "$html" "$md" 2>>"$LOG_FILE"; then
-    return 0
-  fi
-  {
-    printf '<!doctype html><html lang="ja"><head><meta charset="utf-8">'
-    printf '<meta name="viewport" content="width=device-width, initial-scale=1">'
-    printf '<title>%s</title>' "$title"
-    printf '<style>body{margin:0;padding:1rem;font:16px/1.6 -apple-system,system-ui,sans-serif;color:#1a1a1a;background:#fff}@media(prefers-color-scheme:dark){body{color:#e6e6e6;background:#111}}pre{white-space:pre-wrap;word-wrap:break-word;margin:0}</style>'
-    printf '</head><body><pre>'
-    sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' "$md"
-    printf '</pre></body></html>'
-  } >"$html" 2>/dev/null || return 1
-  return 0
-}
-
-# Build the tailnet click URL for the given date, or empty when the brief base
-# URL was not provisioned (MagicDNS underivable at provision time -> degrade).
-# Sourced in a subshell so only the (non-secret) base URL is read out.
-ntfy_brief_url() {
-  local today="$1" base
-  [ -f "$ENV_FILE" ] || return 0
-  [ -O "$ENV_FILE" ] || return 0
-  base="$(
-    # shellcheck source=/dev/null
-    . "$ENV_FILE" 2>/dev/null || true
-    printf '%s' "${NTFY_BRIEF_BASE_URL:-}"
-  )"
-  [ -n "$base" ] || return 0
-  printf '%s/%s.html' "$base" "$today"
+  ntfy_publish attention 5 "Morning Radar" "$1"
 }
 
 main() {
   # launchd provides a minimal environment; build PATH ourselves so the claude wrapper, the
-  # mise-managed binaries (pandoc/gh/jq), and curl resolve. ~/.local/launchers is first so
-  # `claude` hits the per-account wrapper (#345); the mise shims dir follows, the same
-  # hand-built-PATH approach statusline.sh uses for its own headless launchd/hook context.
+  # mise-managed binaries (gh/jq), and curl resolve. ~/.local/launchers is first so `claude`
+  # hits the per-account wrapper (#345); the mise shims dir follows, the same hand-built-PATH
+  # approach statusline.sh uses for its own headless launchd/hook context.
   export PATH="$HOME/.local/launchers:$HOME/.local/share/mise/shims:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
   [ "$(uname)" = "Darwin" ] || exit 0
@@ -286,17 +248,11 @@ EOF
   # day can be retried manually (the approved budget is one successful run/day).
   printf '%s\n' "$TODAY" >"$STATE_DIR/last-run"
 
-  # Render the mobile view and build the tailnet click URL. If either is
-  # unavailable, publish still carries the HEADLINE (graceful degradation).
-  click=""
-  if render_brief_html "$BRIEF_FILE" "$BRIEF_DIR/$TODAY.html" "Morning brief — $TODAY"; then
-    click="$(ntfy_brief_url "$TODAY")"
-  else
-    log "warn: brief HTML render failed; notifying without a link"
-  fi
-
+  # Deliver the brief as a Markdown ntfy message: HEADLINE is the notification
+  # title (preview), the full brief markdown is the body (rendered on open).
+  # publish is fail-open, so a delivery failure never affects the stamp above.
   log "done: $HEADLINE"
-  ntfy_publish brief 3 "$HEADLINE" "$click"
+  ntfy_publish brief 3 "$HEADLINE" "$(cat "$BRIEF_FILE")"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/home/dot_claude/executable_ntfy-notify.sh
+++ b/home/dot_claude/executable_ntfy-notify.sh
@@ -181,6 +181,9 @@ main() {
     body="$(truncate_body "$(scrub_body "$body")")"
   fi
 
+  # markdown:true renders the body as Markdown in the ntfy web app (#361); the
+  # mobile apps still show raw text. Bodies here are short/plain, so this is a
+  # no-op for them and a nicety on the web.
   payload="$(jq -n \
     --arg topic "$topic" \
     --arg title "$title" \
@@ -192,7 +195,7 @@ main() {
     --arg sid "$sid" \
     --argjson priority "$priority" \
     '{topic: $topic, title: $title, message: $message, priority: $priority,
-      tags: [$emoji, $event, $repo, $account, $sid]}')"
+      markdown: true, tags: [$emoji, $event, $repo, $account, $sid]}')"
 
   # Token travels via a 0600 curl config file, never argv.
   umask 077

--- a/home/dot_config/ntfy/compose.yaml.tmpl
+++ b/home/dot_config/ntfy/compose.yaml.tmpl
@@ -42,3 +42,19 @@ services:
       # Runtime state (auth user.db, message cache.db) lives outside the
       # chezmoi target tree, same principle as the CLV2 homunculus move.
       - "{{ .chezmoi.homeDir }}/Library/Application Support/ntfy:/var/lib/ntfy"
+  brief-page:
+    # Static file server for the morning brief (kryota-dev/dotfiles#361). On
+    # macOS the standalone/App Tailscale variant can `tailscale serve` ports but
+    # NOT local files/directories, so the brief dir is served by this loopback
+    # nginx and fronted by `tailscale serve --https=8443` (a PORT proxy, which
+    # does work on macOS). Read-only mount; loopback-only (never all interfaces).
+    # Image tag pinned literally for the Renovate regex manager, same as ntfy.
+    image: nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:{{ .ntfy.brief_port }}:80"
+    volumes:
+      # The dated <YYYY-MM-DD>.html pages morning-radar renders. Read-only: the
+      # server never writes. nginx serves files by name; autoindex is off by
+      # default, so `/` is 403 and only the exact brief URL resolves.
+      - "{{ .chezmoi.homeDir }}/dotfiles/.kryota-dev/morning-brief:/usr/share/nginx/html:ro"

--- a/home/dot_config/ntfy/lib.sh.tmpl
+++ b/home/dot_config/ntfy/lib.sh.tmpl
@@ -38,6 +38,15 @@ ntfy_sub_user="subscriber"
 # Placeholder marker the 1Password bootstrap password carries until provisioned.
 ntfy_placeholder="REPLACE_ME"
 
+# Morning-brief page (kryota-dev/dotfiles#361). A loopback nginx sidecar (the
+# brief-page service in compose.yaml) serves the brief dir on ntfy_brief_port,
+# fronted on the tailnet by `tailscale serve --https` on ntfy_brief_serve_https.
+# macOS Tailscale can proxy ports but not serve files directly, so this is a
+# PORT proxy (which works) rather than a directory serve. Tailnet-only: never
+# funnel. A dedicated HTTPS port keeps it independent of the ntfy root (443).
+ntfy_brief_port="{{ .ntfy.brief_port }}"
+ntfy_brief_serve_https="8443"
+
 ntfy_log() { echo "[ntfy] $*"; }
 ntfy_warn() { echo "[ntfy] $*" >&2; }
 
@@ -134,6 +143,20 @@ ntfy_assert_serve() {
   "$b" serve --bg "${ntfy_serve_target:-}"
 }
 
+# Front the brief static-file sidecar on the tailnet (#361). This is a PORT
+# proxy on a dedicated HTTPS port (macOS cannot serve files/directories), so it
+# is independent of the ntfy root mount on 443 and neither clobbers the other.
+# NEVER funnel (tailnet-only).
+ntfy_assert_brief_serve() {
+  local b
+  b="$(ntfy_tailscale_bin)"
+  [ -n "$b" ] || {
+    ntfy_warn "tailscale CLI not found; cannot assert the brief serve front."
+    return 1
+  }
+  "$b" serve --bg --https "${ntfy_brief_serve_https:-}" "http://127.0.0.1:${ntfy_brief_port:-}"
+}
+
 ntfy_exec() {
   docker compose -f "$ntfy_compose_cfg" exec -T ntfy ntfy "$@"
 }
@@ -208,6 +231,13 @@ ntfy_issue_token() {
 # Write notify-env 0600 via umask; the token reaches the file only through the
 # heredoc (never echoed or traced). Reuses the exact format the wrapper sources.
 ntfy_write_notify_env() {
+  # Derive the tailnet base URL for the brief page (#361): MagicDNS host + the
+  # dedicated serve port. Empty when MagicDNS is not derivable at provision time,
+  # in which case morning-radar degrades to a link-less notification. Non-secret.
+  local brief_base dns
+  dns="$(ntfy_magicdns || true)"
+  brief_base=""
+  [ -n "$dns" ] && brief_base="https://${dns}:${ntfy_brief_serve_https:-}"
   (
     umask 077
     cat >"$ntfy_env_file" <<EOF
@@ -223,6 +253,10 @@ NTFY_TOKEN='$1'
 NTFY_TOPIC_ATTENTION='${ntfy_topic_attention}'
 NTFY_TOPIC_DONE='${ntfy_topic_done}'
 NTFY_TOPIC_BRIEF='${ntfy_topic_brief}'
+# Tailnet base URL for the brief page (#361); the wrapper appends /<date>.html.
+# Empty when MagicDNS was not derivable at provision time (wrapper then notifies
+# without a link).
+NTFY_BRIEF_BASE_URL='${brief_base}'
 EOF
   )
 }

--- a/home/dot_config/ntfy/lib.sh.tmpl
+++ b/home/dot_config/ntfy/lib.sh.tmpl
@@ -38,15 +38,6 @@ ntfy_sub_user="subscriber"
 # Placeholder marker the 1Password bootstrap password carries until provisioned.
 ntfy_placeholder="REPLACE_ME"
 
-# Morning-brief delivery (kryota-dev/dotfiles#361). The brief dir is fronted on
-# the tailnet by a second `tailscale serve` mount at ntfy_brief_serve_path, so
-# the morning-radar notification's click can open the day's page. The path is
-# duplicated in home/dot_claude/executable_morning-radar.sh (which only READS the
-# resulting URL from notify-env) — keep the two in sync. Tailnet-only: never
-# funnel (same boundary as the ntfy front).
-ntfy_brief_dir="$HOME/dotfiles/.kryota-dev/morning-brief"
-ntfy_brief_serve_path="/brief"
-
 ntfy_log() { echo "[ntfy] $*"; }
 ntfy_warn() { echo "[ntfy] $*" >&2; }
 
@@ -143,22 +134,6 @@ ntfy_assert_serve() {
   "$b" serve --bg "${ntfy_serve_target:-}"
 }
 
-# Assert the tailnet static front for the morning brief (#361). A second serve
-# mount at ntfy_brief_serve_path serves the brief dir directly; tailscale serve
-# handlers are additive and independent per (port, path), so this coexists with
-# the root ntfy proxy asserted above and neither re-assert clobbers the other.
-# Serving a directory needs it to exist first. NEVER funnel (tailnet-only).
-ntfy_assert_brief_serve() {
-  local b
-  b="$(ntfy_tailscale_bin)"
-  [ -n "$b" ] || {
-    ntfy_warn "tailscale CLI not found; cannot assert the brief serve mount."
-    return 1
-  }
-  mkdir -p "${ntfy_brief_dir:-}" 2>/dev/null || true
-  "$b" serve --bg --set-path "${ntfy_brief_serve_path:-}" "${ntfy_brief_dir:-}"
-}
-
 ntfy_exec() {
   docker compose -f "$ntfy_compose_cfg" exec -T ntfy ntfy "$@"
 }
@@ -233,13 +208,6 @@ ntfy_issue_token() {
 # Write notify-env 0600 via umask; the token reaches the file only through the
 # heredoc (never echoed or traced). Reuses the exact format the wrapper sources.
 ntfy_write_notify_env() {
-  # Derive the tailnet base URL for the brief page (#361). Empty when MagicDNS is
-  # not derivable at provision time — morning-radar then degrades to a headline-
-  # only notification (no click). This is human-facing, not a secret.
-  local brief_base dns
-  dns="$(ntfy_magicdns || true)"
-  brief_base=""
-  [ -n "$dns" ] && brief_base="https://${dns}${ntfy_brief_serve_path:-}"
   (
     umask 077
     cat >"$ntfy_env_file" <<EOF
@@ -255,10 +223,6 @@ NTFY_TOKEN='$1'
 NTFY_TOPIC_ATTENTION='${ntfy_topic_attention}'
 NTFY_TOPIC_DONE='${ntfy_topic_done}'
 NTFY_TOPIC_BRIEF='${ntfy_topic_brief}'
-# Tailnet base URL for the morning-brief page (#361). The click URL the
-# morning-radar wrapper publishes is this value + /<date>.html. Empty when
-# MagicDNS was not derivable at provision time (wrapper degrades to headline-only).
-NTFY_BRIEF_BASE_URL='${brief_base}'
 EOF
   )
 }
@@ -319,6 +283,12 @@ ntfy_provision_publisher() {
   # pre-check). This mirrors the subscriber self-heal and makes "delete user.db,
   # run ntfy-setup" actually restore the publisher too.
   if [ "${ntfy_user_created:-0}" = 0 ] && ntfy_notify_env_has_token; then
+    # Existing publisher: do NOT reissue the token, but still rewrite notify-env
+    # so schema additions (e.g. NTFY_TOPIC_BRIEF, #361) reach upgrades that
+    # already have a token. Reuse the current token; no server round-trip.
+    local existing
+    existing="$(ntfy_read_notify_env_token || true)"
+    [ -n "$existing" ] && ntfy_write_notify_env "$existing"
     return 0
   fi
   local tok

--- a/home/dot_config/ntfy/lib.sh.tmpl
+++ b/home/dot_config/ntfy/lib.sh.tmpl
@@ -21,6 +21,7 @@
 ntfy_port="{{ .ntfy.port }}"
 ntfy_topic_attention="{{ .ntfy.topic_attention }}"
 ntfy_topic_done="{{ .ntfy.topic_done }}"
+ntfy_topic_brief="{{ .ntfy.topic_brief }}"
 
 ntfy_compose_cfg="$HOME/.config/ntfy/compose.yaml"
 ntfy_env_file="$HOME/.config/ntfy/notify-env"
@@ -36,6 +37,15 @@ ntfy_pub_user="publisher"
 ntfy_sub_user="subscriber"
 # Placeholder marker the 1Password bootstrap password carries until provisioned.
 ntfy_placeholder="REPLACE_ME"
+
+# Morning-brief delivery (kryota-dev/dotfiles#361). The brief dir is fronted on
+# the tailnet by a second `tailscale serve` mount at ntfy_brief_serve_path, so
+# the morning-radar notification's click can open the day's page. The path is
+# duplicated in home/dot_claude/executable_morning-radar.sh (which only READS the
+# resulting URL from notify-env) — keep the two in sync. Tailnet-only: never
+# funnel (same boundary as the ntfy front).
+ntfy_brief_dir="$HOME/dotfiles/.kryota-dev/morning-brief"
+ntfy_brief_serve_path="/brief"
 
 ntfy_log() { echo "[ntfy] $*"; }
 ntfy_warn() { echo "[ntfy] $*" >&2; }
@@ -133,6 +143,22 @@ ntfy_assert_serve() {
   "$b" serve --bg "${ntfy_serve_target:-}"
 }
 
+# Assert the tailnet static front for the morning brief (#361). A second serve
+# mount at ntfy_brief_serve_path serves the brief dir directly; tailscale serve
+# handlers are additive and independent per (port, path), so this coexists with
+# the root ntfy proxy asserted above and neither re-assert clobbers the other.
+# Serving a directory needs it to exist first. NEVER funnel (tailnet-only).
+ntfy_assert_brief_serve() {
+  local b
+  b="$(ntfy_tailscale_bin)"
+  [ -n "$b" ] || {
+    ntfy_warn "tailscale CLI not found; cannot assert the brief serve mount."
+    return 1
+  }
+  mkdir -p "${ntfy_brief_dir:-}" 2>/dev/null || true
+  "$b" serve --bg --set-path "${ntfy_brief_serve_path:-}" "${ntfy_brief_dir:-}"
+}
+
 ntfy_exec() {
   docker compose -f "$ntfy_compose_cfg" exec -T ntfy ntfy "$@"
 }
@@ -193,7 +219,7 @@ ntfy_ensure_user_with_password() {
 # smoke-test topic.
 ntfy_grant_acl() {
   local u="$1" perm="$2" t
-  for t in "${ntfy_topic_attention:-}" "${ntfy_topic_done:-}" "$ntfy_smoke_topic"; do
+  for t in "${ntfy_topic_attention:-}" "${ntfy_topic_done:-}" "${ntfy_topic_brief:-}" "$ntfy_smoke_topic"; do
     ntfy_exec access "$u" "$t" "$perm" >/dev/null 2>&1 || true
   done
 }
@@ -207,6 +233,13 @@ ntfy_issue_token() {
 # Write notify-env 0600 via umask; the token reaches the file only through the
 # heredoc (never echoed or traced). Reuses the exact format the wrapper sources.
 ntfy_write_notify_env() {
+  # Derive the tailnet base URL for the brief page (#361). Empty when MagicDNS is
+  # not derivable at provision time — morning-radar then degrades to a headline-
+  # only notification (no click). This is human-facing, not a secret.
+  local brief_base dns
+  dns="$(ntfy_magicdns || true)"
+  brief_base=""
+  [ -n "$dns" ] && brief_base="https://${dns}${ntfy_brief_serve_path:-}"
   (
     umask 077
     cat >"$ntfy_env_file" <<EOF
@@ -221,6 +254,11 @@ NTFY_URL='${ntfy_serve_target}'
 NTFY_TOKEN='$1'
 NTFY_TOPIC_ATTENTION='${ntfy_topic_attention}'
 NTFY_TOPIC_DONE='${ntfy_topic_done}'
+NTFY_TOPIC_BRIEF='${ntfy_topic_brief}'
+# Tailnet base URL for the morning-brief page (#361). The click URL the
+# morning-radar wrapper publishes is this value + /<date>.html. Empty when
+# MagicDNS was not derivable at provision time (wrapper degrades to headline-only).
+NTFY_BRIEF_BASE_URL='${brief_base}'
 EOF
   )
 }

--- a/home/dot_config/ntfy/private_server.yml.tmpl
+++ b/home/dot_config/ntfy/private_server.yml.tmpl
@@ -33,6 +33,13 @@ listen-http: ":80"
 cache-file: /var/lib/ntfy/cache.db
 cache-duration: "{{ .ntfy.cache_duration }}"
 
+# Raise the per-message size ceiling above ntfy's 4 KB default (#361): the
+# morning brief is delivered as a single Markdown message body, and a message
+# over the limit is silently converted to a downloadable attachment (which the
+# apps do not render inline). 32 KB comfortably fits a brief while staying well
+# under ntfy's 512 KB hard maximum.
+message-size-limit: 32768
+
 # Auth: private instance, deny-all by default. Users/tokens are provisioned
 # automatically by ~/.config/ntfy/lib.sh (run_onchange_after_31-setup-ntfy at
 # apply time, or `ntfy-setup` on demand — see docs/architecture/notifications.md);

--- a/home/dot_config/ntfy/private_server.yml.tmpl
+++ b/home/dot_config/ntfy/private_server.yml.tmpl
@@ -33,13 +33,6 @@ listen-http: ":80"
 cache-file: /var/lib/ntfy/cache.db
 cache-duration: "{{ .ntfy.cache_duration }}"
 
-# Raise the per-message size ceiling above ntfy's 4 KB default (#361): the
-# morning brief is delivered as a single Markdown message body, and a message
-# over the limit is silently converted to a downloadable attachment (which the
-# apps do not render inline). 32 KB comfortably fits a brief while staying well
-# under ntfy's 512 KB hard maximum.
-message-size-limit: 32768
-
 # Auth: private instance, deny-all by default. Users/tokens are provisioned
 # automatically by ~/.config/ntfy/lib.sh (run_onchange_after_31-setup-ntfy at
 # apply time, or `ntfy-setup` on demand — see docs/architecture/notifications.md);

--- a/home/dot_local/bin/executable_ntfy-setup
+++ b/home/dot_local/bin/executable_ntfy-setup
@@ -81,11 +81,6 @@ if ! ntfy_assert_serve; then
   echo "ntfy-setup: 'tailscale serve' failed (is tailscaled healthy?)." >&2
   exit "$EXIT_ERR"
 fi
-# Auxiliary morning-brief mount (#361). Non-fatal: a missing mount only drops the
-# brief notification's link, so it must not fail the core ntfy setup.
-if ! ntfy_assert_brief_serve; then
-  echo "ntfy-setup: brief serve mount failed; the morning brief will notify without a link." >&2
-fi
 ntfy_wait_ready || echo "ntfy-setup: ntfy container is slow to become ready; continuing." >&2
 
 if [ -n "$rotate" ]; then

--- a/home/dot_local/bin/executable_ntfy-setup
+++ b/home/dot_local/bin/executable_ntfy-setup
@@ -81,6 +81,11 @@ if ! ntfy_assert_serve; then
   echo "ntfy-setup: 'tailscale serve' failed (is tailscaled healthy?)." >&2
   exit "$EXIT_ERR"
 fi
+# Auxiliary morning-brief mount (#361). Non-fatal: a missing mount only drops the
+# brief notification's link, so it must not fail the core ntfy setup.
+if ! ntfy_assert_brief_serve; then
+  echo "ntfy-setup: brief serve mount failed; the morning brief will notify without a link." >&2
+fi
 ntfy_wait_ready || echo "ntfy-setup: ntfy container is slow to become ready; continuing." >&2
 
 if [ -n "$rotate" ]; then

--- a/home/dot_local/bin/executable_ntfy-setup
+++ b/home/dot_local/bin/executable_ntfy-setup
@@ -81,6 +81,11 @@ if ! ntfy_assert_serve; then
   echo "ntfy-setup: 'tailscale serve' failed (is tailscaled healthy?)." >&2
   exit "$EXIT_ERR"
 fi
+# Front the morning-brief page sidecar (#361). Non-fatal: a missing front only
+# drops the brief notification's link, so it must not fail the core ntfy setup.
+if ! ntfy_assert_brief_serve; then
+  echo "ntfy-setup: brief serve front failed; the morning brief will notify without a link." >&2
+fi
 ntfy_wait_ready || echo "ntfy-setup: ntfy container is slow to become ready; continuing." >&2
 
 if [ -n "$rotate" ]; then

--- a/home/run_onchange_after_31-setup-ntfy.sh.tmpl
+++ b/home/run_onchange_after_31-setup-ntfy.sh.tmpl
@@ -49,12 +49,6 @@ if ! ntfy_assert_serve; then
 fi
 echo "[ntfy] ntfy server up at ${ntfy_serve_target:-} behind tailscale serve."
 
-# Assert the morning-brief static mount (#361). Non-fatal: a missing mount only
-# drops the notification's link (headline-only fallback), so it never blocks apply.
-if ! ntfy_assert_brief_serve; then
-  echo "[ntfy] brief serve mount failed; the morning brief will notify without a link." >&2
-fi
-
 # Provision publisher (token -> notify-env) and subscriber (username/password ->
 # 1Password). Every failure inside is warn-and-continue; recovery is ntfy-setup.
 ntfy_provision || echo "[ntfy] provisioning incomplete; recover with: ntfy-setup" >&2

--- a/home/run_onchange_after_31-setup-ntfy.sh.tmpl
+++ b/home/run_onchange_after_31-setup-ntfy.sh.tmpl
@@ -49,6 +49,12 @@ if ! ntfy_assert_serve; then
 fi
 echo "[ntfy] ntfy server up at ${ntfy_serve_target:-} behind tailscale serve."
 
+# Front the morning-brief page sidecar (#361). Non-fatal: a missing front only
+# drops the notification's link (link-less fallback), so it never blocks apply.
+if ! ntfy_assert_brief_serve; then
+  echo "[ntfy] brief serve front failed; the morning brief will notify without a link." >&2
+fi
+
 # Provision publisher (token -> notify-env) and subscriber (username/password ->
 # 1Password). Every failure inside is warn-and-continue; recovery is ntfy-setup.
 ntfy_provision || echo "[ntfy] provisioning incomplete; recover with: ntfy-setup" >&2

--- a/home/run_onchange_after_31-setup-ntfy.sh.tmpl
+++ b/home/run_onchange_after_31-setup-ntfy.sh.tmpl
@@ -49,6 +49,12 @@ if ! ntfy_assert_serve; then
 fi
 echo "[ntfy] ntfy server up at ${ntfy_serve_target:-} behind tailscale serve."
 
+# Assert the morning-brief static mount (#361). Non-fatal: a missing mount only
+# drops the notification's link (headline-only fallback), so it never blocks apply.
+if ! ntfy_assert_brief_serve; then
+  echo "[ntfy] brief serve mount failed; the morning brief will notify without a link." >&2
+fi
+
 # Provision publisher (token -> notify-env) and subscriber (username/password ->
 # 1Password). Every failure inside is warn-and-continue; recovery is ntfy-setup.
 ntfy_provision || echo "[ntfy] provisioning incomplete; recover with: ntfy-setup" >&2

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -165,8 +165,13 @@ load helpers/setup
   grep -q -- '--model' "$wrapper"
   # Personal-account isolation must stay explicit (R2.1).
   grep -q 'CLAUDE_CONFIG_DIR' "$wrapper"
-  # AppleScript injection guard: notification text passes via argv (R3.3).
-  grep -q 'on run argv' "$wrapper"
+  # Delivery migrated osascript -> ntfy (#361): no osascript path may remain
+  # (AC-002), and the publisher token must never reach curl argv (AC-006; it
+  # travels via a `curl -K` config file, as ntfy-notify.sh does).
+  run grep -qE 'osascript|display notification' "$wrapper"
+  [ "$status" -ne 0 ]
+  run grep -E -- '(-H|--header)["'"'"'[:space:]]*"?Authorization' "$wrapper"
+  [ "$status" -ne 0 ]
 }
 
 @test "morning-radar delegates account env to the claude wrapper instead of hand-copying it (#336, #345)" {
@@ -1999,6 +2004,27 @@ _gate_decision() {
   # (ntfy_user_created), not a fragile pre-check.
   grep -qF 'already exists' "$l"
   grep -qF 'ntfy_user_created' "$l"
+}
+
+@test "ntfy library provisions the morning-brief tailnet mount and URL (#361)" {
+  local l="${HOME_DIR}/dot_config/ntfy/lib.sh.tmpl"
+  # Dedicated brief topic is SSOT-declared and threaded into the library.
+  grep -qF 'topic_brief = "claude-brief"' "${HOME_DIR}/.chezmoidata.toml"
+  grep -qF '{{ .ntfy.topic_brief }}' "$l"
+  # A second serve mount fronts the brief dir on the tailnet via --set-path; it
+  # must be tailnet-only (never funnel, already asserted globally) and additive
+  # to the root ntfy mount.
+  grep -qF 'ntfy_assert_brief_serve' "$l"
+  grep -qF 'serve --bg --set-path' "$l"
+  # notify-env carries the brief topic + the (non-secret) tailnet base URL the
+  # morning-radar wrapper reads to build the click link.
+  grep -qF 'NTFY_TOPIC_BRIEF' "$l"
+  grep -qF 'NTFY_BRIEF_BASE_URL' "$l"
+  # Publisher gets write access to the brief topic through the shared ACL grant.
+  grep -qF 'ntfy_topic_brief' "$l"
+  # Both setup entry points assert the mount so it self-heals on apply / ntfy-setup.
+  grep -qF 'ntfy_assert_brief_serve' "${HOME_DIR}/run_onchange_after_31-setup-ntfy.sh.tmpl"
+  grep -qF 'ntfy_assert_brief_serve' "${HOME_DIR}/dot_local/bin/executable_ntfy-setup"
 }
 
 @test "ntfy-setup: deploys under ~/.local/bin, sources the lib, prompts before rotating, rotates" {

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -2006,30 +2006,35 @@ _gate_decision() {
   grep -qF 'ntfy_user_created' "$l"
 }
 
-@test "ntfy library provisions the morning-brief Markdown delivery (#361)" {
+@test "ntfy provisions the morning-brief page delivery (#361)" {
   local l="${HOME_DIR}/dot_config/ntfy/lib.sh.tmpl"
-  # Dedicated brief topic is SSOT-declared and threaded into the library.
+  local c="${HOME_DIR}/dot_config/ntfy/compose.yaml.tmpl"
+  local r="${HOME_DIR}/dot_claude/executable_morning-radar.sh"
+  # Dedicated brief topic + sidecar port are SSOT-declared.
   grep -qF 'topic_brief = "claude-brief"' "${HOME_DIR}/.chezmoidata.toml"
+  grep -qF 'brief_port = ' "${HOME_DIR}/.chezmoidata.toml"
   grep -qF '{{ .ntfy.topic_brief }}' "$l"
-  # Publisher gets write access to the brief topic through the shared ACL grant,
-  # and notify-env carries the brief topic for the wrapper to publish to.
   grep -qF 'ntfy_topic_brief' "$l"
   grep -qF 'NTFY_TOPIC_BRIEF' "$l"
-  # Delivery is a Markdown ntfy MESSAGE, not a served page: there is no tailscale
-  # serve mount for the brief and no click base URL (that path was rejected after
-  # the macOS serve-directory limitation surfaced in review — see the PRD).
-  ! grep -qF 'ntfy_assert_brief_serve' "$l"
-  ! grep -qF 'NTFY_BRIEF_BASE_URL' "$l"
-  ! grep -qF 'set-path' "$l"
-  # Existing installs (publisher token already present) must still get the new
-  # notify-env keys without reissuing the token (migration on upgrade): the
-  # provisioner rewrites notify-env with the existing token on that path.
+  # Delivery is a rendered HTML page served by a loopback nginx sidecar fronted
+  # by a tailscale PORT proxy on a dedicated HTTPS port (macOS cannot serve
+  # files/directories directly). The click opens NTFY_BRIEF_BASE_URL/<date>.html.
+  grep -qE 'image: nginx:[0-9.]+-alpine@sha256:[a-f0-9]{64}' "$c"
+  grep -qF '127.0.0.1:{{ .ntfy.brief_port }}:80' "$c"
+  grep -qF 'ntfy_assert_brief_serve' "$l"
+  grep -qF 'serve --bg --https' "$l"
+  ! grep -qE '^[^#]*serve.*--set-path' "$l"
+  grep -qF 'NTFY_BRIEF_BASE_URL' "$l"
+  # Both setup entry points assert the front so it self-heals on apply/ntfy-setup.
+  grep -qF 'ntfy_assert_brief_serve' "${HOME_DIR}/run_onchange_after_31-setup-ntfy.sh.tmpl"
+  grep -qF 'ntfy_assert_brief_serve' "${HOME_DIR}/dot_local/bin/executable_ntfy-setup"
+  # Existing installs (token already present) still get the new notify-env keys
+  # without reissuing the token (migration on upgrade).
   grep -qF 'ntfy_write_notify_env "$existing"' "$l"
-  # The server raises the per-message size ceiling so a full brief is not
-  # silently converted to an attachment.
-  grep -qF 'message-size-limit' "${HOME_DIR}/dot_config/ntfy/private_server.yml.tmpl"
-  # Both publishers mark bodies as Markdown.
-  grep -qF 'markdown: true' "${HOME_DIR}/dot_claude/executable_morning-radar.sh"
+  # The brief page escapes raw HTML from untrusted brief content (pandoc
+  # markdown-raw_html; a <script> in a GitHub title must not execute on the page).
+  grep -qF 'markdown-raw_html' "$r"
+  # Existing hook-notification bodies render as Markdown in the web app (#361).
   grep -qF 'markdown: true' "${HOME_DIR}/dot_claude/executable_ntfy-notify.sh"
 }
 
@@ -2147,6 +2152,9 @@ _gate_decision() {
     <"${HOME_DIR}/run_onchange_after_31-setup-ntfy.sh.tmpl" >/dev/null
   chezmoi execute-template --source "${HOME_DIR}" \
     <"${HOME_DIR}/dot_config/ntfy/private_server.yml.tmpl" >/dev/null
+  # compose carries the brief_port template var (#361); render it too.
+  chezmoi execute-template --source "${HOME_DIR}" \
+    <"${HOME_DIR}/dot_config/ntfy/compose.yaml.tmpl" >/dev/null
 }
 
 @test "install.sh points at ntfy-setup on darwin only, and never provisions at bootstrap" {

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -2006,25 +2006,31 @@ _gate_decision() {
   grep -qF 'ntfy_user_created' "$l"
 }
 
-@test "ntfy library provisions the morning-brief tailnet mount and URL (#361)" {
+@test "ntfy library provisions the morning-brief Markdown delivery (#361)" {
   local l="${HOME_DIR}/dot_config/ntfy/lib.sh.tmpl"
   # Dedicated brief topic is SSOT-declared and threaded into the library.
   grep -qF 'topic_brief = "claude-brief"' "${HOME_DIR}/.chezmoidata.toml"
   grep -qF '{{ .ntfy.topic_brief }}' "$l"
-  # A second serve mount fronts the brief dir on the tailnet via --set-path; it
-  # must be tailnet-only (never funnel, already asserted globally) and additive
-  # to the root ntfy mount.
-  grep -qF 'ntfy_assert_brief_serve' "$l"
-  grep -qF 'serve --bg --set-path' "$l"
-  # notify-env carries the brief topic + the (non-secret) tailnet base URL the
-  # morning-radar wrapper reads to build the click link.
-  grep -qF 'NTFY_TOPIC_BRIEF' "$l"
-  grep -qF 'NTFY_BRIEF_BASE_URL' "$l"
-  # Publisher gets write access to the brief topic through the shared ACL grant.
+  # Publisher gets write access to the brief topic through the shared ACL grant,
+  # and notify-env carries the brief topic for the wrapper to publish to.
   grep -qF 'ntfy_topic_brief' "$l"
-  # Both setup entry points assert the mount so it self-heals on apply / ntfy-setup.
-  grep -qF 'ntfy_assert_brief_serve' "${HOME_DIR}/run_onchange_after_31-setup-ntfy.sh.tmpl"
-  grep -qF 'ntfy_assert_brief_serve' "${HOME_DIR}/dot_local/bin/executable_ntfy-setup"
+  grep -qF 'NTFY_TOPIC_BRIEF' "$l"
+  # Delivery is a Markdown ntfy MESSAGE, not a served page: there is no tailscale
+  # serve mount for the brief and no click base URL (that path was rejected after
+  # the macOS serve-directory limitation surfaced in review — see the PRD).
+  ! grep -qF 'ntfy_assert_brief_serve' "$l"
+  ! grep -qF 'NTFY_BRIEF_BASE_URL' "$l"
+  ! grep -qF 'set-path' "$l"
+  # Existing installs (publisher token already present) must still get the new
+  # notify-env keys without reissuing the token (migration on upgrade): the
+  # provisioner rewrites notify-env with the existing token on that path.
+  grep -qF 'ntfy_write_notify_env "$existing"' "$l"
+  # The server raises the per-message size ceiling so a full brief is not
+  # silently converted to an attachment.
+  grep -qF 'message-size-limit' "${HOME_DIR}/dot_config/ntfy/private_server.yml.tmpl"
+  # Both publishers mark bodies as Markdown.
+  grep -qF 'markdown: true' "${HOME_DIR}/dot_claude/executable_morning-radar.sh"
+  grep -qF 'markdown: true' "${HOME_DIR}/dot_claude/executable_ntfy-notify.sh"
 }
 
 @test "ntfy-setup: deploys under ~/.local/bin, sources the lib, prompts before rotating, rotates" {

--- a/tests/morning_radar.bats
+++ b/tests/morning_radar.bats
@@ -2,11 +2,11 @@
 
 # morning-radar wrapper (home/dot_claude/executable_morning-radar.sh, #257/#361).
 # The wrapper is source-safe (side effects live in main() behind a BASH_SOURCE
-# guard), so these tests source it and exercise the pure delivery functions
-# (ntfy_publish / render_brief_html / ntfy_brief_url) with curl stubbed out on
-# PATH — no network, no server, no claude, CI-safe. Covers the osascript->ntfy
-# migration (AC-002), fail-open delivery (AC-003), graceful degradation
-# (AC-004), topic/priority split (AC-005), and token hygiene (AC-006).
+# guard), so these tests both source it to exercise the pure ntfy_publish helper
+# and run it end-to-end with claude + curl stubbed on PATH — no network, no
+# server, CI-safe. Covers the osascript->ntfy migration (AC-002), fail-open
+# delivery (AC-003), topic/priority split (AC-005), token hygiene incl. the
+# permission-mode guard (AC-006), Markdown delivery, and the main() stamp wiring.
 
 load helpers/setup
 
@@ -30,7 +30,6 @@ NTFY_TOKEN='tk_bats_secret'
 NTFY_TOPIC_ATTENTION='claude-attention'
 NTFY_TOPIC_DONE='claude-done'
 NTFY_TOPIC_BRIEF='claude-brief'
-NTFY_BRIEF_BASE_URL='https://host.example.ts.net/brief'
 EOF
   # The wrapper refuses env files that are not owner-only (0600/0400).
   chmod 600 "$ENV_FILE"
@@ -60,41 +59,33 @@ run_fn() {
   ! grep -qE 'osascript|display notification' "$WRAPPER"
 }
 
-@test "token hygiene: no -H/--header Authorization, no set -x (AC-006)" {
+@test "token hygiene: no -H/--header Authorization, no set -x, token via -K (AC-006)" {
   ! grep -E -- '(-H|--header)["'"'"'[:space:]]*"?Authorization' "$WRAPPER"
   ! grep -qF 'set -x' "$WRAPPER"
-  # The token reaches curl only through a -K config file.
   grep -qF 'curl -fs -K' "$WRAPPER"
 }
 
-@test "ntfy_publish brief -> claude-brief topic with click URL (AC-001/005)" {
-  run_fn ntfy_publish brief 3 "HEADLINE: P1 2件" "https://host.example.ts.net/brief/2026-07-26.html"
+@test "ntfy_publish brief -> claude-brief topic, Markdown, title + body (AC-005)" {
+  run_fn ntfy_publish brief 3 "HEADLINE: P1 2件" "# Brief"$'\n'"- item"
   [ "$status" -eq 0 ]
   [ -f "${STUB_DIR}/curl_stdin" ]
   [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-brief" ]
-  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "HEADLINE: P1 2件" ]
-  [ "$(jq -r .click <"${STUB_DIR}/curl_stdin")" = "https://host.example.ts.net/brief/2026-07-26.html" ]
+  [ "$(jq -r .title <"${STUB_DIR}/curl_stdin")" = "HEADLINE: P1 2件" ]
   [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "3" ]
+  [ "$(jq -r .markdown <"${STUB_DIR}/curl_stdin")" = "true" ]
+  jq -e '.message | test("# Brief")' <"${STUB_DIR}/curl_stdin" >/dev/null
 }
 
-@test "ntfy_publish attention -> claude-attention topic, priority 5, no click (AC-005)" {
-  run_fn ntfy_publish attention 5 "Morning radar failed: claude not found"
+@test "ntfy_publish attention -> claude-attention topic, priority 5 (AC-005)" {
+  run_fn ntfy_publish attention 5 "Morning Radar" "claude not found"
   [ "$status" -eq 0 ]
   [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
   [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "5" ]
-  # No link on error notifications.
-  [ "$(jq -r 'has("click")' <"${STUB_DIR}/curl_stdin")" = "false" ]
-}
-
-@test "empty click degrades to a headline-only payload (AC-004)" {
-  run_fn ntfy_publish brief 3 "HEADLINE only" ""
-  [ "$status" -eq 0 ]
-  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "HEADLINE only" ]
-  [ "$(jq -r 'has("click")' <"${STUB_DIR}/curl_stdin")" = "false" ]
+  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "claude not found" ]
 }
 
 @test "token never reaches curl argv (travels via -K config file) (AC-006)" {
-  run_fn ntfy_publish brief 3 "HEADLINE" "https://host.example.ts.net/brief/x.html"
+  run_fn ntfy_publish brief 3 "HEADLINE" "body"
   [ "$status" -eq 0 ]
   [ -f "${STUB_DIR}/curl_args" ]
   ! grep -q 'tk_bats_secret' "${STUB_DIR}/curl_args"
@@ -103,56 +94,80 @@ run_fn() {
 
 @test "publish failure is fail-open: returns 0, token never logged (AC-003)" {
   NTFY_TEST_CURL_EXIT=1
-  run_fn ntfy_publish brief 3 "HEADLINE" "https://host.example.ts.net/brief/x.html"
+  run_fn ntfy_publish brief 3 "HEADLINE" "body"
   [ "$status" -eq 0 ]
   [ ! -f "$LOG_FILE" ] || ! grep -q 'tk_bats_secret' "$LOG_FILE"
 }
 
 @test "no env file -> silent no-op, no publish" {
   ENV_FILE="${BATS_TEST_TMPDIR}/does-not-exist"
-  run_fn ntfy_publish brief 3 "HEADLINE" "https://host/x.html"
+  run_fn ntfy_publish brief 3 "HEADLINE" "body"
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/curl_args" ]
+}
+
+@test "group/other-readable env file fails open without publishing (mode check, AC-006)" {
+  chmod 644 "$ENV_FILE"
+  run_fn ntfy_publish brief 3 "HEADLINE" "body"
   [ "$status" -eq 0 ]
   [ ! -f "${STUB_DIR}/curl_args" ]
 }
 
 @test "unknown kind is ignored without publishing" {
-  run_fn ntfy_publish bogus 3 "HEADLINE"
+  run_fn ntfy_publish bogus 3 "HEADLINE" "body"
   [ "$status" -eq 0 ]
   [ ! -f "${STUB_DIR}/curl_args" ]
 }
 
-@test "ntfy_brief_url builds the dated tailnet URL from the base URL" {
-  run_fn ntfy_brief_url 2026-07-26
-  [ "$status" -eq 0 ]
-  [ "$output" = "https://host.example.ts.net/brief/2026-07-26.html" ]
-}
+# --- main() integration (claude + curl stubbed under a sandbox HOME) ----------
+# main() rebuilds PATH with $HOME/.local/launchers first, so stubs placed there
+# win over the real claude/curl; the sandbox HOME also isolates the brief dir,
+# state dir, and env file.
 
-@test "ntfy_brief_url yields nothing when the base URL is unset (degradation)" {
-  cat >"$ENV_FILE" <<'EOF'
-NTFY_URL='http://127.0.0.1:9'
-NTFY_TOKEN='tk_bats_secret'
-NTFY_TOPIC_BRIEF='claude-brief'
-NTFY_BRIEF_BASE_URL=''
+@test "main(): success writes the last-run stamp and publishes the brief body (AC-003)" {
+  local home="${BATS_TEST_TMPDIR}/home-ok"
+  mkdir -p "${home}/.local/launchers" "${home}/.config/ntfy"
+  cat >"${home}/.local/launchers/claude" <<'EOF'
+#!/bin/bash
+d="$HOME/dotfiles/.kryota-dev/morning-brief"
+mkdir -p "$d"
+printf '# Morning Brief\n\n- P1: alpha issue\n' >"$d/$(date +%F).md"
+echo "HEADLINE: P1 1件"
 EOF
-  chmod 600 "$ENV_FILE"
-  run_fn ntfy_brief_url 2026-07-26
+  chmod +x "${home}/.local/launchers/claude"
+  cp "${STUB_DIR}/curl" "${home}/.local/launchers/curl"
+  cp "$ENV_FILE" "${home}/.config/ntfy/notify-env"
+  chmod 600 "${home}/.config/ntfy/notify-env"
+  # Redirect the wrapper's stdout/stderr so the backgrounded watchdog does not
+  # hold the bats pipe open; shorten the watchdog so no stray sleep lingers.
+  run env -i HOME="$home" XDG_STATE_HOME="${home}/state" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" NTFY_TEST_CURL_EXIT=0 \
+    MORNING_RADAR_TIMEOUT_SECONDS=2 \
+    MORNING_RADAR_LOG_FILE="${home}/radar.log" \
+    bash -c 'bash "$1" >/dev/null 2>&1' _ "$WRAPPER"
   [ "$status" -eq 0 ]
-  [ -z "$output" ]
+  [ -f "${home}/state/morning-radar/last-run" ]
+  [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-brief" ]
+  [ "$(jq -r .markdown <"${STUB_DIR}/curl_stdin")" = "true" ]
+  jq -e '.message | test("P1: alpha issue")' <"${STUB_DIR}/curl_stdin" >/dev/null
 }
 
-@test "render_brief_html fallback escapes markup and is mobile-readable" {
-  local md="${BATS_TEST_TMPDIR}/brief.md" html="${BATS_TEST_TMPDIR}/brief.html"
-  printf '%s\n' '# Brief' '- item with <script> & ampersand' >"$md"
-  # Force the pandoc-absent path with a minimal PATH (sed/bash only, no pandoc).
-  run env PATH="/usr/bin:/bin" MORNING_RADAR_LOG_FILE="$LOG_FILE" \
-    bash -c 'source "$1"; render_brief_html "$2" "$3" "Morning brief — test"' \
-    _ "$WRAPPER" "$md" "$html"
-  [ "$status" -eq 0 ]
-  [ -s "$html" ]
-  grep -qF '&lt;script&gt;' "$html"
-  grep -qF '&amp; ampersand' "$html"
-  grep -qF 'width=device-width' "$html"
-  grep -qF 'white-space:pre-wrap' "$html"
-  # Raw (unescaped) markup must not survive.
-  ! grep -qF '<script>' "$html"
+@test "main(): a failed run notifies attention and leaves no last-run stamp (AC-003/005)" {
+  local home="${BATS_TEST_TMPDIR}/home-fail"
+  mkdir -p "${home}/.local/launchers" "${home}/.config/ntfy"
+  printf '%s\n' '#!/bin/bash' 'exit 1' >"${home}/.local/launchers/claude"
+  chmod +x "${home}/.local/launchers/claude"
+  cp "${STUB_DIR}/curl" "${home}/.local/launchers/curl"
+  cp "$ENV_FILE" "${home}/.config/ntfy/notify-env"
+  chmod 600 "${home}/.config/ntfy/notify-env"
+  # Redirect the wrapper's stdout/stderr so the backgrounded watchdog does not
+  # hold the bats pipe open; shorten the watchdog so no stray sleep lingers.
+  run env -i HOME="$home" XDG_STATE_HOME="${home}/state" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" NTFY_TEST_CURL_EXIT=0 \
+    MORNING_RADAR_TIMEOUT_SECONDS=2 \
+    MORNING_RADAR_LOG_FILE="${home}/radar.log" \
+    bash -c 'bash "$1" >/dev/null 2>&1' _ "$WRAPPER"
+  [ "$status" -eq 1 ]
+  [ ! -f "${home}/state/morning-radar/last-run" ]
+  [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
 }

--- a/tests/morning_radar.bats
+++ b/tests/morning_radar.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+
+# morning-radar wrapper (home/dot_claude/executable_morning-radar.sh, #257/#361).
+# The wrapper is source-safe (side effects live in main() behind a BASH_SOURCE
+# guard), so these tests source it and exercise the pure delivery functions
+# (ntfy_publish / render_brief_html / ntfy_brief_url) with curl stubbed out on
+# PATH — no network, no server, no claude, CI-safe. Covers the osascript->ntfy
+# migration (AC-002), fail-open delivery (AC-003), graceful degradation
+# (AC-004), topic/priority split (AC-005), and token hygiene (AC-006).
+
+load helpers/setup
+
+WRAPPER="${HOME_DIR}/dot_claude/executable_morning-radar.sh"
+
+setup() {
+  STUB_DIR="${BATS_TEST_TMPDIR}/stub"
+  mkdir -p "$STUB_DIR"
+  cat >"${STUB_DIR}/curl" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >"${NTFY_TEST_STUB_DIR}/curl_args"
+cat >"${NTFY_TEST_STUB_DIR}/curl_stdin"
+exit "${NTFY_TEST_CURL_EXIT:-0}"
+EOF
+  chmod +x "${STUB_DIR}/curl"
+
+  ENV_FILE="${BATS_TEST_TMPDIR}/notify-env"
+  cat >"$ENV_FILE" <<'EOF'
+NTFY_URL='http://127.0.0.1:9'
+NTFY_TOKEN='tk_bats_secret'
+NTFY_TOPIC_ATTENTION='claude-attention'
+NTFY_TOPIC_DONE='claude-done'
+NTFY_TOPIC_BRIEF='claude-brief'
+NTFY_BRIEF_BASE_URL='https://host.example.ts.net/brief'
+EOF
+  # The wrapper refuses env files that are not owner-only (0600/0400).
+  chmod 600 "$ENV_FILE"
+
+  LOG_FILE="${BATS_TEST_TMPDIR}/morning-radar.log"
+}
+
+# Source the wrapper (main() is guarded, so nothing runs) and call one of its
+# functions with the stubbed PATH and fixture env. Args after the function name
+# are forwarded to it.
+run_fn() {
+  run env \
+    PATH="${STUB_DIR}:${PATH}" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" \
+    NTFY_TEST_CURL_EXIT="${NTFY_TEST_CURL_EXIT:-0}" \
+    MORNING_RADAR_NTFY_ENV_FILE="$ENV_FILE" \
+    MORNING_RADAR_LOG_FILE="$LOG_FILE" \
+    bash -c 'source "$1"; shift; fn="$1"; shift; "$fn" "$@"' _ "$WRAPPER" "$@"
+}
+
+@test "morning-radar.sh exists and passes bash -n" {
+  [ -f "$WRAPPER" ]
+  bash -n "$WRAPPER"
+}
+
+@test "no osascript path remains anywhere in the wrapper (AC-002)" {
+  ! grep -qE 'osascript|display notification' "$WRAPPER"
+}
+
+@test "token hygiene: no -H/--header Authorization, no set -x (AC-006)" {
+  ! grep -E -- '(-H|--header)["'"'"'[:space:]]*"?Authorization' "$WRAPPER"
+  ! grep -qF 'set -x' "$WRAPPER"
+  # The token reaches curl only through a -K config file.
+  grep -qF 'curl -fs -K' "$WRAPPER"
+}
+
+@test "ntfy_publish brief -> claude-brief topic with click URL (AC-001/005)" {
+  run_fn ntfy_publish brief 3 "HEADLINE: P1 2件" "https://host.example.ts.net/brief/2026-07-26.html"
+  [ "$status" -eq 0 ]
+  [ -f "${STUB_DIR}/curl_stdin" ]
+  [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-brief" ]
+  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "HEADLINE: P1 2件" ]
+  [ "$(jq -r .click <"${STUB_DIR}/curl_stdin")" = "https://host.example.ts.net/brief/2026-07-26.html" ]
+  [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "3" ]
+}
+
+@test "ntfy_publish attention -> claude-attention topic, priority 5, no click (AC-005)" {
+  run_fn ntfy_publish attention 5 "Morning radar failed: claude not found"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
+  [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "5" ]
+  # No link on error notifications.
+  [ "$(jq -r 'has("click")' <"${STUB_DIR}/curl_stdin")" = "false" ]
+}
+
+@test "empty click degrades to a headline-only payload (AC-004)" {
+  run_fn ntfy_publish brief 3 "HEADLINE only" ""
+  [ "$status" -eq 0 ]
+  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "HEADLINE only" ]
+  [ "$(jq -r 'has("click")' <"${STUB_DIR}/curl_stdin")" = "false" ]
+}
+
+@test "token never reaches curl argv (travels via -K config file) (AC-006)" {
+  run_fn ntfy_publish brief 3 "HEADLINE" "https://host.example.ts.net/brief/x.html"
+  [ "$status" -eq 0 ]
+  [ -f "${STUB_DIR}/curl_args" ]
+  ! grep -q 'tk_bats_secret' "${STUB_DIR}/curl_args"
+  grep -qE -- '-K' "${STUB_DIR}/curl_args"
+}
+
+@test "publish failure is fail-open: returns 0, token never logged (AC-003)" {
+  NTFY_TEST_CURL_EXIT=1
+  run_fn ntfy_publish brief 3 "HEADLINE" "https://host.example.ts.net/brief/x.html"
+  [ "$status" -eq 0 ]
+  [ ! -f "$LOG_FILE" ] || ! grep -q 'tk_bats_secret' "$LOG_FILE"
+}
+
+@test "no env file -> silent no-op, no publish" {
+  ENV_FILE="${BATS_TEST_TMPDIR}/does-not-exist"
+  run_fn ntfy_publish brief 3 "HEADLINE" "https://host/x.html"
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/curl_args" ]
+}
+
+@test "unknown kind is ignored without publishing" {
+  run_fn ntfy_publish bogus 3 "HEADLINE"
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/curl_args" ]
+}
+
+@test "ntfy_brief_url builds the dated tailnet URL from the base URL" {
+  run_fn ntfy_brief_url 2026-07-26
+  [ "$status" -eq 0 ]
+  [ "$output" = "https://host.example.ts.net/brief/2026-07-26.html" ]
+}
+
+@test "ntfy_brief_url yields nothing when the base URL is unset (degradation)" {
+  cat >"$ENV_FILE" <<'EOF'
+NTFY_URL='http://127.0.0.1:9'
+NTFY_TOKEN='tk_bats_secret'
+NTFY_TOPIC_BRIEF='claude-brief'
+NTFY_BRIEF_BASE_URL=''
+EOF
+  chmod 600 "$ENV_FILE"
+  run_fn ntfy_brief_url 2026-07-26
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "render_brief_html fallback escapes markup and is mobile-readable" {
+  local md="${BATS_TEST_TMPDIR}/brief.md" html="${BATS_TEST_TMPDIR}/brief.html"
+  printf '%s\n' '# Brief' '- item with <script> & ampersand' >"$md"
+  # Force the pandoc-absent path with a minimal PATH (sed/bash only, no pandoc).
+  run env PATH="/usr/bin:/bin" MORNING_RADAR_LOG_FILE="$LOG_FILE" \
+    bash -c 'source "$1"; render_brief_html "$2" "$3" "Morning brief — test"' \
+    _ "$WRAPPER" "$md" "$html"
+  [ "$status" -eq 0 ]
+  [ -s "$html" ]
+  grep -qF '&lt;script&gt;' "$html"
+  grep -qF '&amp; ampersand' "$html"
+  grep -qF 'width=device-width' "$html"
+  grep -qF 'white-space:pre-wrap' "$html"
+  # Raw (unescaped) markup must not survive.
+  ! grep -qF '<script>' "$html"
+}

--- a/tests/morning_radar.bats
+++ b/tests/morning_radar.bats
@@ -2,11 +2,12 @@
 
 # morning-radar wrapper (home/dot_claude/executable_morning-radar.sh, #257/#361).
 # The wrapper is source-safe (side effects live in main() behind a BASH_SOURCE
-# guard), so these tests both source it to exercise the pure ntfy_publish helper
-# and run it end-to-end with claude + curl stubbed on PATH — no network, no
-# server, CI-safe. Covers the osascript->ntfy migration (AC-002), fail-open
-# delivery (AC-003), topic/priority split (AC-005), token hygiene incl. the
-# permission-mode guard (AC-006), Markdown delivery, and the main() stamp wiring.
+# guard), so these tests both source it to exercise the pure helpers and run it
+# end-to-end with claude + curl stubbed on PATH — no network, no server, CI-safe.
+# Covers the osascript->ntfy migration (AC-002), fail-open delivery (AC-003),
+# graceful degradation (AC-004), topic/priority split (AC-005), token hygiene
+# incl. the permission-mode guard (AC-006), HTML rendering (raw-HTML escaping),
+# the click URL, and the main() stamp wiring.
 
 load helpers/setup
 
@@ -30,16 +31,15 @@ NTFY_TOKEN='tk_bats_secret'
 NTFY_TOPIC_ATTENTION='claude-attention'
 NTFY_TOPIC_DONE='claude-done'
 NTFY_TOPIC_BRIEF='claude-brief'
+NTFY_BRIEF_BASE_URL='https://host.example.ts.net:8443'
 EOF
-  # The wrapper refuses env files that are not owner-only (0600/0400).
   chmod 600 "$ENV_FILE"
 
   LOG_FILE="${BATS_TEST_TMPDIR}/morning-radar.log"
 }
 
 # Source the wrapper (main() is guarded, so nothing runs) and call one of its
-# functions with the stubbed PATH and fixture env. Args after the function name
-# are forwarded to it.
+# functions with the stubbed PATH and fixture env.
 run_fn() {
   run env \
     PATH="${STUB_DIR}:${PATH}" \
@@ -65,27 +65,32 @@ run_fn() {
   grep -qF 'curl -fs -K' "$WRAPPER"
 }
 
-@test "ntfy_publish brief -> claude-brief topic, Markdown, title + body (AC-005)" {
-  run_fn ntfy_publish brief 3 "HEADLINE: P1 2件" "# Brief"$'\n'"- item"
+@test "ntfy_publish brief -> claude-brief topic with click URL (AC-001/005)" {
+  run_fn ntfy_publish brief 3 "Morning brief" "HEADLINE: P1 2件" "https://host.example.ts.net:8443/2026-07-27.html"
   [ "$status" -eq 0 ]
   [ -f "${STUB_DIR}/curl_stdin" ]
   [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-brief" ]
-  [ "$(jq -r .title <"${STUB_DIR}/curl_stdin")" = "HEADLINE: P1 2件" ]
+  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "HEADLINE: P1 2件" ]
+  [ "$(jq -r .click <"${STUB_DIR}/curl_stdin")" = "https://host.example.ts.net:8443/2026-07-27.html" ]
   [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "3" ]
-  [ "$(jq -r .markdown <"${STUB_DIR}/curl_stdin")" = "true" ]
-  jq -e '.message | test("# Brief")' <"${STUB_DIR}/curl_stdin" >/dev/null
 }
 
-@test "ntfy_publish attention -> claude-attention topic, priority 5 (AC-005)" {
+@test "ntfy_publish attention -> claude-attention topic, priority 5, no click (AC-005)" {
   run_fn ntfy_publish attention 5 "Morning Radar" "claude not found"
   [ "$status" -eq 0 ]
   [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
   [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "5" ]
-  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "claude not found" ]
+  [ "$(jq -r 'has("click")' <"${STUB_DIR}/curl_stdin")" = "false" ]
+}
+
+@test "empty click degrades to a link-less payload (AC-004)" {
+  run_fn ntfy_publish brief 3 "Morning brief" "HEADLINE only" ""
+  [ "$status" -eq 0 ]
+  [ "$(jq -r 'has("click")' <"${STUB_DIR}/curl_stdin")" = "false" ]
 }
 
 @test "token never reaches curl argv (travels via -K config file) (AC-006)" {
-  run_fn ntfy_publish brief 3 "HEADLINE" "body"
+  run_fn ntfy_publish brief 3 "Morning brief" "HEADLINE" "https://host/x.html"
   [ "$status" -eq 0 ]
   [ -f "${STUB_DIR}/curl_args" ]
   ! grep -q 'tk_bats_secret' "${STUB_DIR}/curl_args"
@@ -94,37 +99,77 @@ run_fn() {
 
 @test "publish failure is fail-open: returns 0, token never logged (AC-003)" {
   NTFY_TEST_CURL_EXIT=1
-  run_fn ntfy_publish brief 3 "HEADLINE" "body"
+  run_fn ntfy_publish brief 3 "Morning brief" "HEADLINE" "https://host/x.html"
   [ "$status" -eq 0 ]
   [ ! -f "$LOG_FILE" ] || ! grep -q 'tk_bats_secret' "$LOG_FILE"
 }
 
 @test "no env file -> silent no-op, no publish" {
   ENV_FILE="${BATS_TEST_TMPDIR}/does-not-exist"
-  run_fn ntfy_publish brief 3 "HEADLINE" "body"
+  run_fn ntfy_publish brief 3 "Morning brief" "HEADLINE" "https://host/x.html"
   [ "$status" -eq 0 ]
   [ ! -f "${STUB_DIR}/curl_args" ]
 }
 
 @test "group/other-readable env file fails open without publishing (mode check, AC-006)" {
   chmod 644 "$ENV_FILE"
-  run_fn ntfy_publish brief 3 "HEADLINE" "body"
+  run_fn ntfy_publish brief 3 "Morning brief" "HEADLINE" "https://host/x.html"
   [ "$status" -eq 0 ]
   [ ! -f "${STUB_DIR}/curl_args" ]
 }
 
 @test "unknown kind is ignored without publishing" {
-  run_fn ntfy_publish bogus 3 "HEADLINE" "body"
+  run_fn ntfy_publish bogus 3 "Morning brief" "HEADLINE"
   [ "$status" -eq 0 ]
   [ ! -f "${STUB_DIR}/curl_args" ]
 }
 
-# --- main() integration (claude + curl stubbed under a sandbox HOME) ----------
-# main() rebuilds PATH with $HOME/.local/launchers first, so stubs placed there
-# win over the real claude/curl; the sandbox HOME also isolates the brief dir,
-# state dir, and env file.
+@test "ntfy_brief_url builds the dated tailnet URL from the base URL" {
+  run_fn ntfy_brief_url 2026-07-27
+  [ "$status" -eq 0 ]
+  [ "$output" = "https://host.example.ts.net:8443/2026-07-27.html" ]
+}
 
-@test "main(): success writes the last-run stamp and publishes the brief body (AC-003)" {
+@test "ntfy_brief_url yields nothing when the base URL is unset (degradation)" {
+  cat >"$ENV_FILE" <<'EOF'
+NTFY_URL='http://127.0.0.1:9'
+NTFY_TOKEN='tk_bats_secret'
+NTFY_TOPIC_BRIEF='claude-brief'
+NTFY_BRIEF_BASE_URL=''
+EOF
+  chmod 600 "$ENV_FILE"
+  run_fn ntfy_brief_url 2026-07-27
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "render_brief_html escapes raw HTML (no <script> executes on the page)" {
+  local md="${BATS_TEST_TMPDIR}/brief.md" html="${BATS_TEST_TMPDIR}/brief.html"
+  printf '%s\n' '# Brief' '' '- P1: <script>alert(1)</script> issue title' '' '| 時刻 | 件名 |' '|---|---|' '| 09:00 | 会議 |' >"$md"
+  run_fn render_brief_html "$md" "$html" "Morning brief — test"
+  [ "$status" -eq 0 ]
+  [ -s "$html" ]
+  # Raw <script> must never survive (pandoc markdown-raw_html or the <pre> fallback).
+  ! grep -qF '<script>' "$html"
+  grep -qF '&lt;script&gt;' "$html"
+}
+
+@test "render_brief_html fallback (pandoc absent) still escapes and is mobile-readable" {
+  local md="${BATS_TEST_TMPDIR}/b.md" html="${BATS_TEST_TMPDIR}/b.html"
+  printf '%s\n' '# Brief' '- item with <b> & ampersand' >"$md"
+  run env PATH="/usr/bin:/bin" MORNING_RADAR_LOG_FILE="$LOG_FILE" \
+    bash -c 'source "$1"; render_brief_html "$2" "$3" "t"' _ "$WRAPPER" "$md" "$html"
+  [ "$status" -eq 0 ]
+  [ -s "$html" ]
+  ! grep -qF '<b>' "$html"
+  grep -qF '&lt;b&gt;' "$html"
+  grep -qF 'width=device-width' "$html"
+  grep -qF 'white-space:pre-wrap' "$html"
+}
+
+# --- main() integration (Darwin-only; the wrapper's uname guard exits early) --
+
+@test "main(): success writes the last-run stamp and publishes with a click URL (AC-003)" {
   [ "$(uname)" = "Darwin" ] || skip "morning-radar main() is Darwin-only (uname guard exits early)"
   local home="${BATS_TEST_TMPDIR}/home-ok"
   mkdir -p "${home}/.local/launchers" "${home}/.config/ntfy"
@@ -139,8 +184,6 @@ EOF
   cp "${STUB_DIR}/curl" "${home}/.local/launchers/curl"
   cp "$ENV_FILE" "${home}/.config/ntfy/notify-env"
   chmod 600 "${home}/.config/ntfy/notify-env"
-  # Redirect the wrapper's stdout/stderr so the backgrounded watchdog does not
-  # hold the bats pipe open; shorten the watchdog so no stray sleep lingers.
   run env -i HOME="$home" XDG_STATE_HOME="${home}/state" \
     NTFY_TEST_STUB_DIR="$STUB_DIR" NTFY_TEST_CURL_EXIT=0 \
     MORNING_RADAR_TIMEOUT_SECONDS=2 \
@@ -148,9 +191,9 @@ EOF
     bash -c 'bash "$1" >/dev/null 2>&1' _ "$WRAPPER"
   [ "$status" -eq 0 ]
   [ -f "${home}/state/morning-radar/last-run" ]
+  [ -f "${home}/dotfiles/.kryota-dev/morning-brief/$(date +%F).html" ]
   [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-brief" ]
-  [ "$(jq -r .markdown <"${STUB_DIR}/curl_stdin")" = "true" ]
-  jq -e '.message | test("P1: alpha issue")' <"${STUB_DIR}/curl_stdin" >/dev/null
+  jq -e '.click | test("/[0-9-]+\\.html$")' <"${STUB_DIR}/curl_stdin" >/dev/null
 }
 
 @test "main(): a failed run notifies attention and leaves no last-run stamp (AC-003/005)" {
@@ -162,8 +205,6 @@ EOF
   cp "${STUB_DIR}/curl" "${home}/.local/launchers/curl"
   cp "$ENV_FILE" "${home}/.config/ntfy/notify-env"
   chmod 600 "${home}/.config/ntfy/notify-env"
-  # Redirect the wrapper's stdout/stderr so the backgrounded watchdog does not
-  # hold the bats pipe open; shorten the watchdog so no stray sleep lingers.
   run env -i HOME="$home" XDG_STATE_HOME="${home}/state" \
     NTFY_TEST_STUB_DIR="$STUB_DIR" NTFY_TEST_CURL_EXIT=0 \
     MORNING_RADAR_TIMEOUT_SECONDS=2 \

--- a/tests/morning_radar.bats
+++ b/tests/morning_radar.bats
@@ -125,6 +125,7 @@ run_fn() {
 # state dir, and env file.
 
 @test "main(): success writes the last-run stamp and publishes the brief body (AC-003)" {
+  [ "$(uname)" = "Darwin" ] || skip "morning-radar main() is Darwin-only (uname guard exits early)"
   local home="${BATS_TEST_TMPDIR}/home-ok"
   mkdir -p "${home}/.local/launchers" "${home}/.config/ntfy"
   cat >"${home}/.local/launchers/claude" <<'EOF'
@@ -153,6 +154,7 @@ EOF
 }
 
 @test "main(): a failed run notifies attention and leaves no last-run stamp (AC-003/005)" {
+  [ "$(uname)" = "Darwin" ] || skip "morning-radar main() is Darwin-only (uname guard exits early)"
   local home="${BATS_TEST_TMPDIR}/home-fail"
   mkdir -p "${home}/.local/launchers" "${home}/.config/ntfy"
   printf '%s\n' '#!/bin/bash' 'exit 1' >"${home}/.local/launchers/claude"

--- a/tests/ntfy_notify.bats
+++ b/tests/ntfy_notify.bats
@@ -66,6 +66,8 @@ run_wrapper() {
   payload="$(cat "${STUB_DIR}/curl_stdin")"
   [ "$(printf '%s' "$payload" | jq -r '.topic')" = "claude-attention" ]
   [ "$(printf '%s' "$payload" | jq -r '.priority')" = "4" ]
+  # Bodies are published as Markdown so the ntfy web app renders them (#361).
+  [ "$(printf '%s' "$payload" | jq -r '.markdown')" = "true" ]
   [[ "$(printf '%s' "$payload" | jq -r '.title')" == *"permission_prompt"* ]]
   # Attribution (requirement 1.2): account in title and tags; cwd=/tmp is not a
   # git repo so repo/branch fall back to "-", which must also land in the tags.


### PR DESCRIPTION
## Summary

Deliver the weekday morning brief to mobile and migrate the `morning-radar` wrapper from
local `osascript` to the self-hosted **ntfy** system. The wrapper renders the brief to a
mobile-readable **HTML page** and sends an ntfy notification whose **click opens that page**
over the tailnet. Delivery stays **tailnet-only** — brief content never leaves the tailnet.
Closes #361.

## Design note — two-step pivot during review

The delivery mechanism changed twice as review surfaced hard facts (all verified against primary
sources; full log in `.claude/prds/361-brief-url-ntfy.prd.md`):

1. **tailscale serve static page** → rejected: the macOS standalone/App Tailscale variant can
   serve **ports but not files/directories** ([KB 1242](https://tailscale.com/kb/1242/tailscale-serve)),
   so a directory mount can't work on this Mac.
2. **ntfy Markdown message** → rejected: the ntfy **iOS/Android apps don't render Markdown**
   (docs.ntfy.sh: "web app only for now"; no mobile support in the release notes), so the brief
   would show as raw Markdown on mobile — poor UX.
3. **Adopted: rendered HTML page via an nginx sidecar, port-proxied by tailscale serve.** A
   mobile browser renders the page natively; the port proxy works on macOS.

## What changed

- **`morning-radar.sh`:** `render_brief_html` writes `<date>.html` with pandoc
  (`-f markdown-raw_html`, which **escapes untrusted raw HTML** from brief content — a `<script>`
  from a GitHub title can't execute on the page — while keeping GFM tables; `<pre>` fallback). It
  publishes `HEADLINE` + the page URL as the ntfy `click`; errors go to `claude-attention`.
  Source-safe refactor, env-mode (0600/0400) + `curl -K` token hygiene, fail-open, graceful
  degradation. **All `osascript` removed.**
- **ntfy infra:** a loopback **nginx sidecar** (`brief-page` in `compose.yaml`, image pinned +
  Renovate-tracked) serves the brief dir; `tailscale serve --https 8443` (a port proxy) fronts it
  on a dedicated HTTPS port. New `claude-brief` topic + `brief_port` SSOT; `NTFY_BRIEF_BASE_URL`
  in notify-env; upgrade migration writes the new keys without reissuing the token.
- **`ntfy-notify.sh`:** existing topics now publish `markdown: true` (renders in the web app).
- **Tests / docs:** `make lint` + `make test` green (275 bats, 0 failures); notifications docs
  rewritten; PRD records the pivots.

## Notes

- The notification link opens a plain tailnet HTML page (no ntfy auth needed on the device).
- Decision log: implemented on Opus 4.8 for a large-tier task (Opus 5 `xhigh` floor unmet;
  continue-anyway approved).
