### PR TITLE
feat(claude-hooks): UserPromptSubmitでprompt-conform実行を提案するhookを追加

### DIFF
--- a/docs/agents/claude-code.ja.md
+++ b/docs/agents/claude-code.ja.md
@@ -15,6 +15,7 @@
 - [permissions allow/deny サーフェス](#permissions-allowdeny-サーフェス)
 - [フックグラフ](#フックグラフ)
   - [SessionStart](#sessionstart)
+  - [UserPromptSubmit](#userpromptsubmit)
   - [PreCompact](#precompact)
   - [PreToolUse](#pretooluse)
   - [PostToolUse](#posttooluse)
@@ -47,6 +48,7 @@
 | `home/dot_claude/hooks-fork/governance-capture.js` | `~/.claude/hooks-fork/governance-capture.js` |
 | `home/dot_claude/hooks-fork/post-bash-command-log.js` | `~/.claude/hooks-fork/post-bash-command-log.js` |
 | `home/dot_claude/hooks-fork/ecc-state-reader.js` | `~/.claude/hooks-fork/ecc-state-reader.js` |
+| `home/dot_claude/hooks-fork/prompt-conform-suggest.js` | `~/.claude/hooks-fork/prompt-conform-suggest.js` |
 | `home/dot_claude/agents/*.md` | `~/.claude/agents/*.md` |
 | `home/dot_claude/fable-orchestrator-prompt.md` | `~/.claude/fable-orchestrator-prompt.md`（`cldf`/`cldf-r06` が `--append-system-prompt-file` で読み込む） |
 | `home/dot_claude/symlink_skills.tmpl` | `~/.claude/skills -> ~/.agents/skills` (シンボリックリンク) |
@@ -142,6 +144,8 @@ flowchart TD
     SS[SessionStart] --> SS1[ECC session-start-bootstrap]
     SS --> SS2[clv2-session-notify async]
 
+    UPS[UserPromptSubmit] --> UPS1[prompt-conform-suggest\nmatcherなし]
+
     PC[PreCompact] --> PC1[ECC pre-compact]
 
     PTU[PreToolUse] --> PTU1[suggest-compact\nEdit Write]
@@ -180,6 +184,12 @@ flowchart TD
 |---|---|---|
 | `session:start` | `ecc-hook.sh scripts/hooks/session-start-bootstrap.js` | 前回コンテキスト読み込み、パッケージマネージャー検出 |
 | `session:start:clv2-notify` | `clv2-session-notify.sh` (async、タイムアウト 10 秒) | レビュー待ちクラスター数をキャッシュ；7 日スロットルのデスクトップ通知 |
+
+### UserPromptSubmit
+
+| フック ID | Matcher | コマンド | 備考 |
+|---|---|---|---|
+| `user-prompt-submit:prompt-conform-suggest` | なし | `node hooks-fork/prompt-conform-suggest.js`（タイムアウト 5 秒） | 長くタスク性の強いプロンプトを検知し、`$prompt-conform` の実行提案を `additionalContext` として注入する（task #367）。ECC フォークではなく独立スクリプト — 下記の [ECC hook forks](#ecc-フック-fork-hooks-fork) とは別に文書化している。`UserPromptSubmit` は[公式 Hooks reference](https://code.claude.com/docs/en/hooks)上 `matcher` 非サポート（silently ignored）のため、このエントリでは省略している。fail-open: 不正な payload・env でチューニングした不正な正規表現・その他の例外はすべて no-output・exit 0 に縮退する。チューニング項目は [Env vars reference](#env-vars-reference) を参照。 |
 
 ### PreCompact
 
@@ -284,6 +294,8 @@ $HOME/.claude/ecc-hook.sh scripts/hooks/run-with-flags.js <hook-id> <script-path
 ## ECC フック fork (hooks-fork/)
 
 3 つのフックは ECC のアップストリーム実装では要件を満たせないため、`home/dot_claude/hooks-fork/` に fork されました。いずれも `ecc-hook.sh` を経由せず `node <file>` として直接呼び出されます（`run-with-flags.js` はプラグインルート外のスクリプトをパストラバーサルガードで拒否するため）。各 fork はプラグインルートフォールバックプローブで ECC ランタイムを解決し、chezmoi external から ECC モジュールを `require()` します — 再実装より再利用を優先。
+
+`home/dot_claude/hooks-fork/` には [UserPromptSubmit](#userpromptsubmit) フックである `prompt-conform-suggest.js` も置かれていますが、これは ECC フォーク**ではありません** — ECC 側の対応実装がなく、ECC モジュールの `require()` も行わず、永続化層も持たないステートレスなスクリプトです。呼び出し方法（`node <file>` の直接呼び出し）が下記の 3 つの fork と同じであるため、同じディレクトリに配置されています。
 
 ### governance-capture.js
 
@@ -499,6 +511,9 @@ kryota-dev/dotfiles#257: launchd LaunchAgent が平日朝に `/morning-brief` �
 | `ECC_DISABLED_HOOKS_EXTRA` | シェル（`claude-config` エイリアス、prefix 起動） | セッション単位の追加 opt-out：settings.json env が基底変数を上書きするため、`ecc-hook.sh` がこれを `ECC_DISABLED_HOOKS` へカンマ結合でマージする（#281） |
 | `ECC_QUALITY_GATE_FIX` | `settings.json env` | `true` = 品質ゲートがブロックする代わりにファイルを自動修正 |
 | `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` | `settings.json env` | 追加の破壊的コマンドパターンの正規表現；Codex ゲートと SSOT 共有 |
+| `PROMPT_CONFORM_SUGGEST_MIN_LENGTH` | 既定未設定（運用者がチューニング可能） | `prompt-conform-suggest.js` がプロンプトをさらに検査する前に要求する文字数閾値（既定 150）を上書きする。非負整数のみ有効、それ以外は既定値へフォールバック |
+| `PROMPT_CONFORM_SUGGEST_TASK_REGEX` | 既定未設定（運用者がチューニング可能） | `prompt-conform-suggest.js` が使う命令形タスク動詞の正規表現（既定は JP/EN のタスク文面）を上書きする。不正な正規表現は組み込み既定へフォールバック |
+| `PROMPT_CONFORM_SUGGEST_KEYWORD_REGEX` | 既定未設定（運用者がチューニング可能） | `prompt-conform-suggest.js` が使う skill/プロンプト作成系キーワードの正規表現を上書きする。不正な正規表現は組み込み既定へフォールバック |
 | `CLAUDE_PLUGIN_ROOT` | `ecc-hook.sh` | `~/.agents/skills/ecc` に固定；ECC のプラグインフォールバック走査をスキップ |
 | `CLAUDE_CONFIG_DIR` | claude ラッパー | Claude Code が使用する `~/.claude*` ディレクトリを選択 |
 | `ECC_AGENT_DATA_HOME` | claude ラッパー | ECC（とフック fork）が状態を書き込む場所 |

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -15,6 +15,7 @@ This document covers the Claude Code harness configuration deployed by this dotf
 - [Permissions allow/deny surface](#permissions-allowdeny-surface)
 - [Hooks graph](#hooks-graph)
   - [SessionStart](#sessionstart)
+  - [UserPromptSubmit](#userpromptsubmit)
   - [PreCompact](#precompact)
   - [PreToolUse](#pretooluse)
   - [PostToolUse](#posttooluse)
@@ -47,6 +48,7 @@ This document covers the Claude Code harness configuration deployed by this dotf
 | `home/dot_claude/hooks-fork/governance-capture.js` | `~/.claude/hooks-fork/governance-capture.js` |
 | `home/dot_claude/hooks-fork/post-bash-command-log.js` | `~/.claude/hooks-fork/post-bash-command-log.js` |
 | `home/dot_claude/hooks-fork/ecc-state-reader.js` | `~/.claude/hooks-fork/ecc-state-reader.js` |
+| `home/dot_claude/hooks-fork/prompt-conform-suggest.js` | `~/.claude/hooks-fork/prompt-conform-suggest.js` |
 | `home/dot_claude/agents/*.md` | `~/.claude/agents/*.md` |
 | `home/dot_claude/fable-orchestrator-prompt.md` | `~/.claude/fable-orchestrator-prompt.md` (appended by `cldf`/`cldf-r06` via `--append-system-prompt-file`) |
 | `home/dot_claude/symlink_skills.tmpl` | `~/.claude/skills -> ~/.agents/skills` (symlink) |
@@ -144,6 +146,8 @@ flowchart TD
     SS[SessionStart] --> SS1[ECC session-start-bootstrap]
     SS --> SS2[clv2-session-notify async]
 
+    UPS[UserPromptSubmit] --> UPS1[prompt-conform-suggest\nno matcher]
+
     PC[PreCompact] --> PC1[ECC pre-compact]
 
     PTU[PreToolUse] --> PTU1[suggest-compact\nEdit Write]
@@ -182,6 +186,12 @@ flowchart TD
 |---|---|---|
 | `session:start` | `ecc-hook.sh scripts/hooks/session-start-bootstrap.js` | Loads previous context; detects package manager |
 | `session:start:clv2-notify` | `clv2-session-notify.sh` (async, timeout 10 s) | Caches review-ready cluster count; fires 7-day-throttled desktop notification |
+
+### UserPromptSubmit
+
+| Hook ID | Matcher | Command | Notes |
+|---|---|---|---|
+| `user-prompt-submit:prompt-conform-suggest` | none | `node hooks-fork/prompt-conform-suggest.js` (timeout 5 s) | Detects long, task-shaped prompts and injects `additionalContext` suggesting `$prompt-conform` (task #367). Not an ECC fork — a standalone script, documented separately from [ECC hook forks](#ecc-hook-forks-hooks-fork) below. `UserPromptSubmit` does not support `matcher` per the [official Hooks reference](https://code.claude.com/docs/en/hooks) (silently ignored), so the entry omits it. Fail-open: a malformed payload, an invalid env-tuned regex, or any other exception all degrade to no output and exit 0. See [Env vars reference](#env-vars-reference) for the tuning knobs. |
 
 ### PreCompact
 
@@ -286,6 +296,8 @@ The `run-with-flags.js` wrapper self-gates: it reads `ECC_HOOK_PROFILE` and `ECC
 ## ECC hook forks (hooks-fork/)
 
 Three hooks could not be satisfied by ECC's upstream implementations and were forked into `home/dot_claude/hooks-fork/`. All three are invoked directly as `node <file>` rather than through `ecc-hook.sh`, because `run-with-flags.js` rejects scripts outside the plugin root (path-traversal guard). Each fork resolves the ECC runtime via a plugin-root fallback probe and `require()`s ECC modules from the chezmoi external — reuse over reimplementation.
+
+`home/dot_claude/hooks-fork/` also holds `prompt-conform-suggest.js` (the [UserPromptSubmit](#userpromptsubmit) hook above), which is **not** an ECC fork — it has no ECC upstream, requires no `require()` of ECC modules, and is stateless (no persistence layer). It is colocated here because it is invoked the same way (`node <file>`, direct) as the three forks below.
 
 ### governance-capture.js
 
@@ -501,6 +513,9 @@ Because `claude` resolves to the same wrapper script as `cld` (`~/.local/launche
 | `ECC_DISABLED_HOOKS_EXTRA` | shell (`claude-config` alias, prefix invocation) | Per-session additive opt-out: `ecc-hook.sh` comma-joins it into `ECC_DISABLED_HOOKS`, since settings.json env overrides the base variable (#281) |
 | `ECC_QUALITY_GATE_FIX` | `settings.json env` | `true` = quality-gate auto-fixes files instead of blocking |
 | `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` | `settings.json env` | Regex of additional destructive command patterns; SSOT shared with Codex gate |
+| `PROMPT_CONFORM_SUGGEST_MIN_LENGTH` | unset by default (operator-tunable) | Overrides the character-length floor (default 150) that `prompt-conform-suggest.js` requires before it inspects a prompt further. Must be a non-negative integer; other values fall back to the default |
+| `PROMPT_CONFORM_SUGGEST_TASK_REGEX` | unset by default (operator-tunable) | Overrides the imperative task-verb regex `prompt-conform-suggest.js` uses (default covers JP/EN task phrasing). An invalid pattern falls back to the built-in default |
+| `PROMPT_CONFORM_SUGGEST_KEYWORD_REGEX` | unset by default (operator-tunable) | Overrides the skill/prompt-authoring keyword regex `prompt-conform-suggest.js` uses. An invalid pattern falls back to the built-in default |
 | `CLAUDE_PLUGIN_ROOT` | `ecc-hook.sh` | Fixed to `~/.agents/skills/ecc`; skips ECC's plugin fallback scan |
 | `CLAUDE_CONFIG_DIR` | the claude wrapper | Selects which `~/.claude*` directory Claude Code uses |
 | `ECC_AGENT_DATA_HOME` | the claude wrapper | Governs where ECC (and the hook forks) write state |

--- a/home/dot_claude/hooks-fork/prompt-conform-suggest.js
+++ b/home/dot_claude/hooks-fork/prompt-conform-suggest.js
@@ -21,7 +21,7 @@
  * home/dot_config/gateguard/executable_codex-bash-gate.js): an invalid override
  * falls back to the built-in default rather than crashing the hook.
  *
- *   PROMPT_CONFORM_SUGGEST_MIN_LENGTH  — integer, default 200
+ *   PROMPT_CONFORM_SUGGEST_MIN_LENGTH  — integer, default 150
  *   PROMPT_CONFORM_SUGGEST_TASK_REGEX  — RegExp source, default: imperative task verbs (JP/EN)
  *   PROMPT_CONFORM_SUGGEST_KEYWORD_REGEX — RegExp source, default: skill/prompt-authoring terms
  *
@@ -32,22 +32,37 @@
  * Fail-open: every failure path (malformed stdin JSON, invalid env regex,
  * unexpected exception) degrades to emitting nothing on stdout and exiting 0,
  * so a bug here can never block a prompt submission.
+ *
+ * ReDoS note: a syntactically valid but catastrophically backtracking custom
+ * regex (e.g. `^(a+)+$`) is NOT caught by the try/catch in buildRegex() — that
+ * only rejects syntax errors. Two independent backstops bound the worst case
+ * instead of trying to statically detect dangerous patterns (undecidable in
+ * general): MAX_REGEX_TEST_LENGTH caps the string handed to .test(), and
+ * settings.json's `timeout: 5` kills the hook process outright if both a
+ * pathological regex and a large prompt combine.
  */
 
 const MAX_STDIN = 1024 * 1024;
 
 const DEFAULT_MIN_LENGTH = 150;
 
-// Japanese imperative task-request shapes ("実装して[ください]" etc.) plus a
-// standalone politeness marker, and common English imperative task verbs.
+// Upper bound on the text handed to taskRegex/keywordRegex.test() — bounds the
+// worst-case cost of a catastrophically backtracking custom regex regardless
+// of MAX_STDIN (see the ReDoS note above). Well above any realistic prompt
+// length that would legitimately need the tail truncated for detection purposes.
+const MAX_REGEX_TEST_LENGTH = 4000;
+
+// Japanese imperative task-request shapes ("実装して[ください]" etc.) plus
+// English imperative task verbs anchored to the start of the prompt or a
+// sentence boundary (not a bare \b match anywhere, which false-triggers on
+// verbs inside ordinary questions like "How should I write a commit message?").
 const DEFAULT_TASK_REGEX_SOURCE =
-  '(?:(?:実装|作成|修正|追加|削除|リファクタ(?:リング)?|設計|書き直|直)して(?:ください)?' +
-  '|お願いします' +
-  '|\\b(?:implement|create|refactor|fix|design|build|write)\\b)';
+  '(?:(?:実装|作成|修正|追加|削除|リファクタ(?:リング)?|設計|直)して(?:ください)?' +
+  '|(?:^|[.!?。！？\\n]\\s*)(?:please\\s+)?\\b(?:implement|create|refactor|fix|design|build|write)\\b)';
 
 // Skill / prompt-authoring vocabulary — the domain prompt-conform itself targets.
 const DEFAULT_KEYWORD_REGEX_SOURCE =
-  '(?:skill|SKILL\\.md|slash\\s*command|prompt-conform' +
+  '(?:skill|slash\\s*command|prompt-conform' +
   '|システムプロンプト|プロンプト(?:設計|作成|最適化|エンジニアリング)|指示文|エージェント定義|CLAUDE\\.md)';
 
 function warnOnce(message) {
@@ -67,7 +82,7 @@ function resolveConfig(env) {
   const rawMinLength = env.PROMPT_CONFORM_SUGGEST_MIN_LENGTH;
   if (rawMinLength) {
     const parsed = Number(rawMinLength);
-    if (Number.isFinite(parsed) && parsed >= 0) {
+    if (Number.isInteger(parsed) && parsed >= 0) {
       minLength = parsed;
     } else {
       warnOnce(`ignoring invalid PROMPT_CONFORM_SUGGEST_MIN_LENGTH: ${rawMinLength}`);
@@ -108,13 +123,19 @@ function isOptimizationWorthy(promptText, config) {
   if (promptText.length < config.minLength) {
     return false;
   }
-  return config.taskRegex.test(promptText) || config.keywordRegex.test(promptText);
+  const target =
+    promptText.length > MAX_REGEX_TEST_LENGTH ? promptText.slice(0, MAX_REGEX_TEST_LENGTH) : promptText;
+  return config.taskRegex.test(target) || config.keywordRegex.test(target);
 }
 
+// Written as a factual statement, not an imperative instruction — the official
+// Hooks reference (https://code.claude.com/docs/en/hooks, "Add context for
+// Claude") warns that out-of-band imperative text can trigger Claude's
+// prompt-injection defenses, which surfaces the text to the user instead of
+// applying it as silent context.
 const SUGGESTION_MESSAGE =
-  'このプロンプトは分量が多くタスク性が強いため、実行前に $prompt-conform でのプロンプト最適化をユーザーに提案することを検討してください。' +
-  '有用と判断した場合は AskUserQuestion 等でユーザーに実行可否を確認し、ユーザーが明示的に希望した場合のみ実行してください。' +
-  'ユーザーが急いでいる、または最適化が不要と判断できる場合は提案を省略して構いません。';
+  'このプロンプトはローカルの検知条件（長さとタスク形状）に一致した。' +
+  '$prompt-conform によるプロンプト最適化が利用可能。実行にはユーザーの明示的な希望確認が必要。';
 
 /**
  * @param {string} rawInput
@@ -124,7 +145,8 @@ function run(rawInput) {
   let input = null;
   try {
     input = JSON.parse(rawInput);
-  } catch {
+  } catch (err) {
+    warnOnce(`failed to parse stdin: ${err.message}`);
     return '';
   }
 

--- a/home/dot_claude/hooks-fork/prompt-conform-suggest.js
+++ b/home/dot_claude/hooks-fork/prompt-conform-suggest.js
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Prompt Conform Suggest — UserPromptSubmit hook (task #367).
+ *
+ * Why this exists: `$prompt-conform` optimizes an arbitrary prompt, but nothing
+ * offers it automatically. UserPromptSubmit hooks cannot implement an interactive
+ * gate themselves — they can only inject `additionalContext` or hard-block the
+ * prompt — so this hook mirrors `model-fitness-check`'s design: detect an
+ * optimization-worthy prompt, inject a suggestion into context, and let Claude
+ * decide whether to offer `$prompt-conform` (e.g. via AskUserQuestion). Firing on
+ * every prompt was rejected as noisy, hence the two-stage heuristic below.
+ *
+ * Detection is intentionally conservative (length AND shape/keyword, not OR):
+ * a bare length threshold would also catch long non-task pastes (logs, diffs
+ * quoted for reference), and a bare keyword match would fire on short one-liners
+ * that don't benefit from optimization. Both signals are required.
+ *
+ * Tunable via env (mirrors the GATEGUARD_BASH_EXTRA_DESTRUCTIVE pattern in
+ * home/dot_config/gateguard/executable_codex-bash-gate.js): an invalid override
+ * falls back to the built-in default rather than crashing the hook.
+ *
+ *   PROMPT_CONFORM_SUGGEST_MIN_LENGTH  — integer, default 200
+ *   PROMPT_CONFORM_SUGGEST_TASK_REGEX  — RegExp source, default: imperative task verbs (JP/EN)
+ *   PROMPT_CONFORM_SUGGEST_KEYWORD_REGEX — RegExp source, default: skill/prompt-authoring terms
+ *
+ * Unlike home/dot_claude/hooks-fork/governance-capture.js this hook has no
+ * persistence layer and does not require() the ECC external runtime — it is a
+ * standalone, stateless script (prompt text is never written to disk or a DB).
+ *
+ * Fail-open: every failure path (malformed stdin JSON, invalid env regex,
+ * unexpected exception) degrades to emitting nothing on stdout and exiting 0,
+ * so a bug here can never block a prompt submission.
+ */
+
+const MAX_STDIN = 1024 * 1024;
+
+const DEFAULT_MIN_LENGTH = 150;
+
+// Japanese imperative task-request shapes ("実装して[ください]" etc.) plus a
+// standalone politeness marker, and common English imperative task verbs.
+const DEFAULT_TASK_REGEX_SOURCE =
+  '(?:(?:実装|作成|修正|追加|削除|リファクタ(?:リング)?|設計|書き直|直)して(?:ください)?' +
+  '|お願いします' +
+  '|\\b(?:implement|create|refactor|fix|design|build|write)\\b)';
+
+// Skill / prompt-authoring vocabulary — the domain prompt-conform itself targets.
+const DEFAULT_KEYWORD_REGEX_SOURCE =
+  '(?:skill|SKILL\\.md|slash\\s*command|prompt-conform' +
+  '|システムプロンプト|プロンプト(?:設計|作成|最適化|エンジニアリング)|指示文|エージェント定義|CLAUDE\\.md)';
+
+function warnOnce(message) {
+  process.stderr.write(`[prompt-conform-suggest] ${message}\n`);
+}
+
+/**
+ * Read `PROMPT_CONFORM_SUGGEST_MIN_LENGTH` / `_TASK_REGEX` / `_KEYWORD_REGEX`
+ * from env. Any missing or invalid value falls back to the built-in default
+ * (fail-open) rather than throwing.
+ *
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {{ minLength: number, taskRegex: RegExp, keywordRegex: RegExp }}
+ */
+function resolveConfig(env) {
+  let minLength = DEFAULT_MIN_LENGTH;
+  const rawMinLength = env.PROMPT_CONFORM_SUGGEST_MIN_LENGTH;
+  if (rawMinLength) {
+    const parsed = Number(rawMinLength);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      minLength = parsed;
+    } else {
+      warnOnce(`ignoring invalid PROMPT_CONFORM_SUGGEST_MIN_LENGTH: ${rawMinLength}`);
+    }
+  }
+
+  return {
+    minLength,
+    taskRegex: buildRegex(env.PROMPT_CONFORM_SUGGEST_TASK_REGEX, DEFAULT_TASK_REGEX_SOURCE, 'PROMPT_CONFORM_SUGGEST_TASK_REGEX'),
+    keywordRegex: buildRegex(
+      env.PROMPT_CONFORM_SUGGEST_KEYWORD_REGEX,
+      DEFAULT_KEYWORD_REGEX_SOURCE,
+      'PROMPT_CONFORM_SUGGEST_KEYWORD_REGEX'
+    ),
+  };
+}
+
+function buildRegex(fromEnv, defaultSource, envVarName) {
+  if (fromEnv) {
+    try {
+      return new RegExp(fromEnv, 'i');
+    } catch (err) {
+      warnOnce(`ignoring invalid ${envVarName} regex: ${err.message}`);
+    }
+  }
+  return new RegExp(defaultSource, 'i');
+}
+
+/**
+ * @param {unknown} promptText
+ * @param {{ minLength: number, taskRegex: RegExp, keywordRegex: RegExp }} config
+ * @returns {boolean}
+ */
+function isOptimizationWorthy(promptText, config) {
+  if (typeof promptText !== 'string') {
+    return false;
+  }
+  if (promptText.length < config.minLength) {
+    return false;
+  }
+  return config.taskRegex.test(promptText) || config.keywordRegex.test(promptText);
+}
+
+const SUGGESTION_MESSAGE =
+  'このプロンプトは分量が多くタスク性が強いため、実行前に $prompt-conform でのプロンプト最適化をユーザーに提案することを検討してください。' +
+  '有用と判断した場合は AskUserQuestion 等でユーザーに実行可否を確認し、ユーザーが明示的に希望した場合のみ実行してください。' +
+  'ユーザーが急いでいる、または最適化が不要と判断できる場合は提案を省略して構いません。';
+
+/**
+ * @param {string} rawInput
+ * @returns {string} stdout content (empty string = silent pass-through)
+ */
+function run(rawInput) {
+  let input = null;
+  try {
+    input = JSON.parse(rawInput);
+  } catch {
+    return '';
+  }
+
+  const config = resolveConfig(process.env);
+  const prompt = input && input.prompt;
+
+  if (!isOptimizationWorthy(prompt, config)) {
+    return '';
+  }
+
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'UserPromptSubmit',
+      additionalContext: SUGGESTION_MESSAGE,
+    },
+  });
+}
+
+// Write stdout and exit only once the buffer is fully flushed — see the same
+// rationale in home/dot_claude/hooks-fork/governance-capture.js (a bare
+// process.exit() after a write can truncate output larger than the OS pipe
+// buffer). Output here is always small, but the safe pattern costs nothing.
+function writeAndExit(output) {
+  process.exitCode = 0;
+  if (!output) {
+    process.exit(0);
+    return;
+  }
+  try {
+    process.stdout.write(output, () => process.exit(0));
+  } catch {
+    process.exit(0);
+  }
+}
+
+if (require.main === module) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      raw += chunk.substring(0, MAX_STDIN - raw.length);
+    }
+  });
+  process.stdin.on('error', () => {
+    writeAndExit('');
+  });
+  process.stdin.on('end', () => {
+    let output = '';
+    try {
+      output = run(raw);
+    } catch (err) {
+      warnOnce(`unexpected error: ${err.message}`);
+      output = '';
+    }
+    writeAndExit(output);
+  });
+}
+
+module.exports = { resolveConfig, isOptimizationWorthy, run };

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -150,7 +150,6 @@
     ],
     "UserPromptSubmit": [
       {
-        "matcher": "*",
         "hooks": [
           {
             "type": "command",
@@ -158,7 +157,7 @@
             "timeout": 5
           }
         ],
-        "description": "Detect optimization-worthy (long, task-shaped) prompts and inject additionalContext suggesting $prompt-conform before execution (task #367). Tunable via PROMPT_CONFORM_SUGGEST_MIN_LENGTH / PROMPT_CONFORM_SUGGEST_TASK_REGEX / PROMPT_CONFORM_SUGGEST_KEYWORD_REGEX env vars; falls back to built-in defaults on invalid overrides. Fail-open: never blocks prompt submission.",
+        "description": "Detect optimization-worthy (long, task-shaped) prompts and inject additionalContext suggesting $prompt-conform before execution (task #367). No `matcher` field: UserPromptSubmit does not support matchers per the official Hooks reference and always fires on every prompt. Tunable via PROMPT_CONFORM_SUGGEST_MIN_LENGTH / PROMPT_CONFORM_SUGGEST_TASK_REGEX / PROMPT_CONFORM_SUGGEST_KEYWORD_REGEX env vars; falls back to built-in defaults on invalid overrides. Fail-open: never blocks prompt submission.",
         "id": "user-prompt-submit:prompt-conform-suggest"
       }
     ],

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -148,6 +148,20 @@
         "id": "session:start:clv2-notify"
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$HOME/.claude/hooks-fork/prompt-conform-suggest.js\"",
+            "timeout": 5
+          }
+        ],
+        "description": "Detect optimization-worthy (long, task-shaped) prompts and inject additionalContext suggesting $prompt-conform before execution (task #367). Tunable via PROMPT_CONFORM_SUGGEST_MIN_LENGTH / PROMPT_CONFORM_SUGGEST_TASK_REGEX / PROMPT_CONFORM_SUGGEST_KEYWORD_REGEX env vars; falls back to built-in defaults on invalid overrides. Fail-open: never blocks prompt submission.",
+        "id": "user-prompt-submit:prompt-conform-suggest"
+      }
+    ],
     "PreCompact": [
       {
         "matcher": "*",

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1223,6 +1223,7 @@ FAKE_CLAUDE
 }
 
 @test "prompt-conform-suggest triggers on a long JP task-shaped prompt" {
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
   local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
   local prompt='ユーザー認証機能を実装してください。要件は以下の通りです。メールアドレスとパスワードでログインできること。セッションはJWTで管理すること。パスワードはbcryptでハッシュ化すること。ログイン失敗時は適切なエラーメッセージを返すこと。既存のミドルウェアとの統合方法も検討し、テストも一緒に書いてください。ドキュメントの更新も忘れずにお願いします。'
   local out
@@ -1232,11 +1233,20 @@ FAKE_CLAUDE
 }
 
 @test "prompt-conform-suggest triggers on a long EN task-shaped prompt" {
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
   local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
   local prompt='Please implement a new caching layer for the API responses. It should support TTL-based eviction, be pluggable so we can swap Redis for an in-memory store in tests, and include unit tests covering the eviction edge cases as well as documentation for future maintainers.'
   local out
   out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:process.argv[1]}))' "$prompt" | node "$hook")
   [ "$(echo "$out" | jq -r '.hookSpecificOutput.hookEventName')" = "UserPromptSubmit" ]
+}
+
+@test "prompt-conform-suggest triggers on a long prompt matching only the keyword regex (no task verb)" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  local prompt='新しい SKILL.md の設計について相談したいです。プロンプトエンジニアリングの観点から、既存のエージェント定義との整合性やシステムプロンプトとの重複をどう避けるか、指示文の粒度をどう決めるか、命名規則をどう統一するかなど、検討すべき論点が多くあります。実装方針が固まる前に一度目線を揃えたいです。'
+  local out
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:process.argv[1]}))' "$prompt" | node "$hook")
+  [ -n "$out" ]
 }
 
 @test "prompt-conform-suggest is silent on a short conversational prompt" {
@@ -1253,11 +1263,41 @@ FAKE_CLAUDE
   [ -z "$out" ]
 }
 
-@test "prompt-conform-suggest fails open on malformed stdin JSON" {
+# Regression guard for a false positive found in review: a bare \b(verb)\b match
+# anywhere in the string fired on ordinary questions that merely contain a task
+# verb mid-sentence, not as an imperative directive.
+@test "prompt-conform-suggest is silent on a long EN question that merely contains a task verb" {
   local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
-  run bash -c "printf 'not json' | node \"$hook\""
+  local prompt='How should I write a good commit message for a large refactor that touches many files across the repository and changes the public API surface in several places, while keeping the history readable for future maintainers?'
+  local out
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:process.argv[1]}))' "$prompt" | node "$hook")
+  [ -z "$out" ]
+}
+
+# Regression guard for a false positive found in review: a standalone politeness
+# marker ("お願いします") is not a task-request shape and must not fire on a long
+# question that has no imperative verb.
+@test "prompt-conform-suggest is silent on a long JP question closed with a bare politeness marker" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  local prompt='先日リリースしたバージョンでユーザーからいくつか問い合わせが来ているのですが、ログを見る限り原因の切り分けが難しく、どこから調査を始めるのが良さそうか、これまでの経験に基づいたアドバイスをいただけると非常に助かります。あくまで一般論としての意見で構いませんので、お忙しいところ大変恐縮ですが、何卒よろしくお願いします。'
+  local out
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:process.argv[1]}))' "$prompt" | node "$hook")
+  [ -z "$out" ]
+}
+
+@test "prompt-conform-suggest is silent when the prompt field is missing" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  local out
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit"}))' | node "$hook")
+  [ -z "$out" ]
+}
+
+@test "prompt-conform-suggest fails open on malformed stdin JSON and logs to stderr" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  run --separate-stderr bash -c "printf 'not json' | node \"$hook\""
   [ "$status" -eq 0 ]
   [ -z "$output" ]
+  [[ "$stderr" == *"failed to parse stdin"* ]]
 }
 
 @test "prompt-conform-suggest honours a PROMPT_CONFORM_SUGGEST_MIN_LENGTH override" {
@@ -1266,6 +1306,16 @@ FAKE_CLAUDE
   out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:"直してください"}))' \
     | PROMPT_CONFORM_SUGGEST_MIN_LENGTH=5 node "$hook")
   [ -n "$out" ]
+}
+
+@test "prompt-conform-suggest falls back to the default min length on a non-integer override" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  local out err
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:"skill"}))' \
+    | PROMPT_CONFORM_SUGGEST_MIN_LENGTH=0.5 node "$hook" 2>"${BATS_TEST_TMPDIR}/stderr.log")
+  err=$(cat "${BATS_TEST_TMPDIR}/stderr.log")
+  [ -z "$out" ]
+  [[ "$err" == *"ignoring invalid PROMPT_CONFORM_SUGGEST_MIN_LENGTH"* ]]
 }
 
 @test "prompt-conform-suggest falls back to the built-in task regex on an invalid override" {
@@ -1279,14 +1329,29 @@ FAKE_CLAUDE
   [[ "$err" == *"ignoring invalid PROMPT_CONFORM_SUGGEST_TASK_REGEX regex"* ]]
 }
 
+@test "prompt-conform-suggest applies a valid PROMPT_CONFORM_SUGGEST_TASK_REGEX override" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  # "hogehoge" matches neither the default task nor keyword regex, so this proves
+  # the override — not the built-in default — is what triggers the match.
+  local prompt="hogehoge $(printf 'x%.0s' {1..150})"
+  local out
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:process.argv[1]}))' "$prompt" \
+    | PROMPT_CONFORM_SUGGEST_TASK_REGEX='hogehoge' node "$hook")
+  [ -n "$out" ]
+}
+
 @test "settings.json wires the prompt-conform-suggest UserPromptSubmit hook" {
+  command -v jq >/dev/null 2>&1 || skip "jq unavailable"
   local settings="${HOME_DIR}/dot_claude/settings.json"
   local hook
   hook=$(jq -r '.hooks.UserPromptSubmit[]? | select(.id == "user-prompt-submit:prompt-conform-suggest")' "$settings")
   [ -n "$hook" ]
-  [ "$(echo "$hook" | jq -r '.matcher')" = "*" ]
+  # UserPromptSubmit does not support `matcher` (silently ignored per the
+  # official Hooks reference), so this entry intentionally omits it.
+  [ "$(echo "$hook" | jq -r '.matcher')" = "null" ]
   [ "$(echo "$hook" | jq -r '.hooks[0].command')" = 'node "$HOME/.claude/hooks-fork/prompt-conform-suggest.js"' ]
-  [ "$(echo "$hook" | jq -r '.hooks[0].timeout')" -le 30 ]
+  [ "$(echo "$hook" | jq -r '.hooks[0].timeout')" -eq 5 ]
+  [[ "$(echo "$hook" | jq -r '.description')" == *"PROMPT_CONFORM_SUGGEST_MIN_LENGTH"* ]]
 }
 
 @test "1password-backed secret template exists" {

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1216,6 +1216,79 @@ FAKE_CLAUDE
   [ "$perms" = "600" ]       # owner-only permissions
 }
 
+@test "prompt-conform-suggest hook exists and passes node syntax check" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  [ -f "$hook" ]
+  node --check "$hook"
+}
+
+@test "prompt-conform-suggest triggers on a long JP task-shaped prompt" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  local prompt='ユーザー認証機能を実装してください。要件は以下の通りです。メールアドレスとパスワードでログインできること。セッションはJWTで管理すること。パスワードはbcryptでハッシュ化すること。ログイン失敗時は適切なエラーメッセージを返すこと。既存のミドルウェアとの統合方法も検討し、テストも一緒に書いてください。ドキュメントの更新も忘れずにお願いします。'
+  local out
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:process.argv[1]}))' "$prompt" | node "$hook")
+  [ "$(echo "$out" | jq -r '.hookSpecificOutput.hookEventName')" = "UserPromptSubmit" ]
+  [ -n "$(echo "$out" | jq -r '.hookSpecificOutput.additionalContext')" ]
+}
+
+@test "prompt-conform-suggest triggers on a long EN task-shaped prompt" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  local prompt='Please implement a new caching layer for the API responses. It should support TTL-based eviction, be pluggable so we can swap Redis for an in-memory store in tests, and include unit tests covering the eviction edge cases as well as documentation for future maintainers.'
+  local out
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:process.argv[1]}))' "$prompt" | node "$hook")
+  [ "$(echo "$out" | jq -r '.hookSpecificOutput.hookEventName')" = "UserPromptSubmit" ]
+}
+
+@test "prompt-conform-suggest is silent on a short conversational prompt" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  local out
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:"ありがとうございます、完璧です"}))' | node "$hook")
+  [ -z "$out" ]
+}
+
+@test "prompt-conform-suggest is silent on a long prompt with no task/keyword shape" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  local out
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:"A".repeat(300)}))' | node "$hook")
+  [ -z "$out" ]
+}
+
+@test "prompt-conform-suggest fails open on malformed stdin JSON" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  run bash -c "printf 'not json' | node \"$hook\""
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "prompt-conform-suggest honours a PROMPT_CONFORM_SUGGEST_MIN_LENGTH override" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  local out
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:"直してください"}))' \
+    | PROMPT_CONFORM_SUGGEST_MIN_LENGTH=5 node "$hook")
+  [ -n "$out" ]
+}
+
+@test "prompt-conform-suggest falls back to the built-in task regex on an invalid override" {
+  local hook="${HOME_DIR}/dot_claude/hooks-fork/prompt-conform-suggest.js"
+  local prompt='ユーザー認証機能を実装してください。要件は以下の通りです。メールアドレスとパスワードでログインできること。セッションはJWTで管理すること。パスワードはbcryptでハッシュ化すること。ログイン失敗時は適切なエラーメッセージを返すこと。既存のミドルウェアとの統合方法も検討し、テストも一緒に書いてください。ドキュメントの更新も忘れずにお願いします。'
+  local out err
+  out=$(node -e 'process.stdout.write(JSON.stringify({hook_event_name:"UserPromptSubmit",prompt:process.argv[1]}))' "$prompt" \
+    | PROMPT_CONFORM_SUGGEST_TASK_REGEX='(' node "$hook" 2>"${BATS_TEST_TMPDIR}/stderr.log")
+  err=$(cat "${BATS_TEST_TMPDIR}/stderr.log")
+  [ -n "$out" ]
+  [[ "$err" == *"ignoring invalid PROMPT_CONFORM_SUGGEST_TASK_REGEX regex"* ]]
+}
+
+@test "settings.json wires the prompt-conform-suggest UserPromptSubmit hook" {
+  local settings="${HOME_DIR}/dot_claude/settings.json"
+  local hook
+  hook=$(jq -r '.hooks.UserPromptSubmit[]? | select(.id == "user-prompt-submit:prompt-conform-suggest")' "$settings")
+  [ -n "$hook" ]
+  [ "$(echo "$hook" | jq -r '.matcher')" = "*" ]
+  [ "$(echo "$hook" | jq -r '.hooks[0].command')" = 'node "$HOME/.claude/hooks-fork/prompt-conform-suggest.js"' ]
+  [ "$(echo "$hook" | jq -r '.hooks[0].timeout')" -le 30 ]
+}
+
 @test "1password-backed secret template exists" {
   [ -f "${HOME_DIR}/private_dot_aws/config.tmpl" ]
 }


### PR DESCRIPTION
## 概要

`UserPromptSubmit` hook を新設し、最適化価値のありそうな（長くタスク性の強い）プロンプトを検知して、`$prompt-conform` の実行を Claude に提案させる `additionalContext` を注入する。

## 背景

`UserPromptSubmit` は対話的なゲートを直接実装できず、`additionalContext` の注入かプロンプトの hard-block しかできない。そこで `model-fitness-check` と同じ「detect → inject → offer（Claude が提案）」設計を採用する。毎プロンプト発火はノイズが多いとして却下されているため、条件付き検知とする（Issue #367 背景）。

## 変更内容

- `home/dot_claude/hooks-fork/prompt-conform-suggest.js` を新設。長さ閾値（既定150文字）AND（タスク要求の形状 OR skill/プロンプト作成系キーワード）の2段階ヒューリスティックで検知する。マッチ時のみ `hookSpecificOutput.additionalContext` を stdout へ出力し、それ以外は silent に通過させる。
- 検知パターンは `PROMPT_CONFORM_SUGGEST_MIN_LENGTH` / `PROMPT_CONFORM_SUGGEST_TASK_REGEX` / `PROMPT_CONFORM_SUGGEST_KEYWORD_REGEX` の env 変数でチューニング可能（`GATEGUARD_BASH_EXTRA_DESTRUCTIVE` と同じ fail-open フォールバックパターン）。
- `home/dot_claude/settings.json` の `hooks.UserPromptSubmit`（従来0件）に配線（`timeout: 5`、fail-open な旨を description に明記）。
- `tests/files.bats` に trigger/non-trigger 両ケース・fail-open 経路・env override・settings.json 配線の検証を追加。

## Acceptance Criteria（Issue #367 より）

- [x] 長いタスク性プロンプトは可視の prompt-conform 提案（`additionalContext`）をトリガーする。短い会話的プロンプトはトリガーしない。
- [x] hook は正規表現マッチのみの軽量処理で、`UserPromptSubmit` の30秒制限に対し体感遅延を追加しない（`timeout: 5` を明示設定）。

## 関連

- Closes #367
- Related: #366（`prompt-conform` skill 本体の拡張。本 PR はその実行を hook 経由で自動提案する別レイヤ）

## テスト

- `make test-bats`: 284/284 pass
- `make lint`: pass
