### PR TITLE
fix: macOS defaults の死んだキーを修正し管理対象を拡張

### DIFF
--- a/docs/architecture/lifecycle-scripts.ja.md
+++ b/docs/architecture/lifecycle-scripts.ja.md
@@ -40,7 +40,7 @@ flowchart TD
         G --> H["16 migrate-claude-binary\nrun_once\n(~/.local/bin/claude を\nmise installs/claude/latest へ symlink)"]
         H --> H2["17 setup-claude-plugins\nrun_onchange\n(dot_claude/settings.json が宣言する\nmarketplace 登録 + plugin インストール)"]
         H2 --> I["18 setup-agent-browser\nrun_onchange\n(mise exec 経由で agent-browser install)"]
-        I --> J["20 macos-defaults\nrun_onchange · macOS のみ\n(defaults write + killall Dock/Finder)"]
+        I --> J["20 macos-defaults\nrun_onchange · macOS のみ\n(defaults write + killall Dock/Finder/ControlCenter)"]
         J --> J2["30 register-launchd-agents\nrun_onchange · macOS のみ\n(repo 管理 LaunchAgent の launchctl bootstrap\nCI ではスキップ)"]
         J2 --> J3["31 setup-ntfy\nrun_onchange · macOS のみ\n(ntfy サーバー用の docker compose up +\ntailscale serve; CI ではスキップ)"]
         J3 --> K["40 setup-sheldon\nrun_onchange\n(sheldon lock)"]
@@ -174,7 +174,37 @@ tailnet の MagicDNS 名は保存されず、必要な都度その場で導出�
 
 ### 20 — macos-defaults (`run_onchange`、after、macOS のみ)
 
-キーボード、Finder、Dock、DesktopServices、時計、スクロール設定に対して `defaults write` を適用し、`killall Dock Finder SystemUIServer` で即時反映します。`joinPath .chezmoi.sourceDir` を使った自己ハッシュにより、スクリプト本文の任意の編集で再トリガーされます。
+以下の管理対象ドメインに `defaults write` を適用し、`killall Dock Finder SystemUIServer
+ControlCenter` で即時反映します。`joinPath .chezmoi.sourceDir` を使った自己ハッシュにより、
+スクリプト本文の任意の編集で再トリガーされます。
+
+**管理対象ドメイン**: `NSGlobalDomain`（キーボード/Full Keyboard Access、スクロールバー、
+スプリングローディング、トラックパッドのフォースクリックと追跡速度、音量変更時の
+サウンドフィードバック）、`com.apple.desktopservices`（ネットワーク/USB ボリュームでの
+`.DS_Store` 抑制）、`com.apple.dock`（自動非表示、アイコンサイズ、Spaces の並び替え、
+最近使ったアプリの表示）、`com.apple.finder`（隠しファイル、デスクトップのドライブ
+アイコン、ステータス/パスバー、既定の表示スタイル）、`com.apple.menuextra.clock`
+（メニューバー時計の表示形式。Big Sur 以降の個別キー方式 — 下記参照）、
+`com.apple.terminal`（文字エンコーディング）。
+
+**修正済みの既知の死んだキー**: `AppleKeyboardUIMode` は `3`（「古い macOS バージョンで
+有効」）だったが、Sonoma 以降 Full Keyboard Access を有効化しなくなったため、
+現在は `2`（「Sonoma 以降で有効」）を書き込む。キーがドメイン移動したわけではなく、
+値の意味が変わっただけ（nix-darwin/nix-darwin#1378, #1501）。
+`com.apple.menuextra.clock DateFormat`（単一のフォーマット文字列）は、Big Sur 以降の
+Control Center 刷新で個別キー（`IsAnalog`、`Show24Hour`、`ShowAMPM`、`ShowDate`、
+`ShowDayOfWeek`、`ShowSeconds`）に置き換わり効果を失った。リロード対象も
+`SystemUIServer` から `ControlCenter` に変わっている（tech-otaku/menu-bar-clock）。
+`ApplePressAndHoldEnabled` は検討したうえで**追加していない**: Sonoma/Sequoia では
+動作が不安定で、確実な `defaults` ベースの代替手段が確認できなかった
+（geerlingguy/mac-dev-playbook#210）。
+
+**既知の制限事項**: TCC/プライバシー設定（フルディスクアクセス、カメラ/マイク許可等）や、
+非 plist・サンドボックス化されたアプリ設定（Safari、Mail 等）は `defaults write` では
+管理できず、本スクリプトのスコープ外です。Dock のアイコン配置
+（`persistent-apps`/`persistent-others`）、ホットコーナー、カスタム Terminal
+プロファイルテーマは意図的に除外しています — 既存機の状態を破壊するリスクがあるか、
+`defaults write` 一行を超えて別ファイルの配布が必要になるためです。
 
 ### 30 — register-launchd-agents (`run_onchange`、after、macOS のみ)
 

--- a/docs/architecture/lifecycle-scripts.ja.md
+++ b/docs/architecture/lifecycle-scripts.ja.md
@@ -178,9 +178,10 @@ tailnet の MagicDNS 名は保存されず、必要な都度その場で導出�
 ControlCenter` で即時反映します。`joinPath .chezmoi.sourceDir` を使った自己ハッシュにより、
 スクリプト本文の任意の編集で再トリガーされます。
 
-**管理対象ドメイン**: `NSGlobalDomain`（キーボード/Full Keyboard Access、スクロールバー、
-スプリングローディング、トラックパッドのフォースクリックと追跡速度、音量変更時の
-サウンドフィードバック）、`com.apple.desktopservices`（ネットワーク/USB ボリュームでの
+**管理対象ドメイン**: `com.apple.HIToolbox`（Fn キーの用途）、`NSGlobalDomain`
+（キーボード/Full Keyboard Access、スクロールバー、スプリングローディング、
+トラックパッドのフォースクリックと追跡速度、音量変更時のサウンドフィードバック）、
+`com.apple.desktopservices`（ネットワーク/USB ボリュームでの
 `.DS_Store` 抑制）、`com.apple.dock`（自動非表示、アイコンサイズ、Spaces の並び替え、
 最近使ったアプリの表示）、`com.apple.finder`（隠しファイル、デスクトップのドライブ
 アイコン、ステータス/パスバー、既定の表示スタイル）、`com.apple.menuextra.clock`

--- a/docs/architecture/lifecycle-scripts.md
+++ b/docs/architecture/lifecycle-scripts.md
@@ -40,7 +40,7 @@ flowchart TD
         G --> H["16 migrate-claude-binary\nrun_once\n(symlink ~/.local/bin/claude\n-> mise installs/claude/latest)"]
         H --> H2["17 setup-claude-plugins\nrun_onchange\n(registers marketplaces + installs plugins\ndeclared in dot_claude/settings.json)"]
         H2 --> I["18 setup-agent-browser\nrun_onchange\n(agent-browser install via mise exec)"]
-        I --> J["20 macos-defaults\nrun_onchange · macOS only\n(defaults write + killall Dock/Finder)"]
+        I --> J["20 macos-defaults\nrun_onchange · macOS only\n(defaults write + killall Dock/Finder/ControlCenter)"]
         J --> J2["30 register-launchd-agents\nrun_onchange · macOS only\n(launchctl bootstrap of repo-managed\nLaunchAgents; skipped in CI)"]
         J2 --> J3["31 setup-ntfy\nrun_onchange · macOS only\n(docker compose up + tailscale serve\nfor the ntfy server; skipped in CI)"]
         J3 --> K["40 setup-sheldon\nrun_onchange\n(sheldon lock)"]
@@ -169,7 +169,35 @@ Runs `mise exec -- agent-browser install` (with `--with-deps` on Linux to pull s
 
 ### 20 — macos-defaults (`run_onchange`, after, macOS only)
 
-Applies `defaults write` for keyboard, Finder, Dock, DesktopServices, clock, and scroll settings, then runs `killall Dock Finder SystemUIServer` to apply them immediately. Self-hashes using `joinPath .chezmoi.sourceDir` so any edit to the script body re-triggers it.
+Applies `defaults write` across the managed domains below, then runs `killall Dock Finder
+SystemUIServer ControlCenter` to apply them immediately. Self-hashes using `joinPath
+.chezmoi.sourceDir` so any edit to the script body re-triggers it.
+
+**Managed domains**: `NSGlobalDomain` (keyboard/Full Keyboard Access, scroll bars, spring
+loading, trackpad force-click and tracking speed, volume-change sound feedback),
+`com.apple.desktopservices` (suppress `.DS_Store` on network/USB volumes),
+`com.apple.dock` (auto-hide, icon size, Spaces reordering, recent-apps display),
+`com.apple.finder` (hidden files, desktop drive icons, status/path bar, default view
+style), `com.apple.menuextra.clock` (menu bar clock display format via the discrete
+Big Sur+ keys — see below), and `com.apple.terminal` (string encoding).
+
+**Known-dead keys already fixed**: `AppleKeyboardUIMode` was `3` ("Enabled on older macOS
+versions"), which stopped enabling Full Keyboard Access starting with Sonoma — the script
+now writes `2` ("Enabled on Sonoma or later"); the value moved, the key did not
+(nix-darwin/nix-darwin#1378, #1501). `com.apple.menuextra.clock DateFormat` (a single
+format string) stopped being honored once the Big Sur+ Control Center redesign replaced
+it with discrete keys (`IsAnalog`, `Show24Hour`, `ShowAMPM`, `ShowDate`, `ShowDayOfWeek`,
+`ShowSeconds`); the reload target also moved from `SystemUIServer` to `ControlCenter`
+(tech-otaku/menu-bar-clock). `ApplePressAndHoldEnabled` was evaluated and intentionally
+**not** added: it is unreliable on Sonoma/Sequoia with no confirmed `defaults`-based
+replacement (geerlingguy/mac-dev-playbook#210).
+
+**Known limitations**: TCC/privacy settings (Full Disk Access, camera/microphone
+permissions, etc.) and non-plist or sandboxed app settings (Safari, Mail, and similar)
+cannot be managed via `defaults write` and are out of scope for this script. Dock icon
+layout (`persistent-apps`/`persistent-others`), hot corners, and custom Terminal profile
+themes are deliberately excluded — they are either destructive to an existing machine's
+state or require shipping additional files beyond a `defaults write` line.
 
 ### 30 — register-launchd-agents (`run_onchange`, after, macOS only)
 

--- a/docs/architecture/lifecycle-scripts.md
+++ b/docs/architecture/lifecycle-scripts.md
@@ -173,9 +173,10 @@ Applies `defaults write` across the managed domains below, then runs `killall Do
 SystemUIServer ControlCenter` to apply them immediately. Self-hashes using `joinPath
 .chezmoi.sourceDir` so any edit to the script body re-triggers it.
 
-**Managed domains**: `NSGlobalDomain` (keyboard/Full Keyboard Access, scroll bars, spring
-loading, trackpad force-click and tracking speed, volume-change sound feedback),
-`com.apple.desktopservices` (suppress `.DS_Store` on network/USB volumes),
+**Managed domains**: `com.apple.HIToolbox` (Fn key usage), `NSGlobalDomain` (keyboard/Full
+Keyboard Access, scroll bars, spring loading, trackpad force-click and tracking speed,
+volume-change sound feedback), `com.apple.desktopservices` (suppress `.DS_Store` on
+network/USB volumes),
 `com.apple.dock` (auto-hide, icon size, Spaces reordering, recent-apps display),
 `com.apple.finder` (hidden files, desktop drive icons, status/path bar, default view
 style), `com.apple.menuextra.clock` (menu bar clock display format via the discrete

--- a/home/run_onchange_after_20-macos-defaults.sh.tmpl
+++ b/home/run_onchange_after_20-macos-defaults.sh.tmpl
@@ -7,13 +7,22 @@ echo "Applying macOS defaults..."
 
 # Base
 defaults write com.apple.HIToolbox AppleFnUsageType -int 2
-defaults write NSGlobalDomain AppleKeyboardUIMode -int 3
+# AppleKeyboardUIMode: value semantics changed in Sonoma — 3 ("Enabled on older
+# macOS versions") stopped enabling Full Keyboard Access; 2 is the Sonoma+ value
+# for the same effect (nix-darwin/nix-darwin#1378, #1501).
+defaults write NSGlobalDomain AppleKeyboardUIMode -int 2
 defaults write NSGlobalDomain AppleShowAllExtensions -bool true
 defaults write NSGlobalDomain AppleShowScrollBars -string "Always"
 defaults write NSGlobalDomain com.apple.keyboard.fnState -bool true
 defaults write NSGlobalDomain KeyRepeat -int 2
 defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
 defaults write NSGlobalDomain InitialKeyRepeat -int 25
+defaults write NSGlobalDomain com.apple.springing.enabled -bool true
+defaults write NSGlobalDomain com.apple.springing.delay -float 0.5
+defaults write NSGlobalDomain com.apple.trackpad.forceClick -bool true
+defaults write NSGlobalDomain com.apple.trackpad.scaling -float 2
+defaults write NSGlobalDomain com.apple.sound.beep.feedback -bool true
+defaults write NSGlobalDomain com.apple.sound.beep.flash -bool false
 
 # DesktopServices
 defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
@@ -21,6 +30,10 @@ defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
 
 # Dock
 defaults write com.apple.dock autohide-delay -float 0
+defaults write com.apple.dock autohide -bool true
+defaults write com.apple.dock mru-spaces -bool false
+defaults write com.apple.dock show-recents -bool false
+defaults write com.apple.dock tilesize -int 44
 
 # Finder
 defaults write com.apple.finder AppleShowAllFiles -bool true
@@ -30,14 +43,22 @@ defaults write com.apple.finder ShowMountedServersOnDesktop -bool true
 defaults write com.apple.finder ShowRemovableMediaOnDesktop -bool true
 defaults write com.apple.finder ShowStatusBar -bool true
 defaults write com.apple.finder ShowPathbar -bool true
+defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
 
 # SystemUIServer
-defaults write com.apple.menuextra.clock DateFormat -string 'EEE d MMM HH:mm'
+# menuextra.clock DateFormat stopped being honored once the Big Sur+ Control
+# Center redesign replaced it with these discrete keys (tech-otaku/menu-bar-clock).
+defaults write com.apple.menuextra.clock IsAnalog -bool false
+defaults write com.apple.menuextra.clock Show24Hour -bool true
+defaults write com.apple.menuextra.clock ShowAMPM -bool true
+defaults write com.apple.menuextra.clock ShowDate -int 0
+defaults write com.apple.menuextra.clock ShowDayOfWeek -bool true
+defaults write com.apple.menuextra.clock ShowSeconds -bool true
 
 # Terminal
 defaults write com.apple.terminal StringEncodings -array 4
 
-for app in "Dock" "Finder" "SystemUIServer"; do
+for app in "Dock" "Finder" "SystemUIServer" "ControlCenter"; do
   killall "${app}" &>/dev/null || true
 done
 

--- a/home/run_onchange_after_20-macos-defaults.sh.tmpl
+++ b/home/run_onchange_after_20-macos-defaults.sh.tmpl
@@ -5,7 +5,7 @@ set -euo pipefail
 # defaults hash: {{ include (joinPath .chezmoi.sourceDir "run_onchange_after_20-macos-defaults.sh.tmpl") | sha256sum }}
 echo "Applying macOS defaults..."
 
-# Base
+# Base (keyboard)
 defaults write com.apple.HIToolbox AppleFnUsageType -int 2
 # AppleKeyboardUIMode: value semantics changed in Sonoma — 3 ("Enabled on older
 # macOS versions") stopped enabling Full Keyboard Access; 2 is the Sonoma+ value
@@ -17,10 +17,16 @@ defaults write NSGlobalDomain com.apple.keyboard.fnState -bool true
 defaults write NSGlobalDomain KeyRepeat -int 2
 defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
 defaults write NSGlobalDomain InitialKeyRepeat -int 25
+
+# Finder spring loading
 defaults write NSGlobalDomain com.apple.springing.enabled -bool true
 defaults write NSGlobalDomain com.apple.springing.delay -float 0.5
+
+# Trackpad
 defaults write NSGlobalDomain com.apple.trackpad.forceClick -bool true
 defaults write NSGlobalDomain com.apple.trackpad.scaling -float 2
+
+# Sound feedback
 defaults write NSGlobalDomain com.apple.sound.beep.feedback -bool true
 defaults write NSGlobalDomain com.apple.sound.beep.flash -bool false
 
@@ -45,7 +51,7 @@ defaults write com.apple.finder ShowStatusBar -bool true
 defaults write com.apple.finder ShowPathbar -bool true
 defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
 
-# SystemUIServer
+# Clock (com.apple.menuextra.clock; reload target: ControlCenter)
 # menuextra.clock DateFormat stopped being honored once the Big Sur+ Control
 # Center redesign replaced it with these discrete keys (tech-otaku/menu-bar-clock).
 defaults write com.apple.menuextra.clock IsAnalog -bool false


### PR DESCRIPTION
## 概要

`home/run_onchange_after_20-macos-defaults.sh.tmpl` の既存キーを現行 macOS
（Sonoma/Sequoia 以降）で検証し、死んでいるキーを修正・置換したうえで、実機の
`defaults read` を diff ベースで棚卸しして管理対象ドメインを拡張する。

closes #364

## 修正した死んだキー

- `NSGlobalDomain AppleKeyboardUIMode`: `3` → `2`。Sonoma 以降で値の意味が変わり、
  `3` は Full Keyboard Access を有効化しなくなった
  （[nix-darwin/nix-darwin#1378](https://github.com/nix-darwin/nix-darwin/issues/1378)、
  [#1501](https://github.com/nix-darwin/nix-darwin/pull/1501)）。
- `com.apple.menuextra.clock DateFormat`: Big Sur 以降の Control Center 刷新で
  無効化されており、`IsAnalog`/`Show24Hour`/`ShowAMPM`/`ShowDate`/`ShowDayOfWeek`/
  `ShowSeconds` の個別キーに置換。リロード対象も `SystemUIServer` から
  `ControlCenter` に変更（`killall` 対象に追加）。
- `ApplePressAndHoldEnabled`: Issue で言及されていたが元々未管理。Sonoma/Sequoia
  で確実な代替手段がないことを確認し、追加しない判断を記録（採用しない）。

## 追加した管理対象キー（実機インベントリより採用）

- `NSGlobalDomain`: スプリングローディング、トラックパッドのフォースクリック/
  追跡速度、音量変更時のサウンドフィードバック
- `com.apple.dock`: 自動非表示、アイコンサイズ、Spaces 並び替え抑制、最近使った
  アプリの非表示
- `com.apple.finder`: 既定の表示スタイル（リスト表示）

個人情報（テキスト置換辞書等）や移植性のないキー（ネットワークホスト名、
インストール済み IME 等）は除外し、除外理由を design doc に記録済み。

## ドキュメント

`docs/architecture/lifecycle-scripts.md` / `.ja.md` の `20 — macos-defaults`
セクションを、拡張後の管理対象・修正した死んだキー・TCC/プライバシー設定等の
制限事項に合わせて更新。

## 検証

- `make lint` / `make test` 通過（275 bats テスト、全て green）
- `chezmoi execute-template` でテンプレート構文・レンダリング結果を確認（構文エラーなし）
- **訂正**: 当初 `setup-validation.yml` の macOS ジョブが `chezmoi apply` を実行し
  実機検証すると想定していたが、このワークフローはリポジトリ側で手動 disable
  されている（本 Issue と無関係の既存状態）ことが判明。実際に走る `CI` ワークフローは
  `ubuntu-latest` 上の `make lint`/`make test-bats` のみで macOS 固有の検証は行わない。
  実際の `chezmoi apply` によるライブ実行は、実機設定を変更する不可逆感のある操作の
  ため本 PR 実装時点では未実行 — マージ前にユーザー自身の実機で確認するか、
  `setup-validation.yml` の再有効化を別途検討されたい

