### PR TITLE
docs: commit/PR/issue の言語ポリシーを日本語ベースに切り替え、skill の言語を統一する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,13 @@ The chezmoi source directory is `home/` (configured via `.chezmoiroot`).
 Written artifacts in this repository follow one of two rules:
 
 **English required:**
-- Code review comments
 - Documentation and markdown files
 
 **Japanese required:**
 - Commit messages — Conventional Commits with an English `type(scope):` prefix and a Japanese subject/body, e.g. `feat(ntfy): 認証を自動プロビジョニングする` (matches the existing `commit` / `sdd` skill defaults)
 - Pull request titles and descriptions
 - GitHub Issue titles and bodies
+- Code review comments — matches the agent definition files' system prompts, which already steer Japanese-speaking review output (see below)
 - Agent skill files (`SKILL.md`) and their script comments — except `agent-browser`, which stays English: it is an upstream-synced discovery stub whose specialized skills are fetched live via `agent-browser skills get <name>` rather than vendored (see `home/AGENTS.md.tmpl:19`)
 - Agent definition files (`home/dot_claude/agents/*.md`) — their system prompts steer Japanese-speaking review output
 - The Fable 5 orchestrator system prompt (`home/dot_claude/fable-orchestrator-prompt.md`) — appended to Fable 5 sessions launched via `cldf` / `cldf-r06`, so it must steer Japanese-speaking session output

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,17 @@ The chezmoi source directory is `home/` (configured via `.chezmoiroot`).
 
 ## Language policy
 
-All written artifacts in this repository must be in English:
-- Commit messages
-- Pull request titles and descriptions
+Written artifacts in this repository follow one of two rules:
+
+**English required:**
 - Code review comments
 - Documentation and markdown files
 
-Exceptions — the following must be written in Japanese:
-- Agent skill files (`SKILL.md`) and their script comments
+**Japanese required:**
+- Commit messages — Conventional Commits with an English `type(scope):` prefix and a Japanese subject/body, e.g. `feat(ntfy): 認証を自動プロビジョニングする` (matches the existing `commit` / `sdd` skill defaults)
+- Pull request titles and descriptions
+- GitHub Issue titles and bodies
+- Agent skill files (`SKILL.md`) and their script comments — except `agent-browser`, which stays English: it is an upstream-synced discovery stub whose specialized skills are fetched live via `agent-browser skills get <name>` rather than vendored (see `home/AGENTS.md.tmpl:19`)
 - Agent definition files (`home/dot_claude/agents/*.md`) — their system prompts steer Japanese-speaking review output
 - The Fable 5 orchestrator system prompt (`home/dot_claude/fable-orchestrator-prompt.md`) — appended to Fable 5 sessions launched via `cldf` / `cldf-r06`, so it must steer Japanese-speaking session output
 - The global agent instructions deployed from this repo (`home/AGENTS.md.tmpl`, `home/dot_claude/CLAUDE.md`, `home/.chezmoitemplates/coding-standards.md`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ The chezmoi source directory is `home/` (configured via `.chezmoiroot`).
 Written artifacts in this repository follow one of two rules:
 
 **English required:**
-- Documentation and markdown files
+- Documentation and markdown files under `docs/` and repo-root reference files (e.g. `README.md`) — the agent-facing Markdown files listed below are the exception
 
 **Japanese required:**
 - Commit messages — Conventional Commits with an English `type(scope):` prefix and a Japanese subject/body, e.g. `feat(ntfy): 認証を自動プロビジョニングする` (matches the existing `commit` / `sdd` skill defaults)

--- a/home/dot_agents/skills/compact-docs/SKILL.md
+++ b/home/dot_agents/skills/compact-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compact-docs
-description: Compress, reduce, optimize, or shrink documentation files. Use when docs are verbose, redundant, or need consolidation for clarity.
+description: ドキュメントファイルを圧縮・削減・最適化・縮小する。冗長・重複していて明確化のため統合が必要なドキュメントに使用する。
 disable-model-invocation: true
 allowed-tools: Read, Edit
 ---

--- a/home/dot_agents/skills/compact-docs/SKILL.md
+++ b/home/dot_agents/skills/compact-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compact-docs
-description: ドキュメントファイルを圧縮・削減・最適化・縮小する。冗長・重複していて明確化のため統合が必要なドキュメントに使用する。
+description: ドキュメントファイルを圧縮・削減・最適化・縮小する。冗長・重複しており、明確化のために統合が必要なドキュメントに使用する。
 disable-model-invocation: true
 allowed-tools: Read, Edit
 ---

--- a/home/dot_agents/skills/issue-fleet/SKILL.md
+++ b/home/dot_agents/skills/issue-fleet/SKILL.md
@@ -95,10 +95,10 @@ wtp list                # 作成結果とパスの確認
 1. cd <worktree絶対パス> し、以降すべての操作をこの worktree 内で行う
 2. Issue の要求を実装する。既存コードの流儀（命名・構成・テスト規範）に合わせる
 3. プロジェクトの lint / test があれば実行して通す
-4. commit する（メッセージは英語・Conventional Commits。1Password 署名エラーが出たら
-   commit を中断し、エラー内容をそのまま報告して終了する）
+4. commit する（メッセージは Conventional Commits。type/scope は英語、subject/body は日本語。
+   1Password 署名エラーが出たら commit を中断し、エラー内容をそのまま報告して終了する）
 5. push し、draft PR を作成する:
-   gh pr create --draft --title "<英語タイトル>" --body "<英語本文。Closes #<番号> を含める>"
+   gh pr create --draft --title "<日本語タイトル>" --body "<日本語本文。Closes #<番号> を含める>"
 6. **絶対にマージしない。main に push しない。**
 
 ## 返答形式（最終メッセージ）

--- a/home/dot_agents/skills/monitor-ci/SKILL.md
+++ b/home/dot_agents/skills/monitor-ci/SKILL.md
@@ -5,41 +5,41 @@ description: PR作成後やCI実行中にStatus Checksの状態を監視する�
 
 # Monitor CI Checks
 
-Monitors pull request CI checks until they are resolved (pass or fail).
+Pull Request の CI チェックが解決する（成功または失敗）まで監視する。
 
-## Usage
+## 使い方
 
-When asked to monitor CI checks, Claude will:
+CI チェックの監視を求められたら、Claude は以下を行う:
 
-1. Run `gh pr checks --watch` to continuously monitor the status
-2. Wait until all checks are completed
-3. Report the final status of all checks
-4. If checks fail, analyze the failure logs and suggest fixes
+1. `gh pr checks --watch` を実行し、継続的にステータスを監視する
+2. すべてのチェックが完了するまで待つ
+3. 全チェックの最終ステータスを報告する
+4. チェックが失敗した場合、失敗ログを分析し修正案を提示する
 
-## Command
+## コマンド
 
 ```bash
-# Monitor PR checks in watch mode
+# watch モードで PR チェックを監視
 gh pr checks --watch
 
-# Alternative: Check status once
+# 代替: 一度だけステータスを確認
 gh pr checks
 
-# View specific check details if needed
+# 必要に応じて特定チェックの詳細を表示
 gh pr checks --verbose
 ```
 
-## Workflow
+## ワークフロー
 
-1. **Start Monitoring**: Run `gh pr checks --watch` immediately after PR creation or when requested
-2. **Track Progress**: The command will show real-time updates of all CI checks
-3. **Completion**: Wait until all checks show as either ✓ (passed) or X (failed)
-4. **Action on Failure**:
-   - If any checks fail, use `gh pr checks --verbose` to get detailed logs
-   - Analyze the failure and suggest or implement fixes
-   - After fixes, push changes and monitor again
+1. **監視開始**: PR 作成直後、または依頼を受けたら即座に `gh pr checks --watch` を実行する
+2. **進捗の追跡**: このコマンドは全 CI チェックの状態をリアルタイムで表示する
+3. **完了**: すべてのチェックが ✓（成功）または X（失敗）になるまで待つ
+4. **失敗時の対応**:
+   - チェックが失敗したら `gh pr checks --verbose` で詳細ログを取得する
+   - 失敗内容を分析し、修正を提案または実装する
+   - 修正後、変更を push して再度監視する
 
-## Example Output
+## 出力例
 
 ```
 Refreshing checks status every 10 seconds. Press Ctrl+C to quit.
@@ -53,9 +53,9 @@ Type Check              in_progress -           ◐
 Some checks were not successful
 ```
 
-## Important Notes
+## 重要な注意事項
 
-- The `--watch` flag refreshes every 10 seconds
-- Press Ctrl+C to stop monitoring
-- Always wait for all checks to complete before proceeding
-- If checks fail, investigate and fix issues before merging
+- `--watch` フラグは10秒ごとに更新する
+- 監視を止めるには Ctrl+C を押す
+- 次のステップに進む前に、必ずすべてのチェックの完了を待つこと
+- チェックが失敗した場合、マージ前に問題を調査・修正すること

--- a/home/dot_agents/skills/wtp/SKILL.md
+++ b/home/dot_agents/skills/wtp/SKILL.md
@@ -1,147 +1,148 @@
 ---
 name: wtp
-description: "Comprehensive guide for the `wtp` (Worktree Plus) CLI by satococoa — an enhanced Git worktree manager. Use this whenever the user wants to create, list, remove, or navigate Git worktrees with wtp, mentions `wtp add`/`wtp cd`/`wtp list`/`wtp remove`/`wtp exec`, asks about automatic worktree paths from branch names, post-create hooks (copy/symlink/command) in `.wtp.yml`, branch tracking for worktrees, or shell integration (`wtp shell-init`, `wtp hook`, tab completion, auto-cd). Trigger this even when the user just describes the workflow — e.g. 'spin up a worktree for this feature branch', 'jump to my auth worktree', 'clean up the worktree and its branch' — without naming wtp explicitly, as long as wtp is the available tool."
+description: "satococoa 製の `wtp`（Worktree Plus）CLI の総合ガイド。Git ワークツリーを `wtp` で作成・一覧・削除・移動したいとき、`wtp add`/`wtp cd`/`wtp list`/`wtp remove`/`wtp exec` に言及されたとき、ブランチ名からの自動ワークツリーパス導出、`.wtp.yml` の post-create フック（copy/symlink/command）、ワークツリーのブランチ追跡、シェル統合（`wtp shell-init`, `wtp hook`, タブ補完, auto-cd）について尋ねられたときに使用する。ユーザーが `wtp` と明示せずワークフローを説明しただけの場合（例:「この feature ブランチ用にワークツリーを立ち上げて」「auth のワークツリーに移動して」「ワークツリーとそのブランチを片付けて」）でも、`wtp` が利用可能なツールである限りこの skill を起動する。"
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
 # wtp (Worktree Plus)
 
-`wtp` is a Git worktree manager that removes the friction from `git worktree`: it
-derives sensible paths from branch names, auto-tracks remote branches, runs
-project-specific setup hooks on creation, and provides instant `cd` navigation
-between worktrees.
+`wtp` は `git worktree` の面倒な部分を取り除く Git ワークツリーマネージャーである。
+ブランチ名から適切なパスを自動導出し、リモートブランチを自動追跡し、作成時に
+プロジェクト固有のセットアップフックを実行し、ワークツリー間を即座に `cd` で
+移動できるようにする。
 
-This skill covers the day-to-day commands plus configuration and shell
-integration. For the full `.wtp.yml` hook reference (copy/symlink/command hooks,
-path resolution rules), read `references/configuration.md`.
+この skill では日常的なコマンドに加え、設定とシェル統合を扱う。`.wtp.yml` フック
+の完全なリファレンス（copy/symlink/command フック、パス解決ルール）は
+`references/configuration.md` を参照すること。
 
-## Mental model
+## メンタルモデル
 
-- **Worktrees live outside the repo.** By default they go under
-  `../worktrees/<branch-name>`, so `feature/auth` → `../worktrees/feature/auth`.
-  Slashes in branch names become directories, keeping things organized by type.
-- **The main worktree is `@`.** Refer to it as `@` in `wtp cd` / `wtp exec`, or
-  omit the name entirely to mean "go home" (like bare `cd`).
-- **Hooks run on `wtp add`.** Anything you'd normally do by hand after creating a
-  worktree (copy `.env`, symlink caches, install deps) belongs in `.wtp.yml`.
+- **ワークツリーはリポジトリの外に存在する。** デフォルトでは `../worktrees/<branch-name>`
+  配下に作られるため、`feature/auth` は `../worktrees/feature/auth` になる。ブランチ名の
+  スラッシュはディレクトリになり、種類ごとに整理された状態を保つ。
+- **メインのワークツリーは `@` である。** `wtp cd` / `wtp exec` では `@` と指定するか、
+  名前を省略すると「ホームへ戻る」（素の `cd` と同様）意味になる。
+- **フックは `wtp add` 実行時に走る。** ワークツリー作成後に手動で行っていたこと
+  （`.env` のコピー、キャッシュのシンボリックリンク、依存関係のインストール等）は
+  `.wtp.yml` に書いておく。
 
-Always confirm the installed version with `wtp --version` if behavior seems off —
-this skill is written against **v2.10.x**.
+挙動がおかしいと感じたら、必ず `wtp --version` でインストール済みバージョンを確認
+すること — 本 skill は **v2.10.x** を前提に書かれている。
 
-## Creating worktrees — `wtp add`
-
-```bash
-wtp add <existing-branch>          # worktree from an existing local/remote branch
-wtp add -b <new-branch> [<commit>] # create a new branch + worktree
-```
-
-Key behaviors:
-
-- **Auto-tracking**: if `<branch>` isn't local but exists on exactly one remote,
-  wtp creates a local tracking branch automatically. No remote → clear error.
-- **New branch from a base**: `wtp add -b hotfix/urgent main` branches off `main`.
-  The base can be a commit (`abc1234`) or a remote ref (`origin/main`).
-- **Run setup after creation**: `--exec "<cmd>"` runs a command inside the new
-  worktree *after* hooks finish (supports interactive commands when a TTY exists).
-- **Script-friendly**: `--quiet` / `-q` prints only the created absolute path, so
-  you can capture it: `dir=$(wtp add -b feature/x --quiet)`.
-
-Examples:
+## ワークツリーの作成 — `wtp add`
 
 ```bash
-wtp add feature/auth                      # existing branch (tracks remote if needed)
-wtp add -b feature/new-feature            # brand-new branch
-wtp add -b hotfix/urgent main             # new branch based on main
-wtp add -b feature/test origin/main       # new branch tracking origin/main
-wtp add -b feature/x --exec "npm test"    # create, run hooks, then npm test
+wtp add <existing-branch>          # 既存のローカル/リモートブランチからワークツリーを作成
+wtp add -b <new-branch> [<commit>] # 新規ブランチ + ワークツリーを作成
 ```
 
-**Multiple remotes** with the same branch name are ambiguous by design. wtp won't
-guess — create the local branch yourself, then retry:
+主な挙動:
+
+- **自動追跡**: `<branch>` がローカルに存在せず、リモートにちょうど1つだけ存在する場合、
+  `wtp` は自動的にローカル追跡ブランチを作成する。リモートにも無ければ明確なエラーになる。
+- **base 指定での新規ブランチ**: `wtp add -b hotfix/urgent main` は `main` から分岐する。
+  base にはコミット（`abc1234`）やリモート ref（`origin/main`）も指定できる。
+- **作成後にセットアップを実行**: `--exec "<cmd>"` はフック完了 *後* に新しいワークツリー内で
+  コマンドを実行する（TTY が存在すればインタラクティブなコマンドにも対応）。
+- **スクリプトフレンドリー**: `--quiet` / `-q` を付けると作成された絶対パスのみを出力するため、
+  `dir=$(wtp add -b feature/x --quiet)` のように捕捉できる。
+
+例:
+
+```bash
+wtp add feature/auth                      # 既存ブランチ（必要ならリモートを追跡）
+wtp add -b feature/new-feature            # 全く新しいブランチ
+wtp add -b hotfix/urgent main             # main を base にした新規ブランチ
+wtp add -b feature/test origin/main       # origin/main を追跡する新規ブランチ
+wtp add -b feature/x --exec "npm test"    # 作成 → フック実行 → npm test
+```
+
+**同名ブランチが複数のリモートに存在する場合**は設計上あいまいなため、`wtp` は推測しない。
+自分でローカルブランチを作成してから再実行すること:
 
 ```bash
 git branch --track feature/shared upstream/feature/shared
 wtp add feature/shared
 ```
 
-## Listing worktrees — `wtp list` (alias `ls`)
+## ワークツリーの一覧 — `wtp list`（エイリアス `ls`）
 
 ```bash
-wtp list                 # table: PATH, BRANCH, HEAD; main worktree shown as @ ... *
-wtp list --quiet         # paths only (one per line) — good for scripting/piping
-wtp list --compact       # minimize column widths for narrow/redirected output
+wtp list                 # 表形式: PATH, BRANCH, HEAD; メインワークツリーは @ ... * で表示
+wtp list --quiet         # パスのみ（1行ずつ）— スクリプト/パイプ処理向け
+wtp list --compact       # 幅の狭い/リダイレクト出力向けに列幅を最小化
 wtp list --max-path-width 80
 ```
 
-Note: `wtp list` may abbreviate branch names. When you need the **full** branch
-name (e.g. to check merge status), pair it with
-`git worktree list --porcelain | grep '^branch '`.
+補足: `wtp list` はブランチ名を省略表示することがある。**完全な** ブランチ名が
+必要な場合（マージ状況の確認等）は、以下と組み合わせること:
+`git worktree list --porcelain | grep '^branch '`
 
-## Removing worktrees — `wtp remove` (alias `rm`)
-
-```bash
-wtp remove <worktree-name>                    # remove the worktree only
-wtp remove --force <name>                      # remove even if the worktree is dirty
-wtp remove --with-branch <name>                # also delete the branch (only if merged)
-wtp remove --with-branch --force-branch <name> # delete the branch even if unmerged
-```
-
-`--with-branch` is the headline feature: it removes the worktree *and* its branch
-in one atomic step, so you don't leave orphaned branches behind. The branch is
-only deleted if merged unless you add `--force-branch`. The target is the
-worktree's **directory name**, not the branch path (see `wtp list` output).
-
-## Navigating — `wtp cd`
-
-`wtp cd` prints the absolute path of a worktree. Two ways to use it:
+## ワークツリーの削除 — `wtp remove`（エイリアス `rm`）
 
 ```bash
-cd "$(wtp cd feature/auth)"   # direct: command substitution, works in any shell
-cd "$(wtp cd)"                # main worktree (bare cd = "go home")
+wtp remove <worktree-name>                    # ワークツリーのみ削除
+wtp remove --force <name>                      # dirty な状態でも強制削除
+wtp remove --with-branch <name>                # ブランチも削除（マージ済みの場合のみ）
+wtp remove --with-branch --force-branch <name> # 未マージでもブランチを削除
 ```
 
-With the shell hook installed (see Shell integration), `wtp cd` changes the
-directory directly — no subshell needed:
+`--with-branch` はこの目玉機能で、ワークツリーと**そのブランチ**を1ステップで
+アトミックに削除し、孤立したブランチを残さない。ブランチは `--force-branch` を
+付けない限りマージ済みの場合のみ削除される。対象はワークツリーの**ディレクトリ名**
+であり、ブランチパスではない（`wtp list` の出力を参照）。
+
+## 移動 — `wtp cd`
+
+`wtp cd` はワークツリーの絶対パスを出力する。使い方は2通り:
 
 ```bash
-wtp cd feature/auth   # jumps there
-wtp cd @              # main worktree (explicit)
-wtp cd                # main worktree
-wtp cd <TAB>          # tab completion of worktree names
+cd "$(wtp cd feature/auth)"   # 直接: コマンド置換。どのシェルでも動く
+cd "$(wtp cd)"                # メインワークツリー（素の cd = 「ホームへ戻る」）
 ```
 
-## Running commands in a worktree — `wtp exec`
+シェルフックがインストールされていれば（シェル統合を参照）、`wtp cd` は
+サブシェル無しで直接ディレクトリを変更する:
+
+```bash
+wtp cd feature/auth   # そこへジャンプ
+wtp cd @              # メインワークツリー（明示指定）
+wtp cd                # メインワークツリー
+wtp cd <TAB>          # ワークツリー名のタブ補完
+```
+
+## ワークツリー内でのコマンド実行 — `wtp exec`
 
 ```bash
 wtp exec <worktree> -- <command> [args...]
 ```
 
-Runs a command in another worktree without `cd`-ing there. Target resolution is
-the same as `wtp cd` (so `@` is the main worktree):
+`cd` せずに別のワークツリー内でコマンドを実行する。ターゲットの解決方法は
+`wtp cd` と同じ（`@` はメインワークツリー）:
 
 ```bash
 wtp exec feature/auth -- go test ./...
 wtp exec @ -- pwd
 ```
 
-## Configuration — `.wtp.yml`
+## 設定 — `.wtp.yml`
 
 ```bash
-wtp init   # scaffold a .wtp.yml in the repo root with example hooks
+wtp init   # サンプルフック付きの .wtp.yml をリポジトリルートに雛形生成
 ```
 
-Minimal shape:
+最小構成:
 
 ```yaml
 version: "1.0"
 defaults:
-  base_dir: "../worktrees"   # where worktrees are created, relative to project root
+  base_dir: "../worktrees"   # ワークツリーの作成先（プロジェクトルートからの相対パス）
 hooks:
   post_create:
     - type: copy
-      from: ".env"            # 'from' is relative to the MAIN worktree (gitignored OK)
-      to: ".env"              # 'to' is relative to the NEW worktree (defaults to 'from')
+      from: ".env"            # 'from' はメインワークツリーからの相対パス（gitignore 済みでも可）
+      to: ".env"              # 'to' は新しいワークツリーからの相対パス（既定は 'from' と同じ）
     - type: symlink
       from: ".bin"
       to: ".bin"
@@ -149,51 +150,49 @@ hooks:
       command: "npm ci"
 ```
 
-The three hook types (`copy`, `symlink`, `command`), the exact path-resolution
-rules, and `env`/`work_dir` options are detailed in
-`references/configuration.md` — read it before editing or generating a `.wtp.yml`,
-because the `from`/`to` "main vs new worktree" distinction is the most common
-source of mistakes.
+3種類のフック（`copy`, `symlink`, `command`）、正確なパス解決ルール、`env`/`work_dir`
+オプションの詳細は `references/configuration.md` に記載されている — `from`/`to` の
+「メイン vs 新規ワークツリー」の区別が最もよくある間違いの元なので、`.wtp.yml` を
+編集・生成する前に読むこと。
 
-## Shell integration
+## シェル統合
 
-Enables tab completion **and** directory-changing `wtp cd` / auto-cd on
-interactive `wtp add`.
+タブ補完 **と** ディレクトリ変更する `wtp cd` / インタラクティブな `wtp add` での
+auto-cd を有効にする。
 
-- **Installed via Homebrew** (this machine): lazy-loaded. The first `TAB` after
-  typing `wtp` evaluates `wtp shell-init <shell>` for the session — no rc edits
-  needed. To refresh in the current shell, run `wtp shell-init <shell>` manually.
-- **Installed via `go install`**: add one line to your shell rc:
+- **Homebrew でインストールした場合**（このマシン）: 遅延ロードされる。`wtp` と
+  入力後に最初に `TAB` を押すと、そのセッションで `wtp shell-init <shell>` が
+  評価される — rc の編集は不要。現在のシェルで即座に反映したい場合は
+  `wtp shell-init <shell>` を手動実行すること。
+- **`go install` でインストールした場合**: シェルの rc に1行追加する:
 
   ```bash
   eval "$(wtp shell-init zsh)"     # zsh  (~/.zshrc)
-  eval "$(wtp shell-init bash)"    # bash (~/.bashrc); needs bash-completion v2
+  eval "$(wtp shell-init bash)"    # bash (~/.bashrc); bash-completion v2 が必要
   wtp shell-init fish | source     # fish (~/.config/fish/config.fish)
   ```
 
-`shell-init` bundles completion + the cd hook. If you want *only* the cd hook
-without completions, use `wtp hook <shell>` instead (`bash`/`zsh`/`fish`
-subcommands).
+`shell-init` は補完 + cd フックをまとめて有効化する。補完なしで cd フックだけ
+欲しい場合は、代わりに `wtp hook <shell>` を使うこと（`bash`/`zsh`/`fish` サブコマンド）。
 
-When stdout is not a TTY (command substitution, pipes), `wtp add` keeps plain CLI
-behavior and does **not** auto-switch directories — so scripts stay predictable.
+標準出力が TTY でない場合（コマンド置換、パイプ）、`wtp add` はプレーンな CLI 挙動を
+保ち、ディレクトリの自動切り替えは**行わない**（スクリプトの動作が予測可能なままになる）。
 
-## Troubleshooting
+## トラブルシューティング
 
-wtp aims for actionable errors. Common ones:
+`wtp` は実用的なエラーメッセージを目指している。よくあるもの:
 
-- `branch '<x>' not found in local or remote branches` — typo, or the remote
-  isn't fetched. Run `git fetch` and retry.
-- `branch '<x>' exists in multiple remotes: origin, upstream` — ambiguous;
-  create a local tracking branch first (`git branch --track <x> origin/<x>`),
-  then `wtp add <x>`.
-- `failed to create worktree: exit status 128` — usually the worktree path
-  already exists. Check `wtp list`.
+- `branch '<x>' not found in local or remote branches` — タイプミス、もしくは
+  リモートが fetch されていない。`git fetch` してから再試行すること。
+- `branch '<x>' exists in multiple remotes: origin, upstream` — あいまい。
+  先にローカル追跡ブランチを作成してから（`git branch --track <x> origin/<x>`）、
+  `wtp add <x>` すること。
+- `failed to create worktree: exit status 128` — 大抵はワークツリーのパスが
+  既に存在している。`wtp list` で確認すること。
 - `Cannot remove worktree with uncommitted changes. Use --force to override` —
-  commit/stash, or `wtp remove --force <name>` if you mean to discard.
+  commit/stash するか、破棄してよいなら `wtp remove --force <name>` を使うこと。
 
-## Related skills
+## 関連 skill
 
-For bulk cleanup of merged worktrees, see the `wtp-cleanup` skill, which detects
-worktrees whose branches are already merged into `main` and removes them after
-confirmation.
+マージ済みワークツリーの一括整理については `wtp-cleanup` skill を参照。
+`main` にマージ済みのブランチを持つワークツリーを検出し、確認の上で削除する。


### PR DESCRIPTION
## 概要

commit message / PR タイトル・説明 / GitHub Issue の言語ポリシーを日本語ベースに一本化し、curated skill 間の記述言語の不一致を解消する。

Closes #363

## 背景

`AGENTS.md`（`CLAUDE.md` のシンボリックリンク先）の Language policy は「commit message / PR タイトル・説明は英語必須」と定めていたが、共有 skill である `commit`/`sdd` は既に日本語コミットメッセージをデフォルトとしており、ポリシーと実態が矛盾していた。さらに `issue-fleet` は commit/PR を英語とハードコードしており、`commit`/`sdd` とは逆方向の不整合があった。curated skill 本体の記述言語にも `wtp`（全文英語）・`monitor-ci`（description のみ日本語）・`compact-docs`（description のみ英語）という 3 パターンの不統一が存在した。

## 変更内容

1. `AGENTS.md`: Language policy を書き換え、commit message（英語 type/scope + 日本語 subject/body）・PR タイトル/説明・GitHub Issue を日本語必須と明記。`agent-browser` の英語維持例外を追加。
2. `issue-fleet/SKILL.md`: commit/PR の言語指示を英語→日本語に修正し、`commit`/`sdd` の既定と一致させる。
3. `wtp/SKILL.md`: 全文（frontmatter description + body）を日本語に翻訳。コードブロック内のコマンド構文は変更していない。
4. `monitor-ci/SKILL.md`: body を日本語に翻訳（description は既に日本語のため変更なし）。
5. `compact-docs/SKILL.md`: description を日本語に翻訳（body は既に日本語のため変更なし）。
6. `AGENTS.md`（追補）: 「Code review comments」を英語必須リストから日本語必須リストへ移動。Agent 定義ファイルの system prompt が既に日本語出力を誘導しているという既存の例外と矛盾していたため（レビュー中の指摘を受けて対応。spec ドキュメント（requirements.md/design.md）も合わせて更新済み）。

`docs/`（EN canonical + `.ja.md` mirror）、`commit`/`sdd` skill 本体（既に正しい規定を持つため）は変更していない。

## 検証内容

- 翻訳した SKILL.md のコードブロック（コマンド・フラグ・YAML）を `git diff` で元の英語版と比較し、技術的内容が変わっていないことを確認済み
- `tests/files.bats` を調査し、本変更対象ファイルの言語（英語/日本語）に依存する既存アサーションが無いことを確認済み（テスト更新は不要と判断）
- `make test` 実行済み（lint + Bats、全件通過）

## Decision log

本タスクは pr-workflow の分類・GATE・統合判断、および `/sdd` の spec 執筆・実装を、`model-fitness-check` が standard tier の floor として要求する Opus 5 @ high ではなく Sonnet 5 @ high で実行した。セッション開始時のユーザー操作（`/model sonnet` → `/effort high`）に伴う floor 未達を提示した上で、ユーザーが "continue anyway" を選択している。

## テスト計画

- [x] `make test`（lint + Bats）が通過することを確認済み
- [ ] レビュー（`/multi-review`）でコンテンツ・整合性の指摘がないか確認

