### PR TITLE
feat(knowledge-distill): 週次 launchd エージェントで自動実行し ntfy 通知する

### DIFF
--- a/docs/architecture/notifications.ja.md
+++ b/docs/architecture/notifications.ja.md
@@ -11,13 +11,15 @@ tailnet 上のデバイスから subscribe されます（kryota-dev/dotfiles#33
 `.claude/prds/337-ntfy-tailscale.prd.md` にあります。
 
 **スコープの境界**: このページが扱うのは Claude Code の `Notification`/`Stop` フックから
-ntfy への経路に加え、平日朝ブリーフの配信（#361）です。本システムが意図的に手を付けて
-いない独立したローカル限定の通知経路が他に2つあります: `clv2-session-notify.sh`
-（SessionStart、instinct クラスターのレビュー促し）と `notify` zsh エイリアス（可聴チャイム。
-本システムの wrapper も失敗時のアラート音として再利用しています）。`morning-radar.sh`
-（launchd、平日ブリーフ）は以前はローカル `osascript` で通知していましたが、現在はブリーフを
-tailnet の HTML ページにレンダリングし、それにリンクする ntfy 通知を送ります —— 下記
-[朝ブリーフの配信](#朝ブリーフの配信-361)を参照。
+ntfy への経路に加え、平日朝ブリーフの配信（#361）と週次 knowledge-distill 配信（#368）です。
+本システムが意図的に手を付けていない独立したローカル限定の通知経路が他に2つあります:
+`clv2-session-notify.sh`（SessionStart、instinct クラスターのレビュー促し）と `notify` zsh
+エイリアス（可聴チャイム。両方の wrapper も失敗時のアラート音として再利用しています）。
+`morning-radar.sh`（launchd、平日ブリーフ）は以前はローカル `osascript` で通知していましたが、
+現在はブリーフを tailnet の HTML ページにレンダリングし、それにリンクする ntfy 通知を送ります
+—— 下記[朝ブリーフの配信](#朝ブリーフの配信-361)を参照。`knowledge-distill-radar.sh`
+（launchd、週次）はレンダリングされたページを持たないプレーンテキストの ntfy 通知を送ります
+—— 下記[週次 knowledge-distill 配信](#週次-knowledge-distill-配信-368)を参照。
 
 ## アーキテクチャ
 
@@ -66,7 +68,7 @@ phones/tablets on the tailnet (username/password login)
 
 | Topic | Events | Priority | Intended device setting |
 |-------|--------|----------|------------------------|
-| `claude-attention` | permission_prompt, idle_prompt, agent_needs_input | high (4) | sound/vibrate on |
+| `claude-attention` | permission_prompt, idle_prompt, agent_needs_input, weekly knowledge-distill radar (#368) | high (4) | sound/vibrate on |
 | `claude-done` | agent_completed, Stop | default (3) | silent delivery |
 | `claude-brief` | weekday morning brief (morning-radar, #361) | default (3) | mute optional |
 | `claude-test` | manual smoke tests | — | mute after testing |
@@ -119,6 +121,44 @@ Smoke test（オンデマンドでブリーフを publish）:
 BASE="https://$(tailscale status --json | jq -r .Self.DNSName | sed 's/\.$//'):8443"
 curl -sI "$BASE/$(date +%F).html" | head -1   # 期待: HTTP/… 200
 tailscale funnel status                        # 期待: 何も serve していない（tailnet-only）
+```
+
+## 週次 knowledge-distill 配信 (#368)
+
+`knowledge-distill` skill（`home/dot_agents/skills/knowledge-distill/SKILL.md`）は、
+CLV2 継続学習ループを週次で診断し、昇華提案（evolved skill 化・curated skill 改修・memory
+追加・ルール化）を行います。cron 化は skill 上でユーザー承認待ちとして明示的にスコープ外に
+されていましたが、2026-07-26 に承認され（週次 cadence）、`dev.kryota.knowledge-distill`
+LaunchAgent（金曜 18:00 ローカル時刻）が現在これを headless で実行します。
+`dev.kryota.morning-radar` パターン（#257）を踏襲しつつ、よりシンプルです:
+レンダリングされたページも click URL も無く、既存の `claude-attention` トピックへの
+テキストサマリー publish のみです（専用トピックは追加していません）。
+
+- **Precheck**: claude を起動する前に、wrapper が `$CLV2_HOMUNCULUS_DIR/instincts/personal/`
+  （skill 自身の Phase 0 と同じ fallback、`~/.local/share/ecc-homunculus-default`）配下の
+  instinct 蓄積数を数え、skill 自身の `--min-instincts` 既定値（10）と比較します。この
+  dry/healthy 判定は**claude 自身の自由記述レスポンスから独立して**行われるため、instinct
+  蓄積が不足した週が静かに通常週として報告されることはありません —— 通知は常にその旨を
+  明示します（`[縮退] instinct N/10 — ...`）。
+- **レポート**: どちらの場合でも skill 自体は実行され（dry の週でも skill 自身の Phase 0/1
+  縮退診断レポートが生成されます）、`~/dotfiles/.kryota-dev/knowledge-distill/<YYYY-Www>.md`
+  に書き込まれます。wrapper はレポートファイルが空でないことを検証してから週のスタンプを
+  書き込みます —— 同週ガード・watchdog・スタンプの意味論は morning-radar の同日ガードと
+  同じです。
+- **権限**: headless の `--allowedTools` は `Skill(knowledge-distill)`、skill 自身の
+  Phase 0/2 診断に対応する read-only Bash prefix（`ls`/`cat`/`date`/`jq`/`grep`/`find`/
+  `head`/`tail`/`wc`/`ghq list`/`instinct-cli.py evolve` 呼び出し）、
+  `Edit(~/dotfiles/.kryota-dev/knowledge-distill/**)` に限定されます。昇華提案の適用は
+  引き続き手動です —— wrapper も skill も自身の昇華提案を自動適用することはありません。
+- **通知**: 成功時、`claude-attention` は priority 3（default）で `HEADLINE` を受け取り、
+  precheck が dry pipeline と判定した場合は `[縮退]` と instinct 数のプレフィックスが
+  付きます。エラー経路（claude 不在 / timeout / 非 0 exit / レポートファイル欠損）は
+  priority 5 で publish されます（morning-radar のエラー時と同じ規約）。
+
+Smoke test（オンデマンドで今週のレポートを publish）:
+
+```bash
+~/.claude/knowledge-distill-radar.sh --force   # 課金される実行 1 回。claude-attention に通知
 ```
 
 ## セットアップ手順（初回のみ）

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -9,14 +9,18 @@ persistent, remotely subscribable notifications. The finalized decision record l
 in `.claude/prds/337-ntfy-tailscale.prd.md`.
 
 **Scope boundary**: this page covers the Claude Code `Notification`/`Stop`
-hook → ntfy path plus the weekday morning-brief delivery (#361). Two other
-independent local-only notification paths are deliberately left untouched:
-`clv2-session-notify.sh` (SessionStart, instinct-cluster review nudge) and the
-`notify` zsh alias (audible chime, also reused by this system's wrapper as its
-failure alert sound). `morning-radar.sh` (launchd, weekday brief) used to notify
-via local `osascript`; it now renders the brief to a tailnet HTML page and sends
-an ntfy notification that links to it —
+hook → ntfy path plus the weekday morning-brief delivery (#361) and the weekly
+knowledge-distill delivery (#368). Two other independent local-only
+notification paths are deliberately left untouched: `clv2-session-notify.sh`
+(SessionStart, instinct-cluster review nudge) and the `notify` zsh alias
+(audible chime, also reused by both wrappers as their failure alert sound).
+`morning-radar.sh` (launchd, weekday brief) used to notify via local
+`osascript`; it now renders the brief to a tailnet HTML page and sends an ntfy
+notification that links to it —
 see [Morning-brief delivery](#morning-brief-delivery-361) below.
+`knowledge-distill-radar.sh` (launchd, weekly) sends a plain-text ntfy
+notification with no rendered page —
+see [Weekly knowledge-distill delivery](#weekly-knowledge-distill-delivery-368) below.
 
 ## Architecture
 
@@ -66,7 +70,7 @@ phones/tablets on the tailnet (username/password login)
 
 | Topic | Events | Priority | Intended device setting |
 |-------|--------|----------|------------------------|
-| `claude-attention` | permission_prompt, idle_prompt, agent_needs_input | high (4) | sound/vibrate on |
+| `claude-attention` | permission_prompt, idle_prompt, agent_needs_input, weekly knowledge-distill radar (#368) | high (4) | sound/vibrate on |
 | `claude-done` | agent_completed, Stop | default (3) | silent delivery |
 | `claude-brief` | weekday morning brief (morning-radar, #361) | default (3) | mute optional |
 | `claude-test` | manual smoke tests | — | mute after testing |
@@ -127,6 +131,51 @@ Smoke test (publish the current brief on demand):
 BASE="https://$(tailscale status --json | jq -r .Self.DNSName | sed 's/\.$//'):8443"
 curl -sI "$BASE/$(date +%F).html" | head -1   # expect: HTTP/… 200
 tailscale funnel status                        # expect: nothing served (tailnet-only)
+```
+
+## Weekly knowledge-distill delivery (#368)
+
+The `knowledge-distill` skill (`home/dot_agents/skills/knowledge-distill/SKILL.md`)
+diagnoses the CLV2 continuous-learning loop weekly and proposes promotions
+(evolved skills, curated-skill fixes, memory entries, rules). Cron automation
+was explicitly scoped out of the skill pending user approval; approval was
+given on 2026-07-26 (weekly cadence), and the `dev.kryota.knowledge-distill`
+LaunchAgent (Friday 18:00 local time) now runs it headless, following the
+`dev.kryota.morning-radar` pattern (#257) but simpler: no rendered page, no
+click URL — just a text summary published to the existing `claude-attention`
+topic (no dedicated topic was added).
+
+- **Precheck**: before invoking claude at all, the wrapper counts accumulated
+  instincts under `$CLV2_HOMUNCULUS_DIR/instincts/personal/` (same fallback as
+  the skill's own Phase 0, `~/.local/share/ecc-homunculus-default`) and
+  compares against the skill's own `--min-instincts` default (10). This dry/
+  healthy determination is made **independently of claude's own free-text
+  response**, so a week with an under-accumulated pipeline is never silently
+  reported as a normal week — the notification always says so explicitly
+  (`[縮退] instinct N/10 — ...`).
+- **Report**: the skill still runs either way (a dry week still gets the
+  skill's own Phase 0/1 degraded diagnostic report) and writes to
+  `~/dotfiles/.kryota-dev/knowledge-distill/<YYYY-Www>.md`. The wrapper
+  verifies the report file is non-empty before stamping the week done — the
+  same-week guard, watchdog, and stamp semantics all mirror morning-radar's
+  same-day guard.
+- **Permissions**: headless `--allowedTools` is confined to
+  `Skill(knowledge-distill)`, read-only Bash prefixes matching the skill's own
+  Phase 0/2 diagnostics (`ls`/`cat`/`date`/`jq`/`grep`/`find`/`head`/`tail`/
+  `wc`/`ghq list`/the `instinct-cli.py evolve` invocation), and
+  `Edit(~/dotfiles/.kryota-dev/knowledge-distill/**)`. Proposal application
+  remains manual — neither the wrapper nor the skill ever applies its own
+  promotions.
+- **Notification**: on success, `claude-attention` receives the `HEADLINE` at
+  priority 3 (default), prefixed with `[縮退]` and the instinct count when the
+  precheck found a dry pipeline. Error paths (claude missing / timeout /
+  non-zero exit / report file missing) publish at priority 5, the same
+  convention morning-radar uses for errors.
+
+Smoke test (publish the current week's report on demand):
+
+```bash
+~/.claude/knowledge-distill-radar.sh --force   # one billed run; notifies claude-attention
 ```
 
 ## Setup runbook (one-time)

--- a/home/Library/LaunchAgents/dev.kryota.knowledge-distill.plist.tmpl
+++ b/home/Library/LaunchAgents/dev.kryota.knowledge-distill.plist.tmpl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Weekly knowledge-distill radar (kryota-dev/dotfiles#368).
+  Fires the knowledge-distill headless wrapper at 18:00 local time on
+  Fridays. Local time is assumed to be JST on this machine. launchd coalesces
+  fires missed while asleep into one run on wake; the wrapper's own same-week
+  guard then keeps a later manual/coalesced run from double-billing.
+  Registered/reloaded by run_onchange_after_30-register-launchd-agents.sh.tmpl.
+  RunAtLoad is intentionally absent (defaults to false) so registration itself
+  never triggers a billed run.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.kryota.knowledge-distill</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{ .chezmoi.homeDir }}/.claude/knowledge-distill-radar.sh</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Weekday</key>
+    <integer>5</integer>
+    <key>Hour</key>
+    <integer>18</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>WorkingDirectory</key>
+  <string>{{ .chezmoi.homeDir }}/dotfiles</string>
+  <key>StandardOutPath</key>
+  <string>{{ .chezmoi.homeDir }}/Library/Logs/dev.kryota.knowledge-distill.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{ .chezmoi.homeDir }}/Library/Logs/dev.kryota.knowledge-distill.log</string>
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>

--- a/home/dot_agents/skills/knowledge-distill/SKILL.md
+++ b/home/dot_agents/skills/knowledge-distill/SKILL.md
@@ -123,5 +123,9 @@ CLV2_HOMUNCULUS_DIR="$H" python3 ~/.agents/skills/continuous-learning-v2/scripts
 
 ## 運用メモ
 
-- 推奨リズム: 週 1 回（金曜夕方 or 月曜朝）。morning-brief / worklog と同じ朝ルーチンに組み込める。
-- 定期自動実行（cron）は本 skill の範囲外。載せる場合は課金を伴うため、ユーザーの明示承認で別途設定する。
+- 週次自動実行: `dev.kryota.knowledge-distill` launchd エージェント（金曜 18:00 JST、
+  `home/dot_claude/executable_knowledge-distill-radar.sh`）が headless で本 skill を起動し、
+  CLV2 パイプラインの健全性（instinct 蓄積数）を独立に precheck した上でレポート要約を
+  ntfy（`claude-attention`）へ通知する（kryota-dev/dotfiles#368、2026-07-26 承認）。
+  詳細は `docs/architecture/notifications.md` の「Weekly knowledge-distill delivery」節を参照。
+  手動実行（`--week=last` での過去週再確認等）も引き続き可能。

--- a/home/dot_claude/executable_knowledge-distill-radar.sh
+++ b/home/dot_claude/executable_knowledge-distill-radar.sh
@@ -39,16 +39,21 @@ MIN_INSTINCTS="${KNOWLEDGE_DISTILL_RADAR_MIN_INSTINCTS:-10}"
 HOMUNCULUS_DIR="${CLV2_HOMUNCULUS_DIR:-$HOME/.local/share/ecc-homunculus-default}"
 # Least-privilege allowlist (read-mostly design, #368): the skill's Phase 0/2
 # diagnostics run as individual read-only commands (ls/cat/date/jq/grep/find/
-# head/tail/wc/ghq list) plus the instinct-cli.py evolve invocation. Because
-# CLV2_HOMUNCULUS_DIR is already exported into this process's environment (via
-# the claude launcher below), the headless prompt tells claude to reference it
-# directly rather than re-deriving it with a `H="${CLV2_HOMUNCULUS_DIR:-...}"`
-# assignment -- each diagnostic command then starts with its own binary name,
-# which is what the prefix-matched allow rules below actually match. Writes
-# are confined to this wrapper's own report dir (knowledge-distill never
-# applies its own proposals). Artifact is deliberately NOT granted (no page
-# delivery for this radar, unlike morning-radar's brief page).
-ALLOWED_TOOLS="Bash(ls:*),Bash(cat:*),Bash(date:*),Bash(jq:*),Bash(grep:*),Bash(find:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(ghq list:*),Bash(python3 ~/.agents/skills/continuous-learning-v2/scripts/instinct-cli.py:*),Read,Glob,Grep,Skill(knowledge-distill),Edit(~/dotfiles/.kryota-dev/knowledge-distill/**)"
+# head/tail/wc/printf/ghq list) plus the instinct-cli.py evolve invocation.
+# printf is required for Phase 0's mandatory ECC_OBSERVER_TIMEOUT_SECONDS
+# check. instinct-cli.py is scoped to the `evolve` subcommand only -- the CLI
+# also has `import`/`promote`/`prune`, which mutate or delete instinct state,
+# so a bare script-path wildcard would violate the read-mostly design (#388
+# review). Because CLV2_HOMUNCULUS_DIR is already exported into this
+# process's environment (via the claude launcher below), the headless prompt
+# tells claude to reference it directly rather than re-deriving it with a
+# `H="${CLV2_HOMUNCULUS_DIR:-...}"` assignment -- each diagnostic command then
+# starts with its own binary name, which is what the prefix-matched allow
+# rules below actually match. Writes are confined to this wrapper's own
+# report dir (knowledge-distill never applies its own proposals). Artifact is
+# deliberately NOT granted (no page delivery for this radar, unlike
+# morning-radar's brief page).
+ALLOWED_TOOLS="Bash(ls:*),Bash(cat:*),Bash(date:*),Bash(jq:*),Bash(grep:*),Bash(find:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(printf:*),Bash(ghq list:*),Bash(python3 ~/.agents/skills/continuous-learning-v2/scripts/instinct-cli.py evolve:*),Read,Glob,Grep,Skill(knowledge-distill),Edit(~/dotfiles/.kryota-dev/knowledge-distill/**)"
 
 log() {
   printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >>"$LOG_FILE" 2>/dev/null || true
@@ -166,7 +171,7 @@ main() {
 /knowledge-distill --week=this --min-instincts=${MIN_INSTINCTS} を headless 実行してください。
 - --dry-run は使わない。レポート全文を Write で ${REPORT_FILE} に保存する（同週ファイルが既に存在する場合、--force 再実行時は Read してから全文を上書き保存する）。
 - CLV2_HOMUNCULUS_DIR は既にこのプロセスの環境に export 済みです。SKILL.md の \`H="\${CLV2_HOMUNCULUS_DIR:-...}"\` という変数代入は行わず、\$CLV2_HOMUNCULUS_DIR を直接参照してください。
-- Phase 0 の各診断コマンド（jq/ls/grep/find/head/tail/wc/date 等）は 1 コマンド = 1 回の Bash 呼び出しとし、複数コマンドをセミコロンや && で連結しないでください。
+- Phase 0 の各診断コマンド（jq/ls/grep/find/head/tail/wc/date 等）は 1 コマンド = 1 回の Bash 呼び出しとし、複数コマンドをセミコロンや && で連結しないでください。Phase 2 の instinct-cli.py evolve 呼び出しも同様に、\`CLV2_HOMUNCULUS_DIR="\$H"\` のような prefix を付けず \`python3 ~/.agents/skills/continuous-learning-v2/scripts/instinct-cli.py evolve\` を単独のコマンドとして実行してください（\$CLV2_HOMUNCULUS_DIR は既に export 済みのため prefix は不要です）。
 - 昇華提案（evolved skill化・curated skill改修・memory追加・ルール化）はレポートへの提示のみとし、一切適用しない。
 - 最終応答は「HEADLINE: <一行要約>」形式の1行のみとする（例: "HEADLINE: 縮退終了（instinct 3件、閾値未満）" または "HEADLINE: 昇華提案 4件 / instinct 12件"）。
 EOF

--- a/home/dot_claude/executable_knowledge-distill-radar.sh
+++ b/home/dot_claude/executable_knowledge-distill-radar.sh
@@ -1,0 +1,271 @@
+#!/bin/bash
+# Weekly knowledge-distill radar wrapper (kryota-dev/dotfiles#368).
+# Launched by the dev.kryota.knowledge-distill LaunchAgent every Friday
+# evening. Runs /knowledge-distill headless on the personal Claude Code
+# account, prechecks CLV2 instinct accumulation independently of claude's own
+# free-text response (so a dry pipeline is never silently reported as a
+# normal week), and sends a one-line summary via ntfy. Proposal application
+# remains manual: this wrapper only ever triggers the skill's own report
+# generation, never applies any promotion.
+#
+# Source-safe: side effects live in main(), guarded by the BASH_SOURCE check
+# at the end, so tests can source this file and exercise ntfy_publish without
+# launching claude.
+set -euo pipefail
+
+LABEL="dev.kryota.knowledge-distill"
+LOG_FILE="${KNOWLEDGE_DISTILL_RADAR_LOG_FILE:-$HOME/Library/Logs/${LABEL}.log}"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/knowledge-distill-radar"
+REPORT_DIR="$HOME/dotfiles/.kryota-dev/knowledge-distill"
+# Publisher credentials + attention topic, written 0600 by ~/.config/ntfy/lib.sh
+# (#337/#357/#361). Overridable for tests. Sourced only inside a subshell so the
+# token never enters this script's (or claude's) environment.
+ENV_FILE="${KNOWLEDGE_DISTILL_RADAR_NTFY_ENV_FILE:-$HOME/.config/ntfy/notify-env}"
+# Overridable only so the bats main() integration tests can shorten the watchdog
+# (its backgrounded sleep would otherwise outlive the run); 600s in production.
+TIMEOUT_SECONDS="${KNOWLEDGE_DISTILL_RADAR_TIMEOUT_SECONDS:-600}"
+MAX_TURNS=50
+# Pinned model keeps the pre-approved weekly recurring cost predictable even
+# when the account's default model changes.
+CLAUDE_MODEL="sonnet"
+# Matches the skill's own --min-instincts default (SKILL.md), so the wrapper's
+# independent precheck and the skill's internal degradation threshold never
+# disagree (the wrapper passes this same value through explicitly, below).
+MIN_INSTINCTS="${KNOWLEDGE_DISTILL_RADAR_MIN_INSTINCTS:-10}"
+# Same fallback expression as knowledge-distill SKILL.md Phase 0. In
+# production CLV2_HOMUNCULUS_DIR is already exported by the ~/.local/launchers/
+# claude wrapper (personal account -> ecc-homunculus-default); overridable here
+# for test isolation.
+HOMUNCULUS_DIR="${CLV2_HOMUNCULUS_DIR:-$HOME/.local/share/ecc-homunculus-default}"
+# Least-privilege allowlist (read-mostly design, #368): the skill's Phase 0/2
+# diagnostics run as individual read-only commands (ls/cat/date/jq/grep/find/
+# head/tail/wc/ghq list) plus the instinct-cli.py evolve invocation. Because
+# CLV2_HOMUNCULUS_DIR is already exported into this process's environment (via
+# the claude launcher below), the headless prompt tells claude to reference it
+# directly rather than re-deriving it with a `H="${CLV2_HOMUNCULUS_DIR:-...}"`
+# assignment -- each diagnostic command then starts with its own binary name,
+# which is what the prefix-matched allow rules below actually match. Writes
+# are confined to this wrapper's own report dir (knowledge-distill never
+# applies its own proposals). Artifact is deliberately NOT granted (no page
+# delivery for this radar, unlike morning-radar's brief page).
+ALLOWED_TOOLS="Bash(ls:*),Bash(cat:*),Bash(date:*),Bash(jq:*),Bash(grep:*),Bash(find:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(ghq list:*),Bash(python3 ~/.agents/skills/continuous-learning-v2/scripts/instinct-cli.py:*),Read,Glob,Grep,Skill(knowledge-distill),Edit(~/dotfiles/.kryota-dev/knowledge-distill/**)"
+
+log() {
+  printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >>"$LOG_FILE" 2>/dev/null || true
+}
+
+# Publish a Markdown ntfy notification to the attention topic (fail-open).
+#   ntfy_publish <priority> <title> <message>
+# Unlike morning-radar's ntfy_publish, there is a single topic (claude-attention,
+# reused per intent-gate decision -- no dedicated topic for this radar) and no
+# click URL (this report has no rendered page). The env file is sourced inside
+# a subshell so NTFY_TOKEN never lands in this script's environment (and thus
+# never in the claude subprocess); the token reaches curl only through a 0600
+# `curl -K` config file, never argv/stdout/trace (mirrors
+# home/dot_claude/executable_ntfy-notify.sh; bats asserts this). The env file
+# must be owner-only (0600/0400) -- sourcing it is code execution, so a
+# group/other-accessible file fails open (same guard as ntfy-notify.sh).
+ntfy_publish() {
+  local priority="$1" title="$2" message="$3"
+  local env_mode
+  [ -f "$ENV_FILE" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  [ -O "$ENV_FILE" ] || return 0
+  if stat --version >/dev/null 2>&1; then
+    env_mode="$(stat -c '%a' "$ENV_FILE" 2>/dev/null || true)"
+  else
+    env_mode="$(stat -f '%Lp' "$ENV_FILE" 2>/dev/null || true)"
+  fi
+  case "$env_mode" in 600 | 400) ;; *) return 0 ;; esac
+  (
+    umask 077
+    # shellcheck source=/dev/null
+    . "$ENV_FILE" 2>/dev/null || exit 0
+    { [ -n "${NTFY_URL:-}" ] && [ -n "${NTFY_TOKEN:-}" ]; } || exit 0
+    topic="${NTFY_TOPIC_ATTENTION:-}"
+    [ -n "$topic" ] || exit 0
+    payload="$(jq -n --arg topic "$topic" --arg title "$title" \
+      --arg message "$message" --argjson priority "$priority" \
+      '{topic: $topic, title: $title, message: $message, priority: $priority,
+        tags: ["microscope", "knowledge-distill"]}')" || exit 0
+    curl_cfg="$(mktemp "${TMPDIR:-/tmp}/knowledge-distill-radar-ntfy.XXXXXX")" || exit 0
+    # EXIT alone misses signal deaths (the watchdog may kill us); cover the
+    # catchable signals so the token file never lingers.
+    trap 'rm -f "$curl_cfg"' EXIT INT TERM HUP
+    printf 'header = "Authorization: Bearer %s"\n' "$NTFY_TOKEN" >"$curl_cfg"
+    if ! printf '%s' "$payload" | curl -fs -K "$curl_cfg" --max-time 5 \
+      -o /dev/null -d @- "$NTFY_URL" 2>/dev/null; then
+      log "ntfy publish failed: topic=${topic} url=${NTFY_URL}"
+    fi
+  ) || true
+}
+
+# Error notification helper: high-priority attention topic.
+notify_error() {
+  ntfy_publish 5 "Knowledge Distill" "$1"
+}
+
+main() {
+  # launchd provides a minimal environment; build PATH ourselves so the claude wrapper, the
+  # mise-managed binaries (jq/python3), and curl resolve. ~/.local/launchers is first so `claude`
+  # hits the per-account wrapper (#345), which is also what exports CLV2_HOMUNCULUS_DIR for us.
+  export PATH="$HOME/.local/launchers:$HOME/.local/share/mise/shims:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+  [ "$(uname)" = "Darwin" ] || exit 0
+
+  mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR" "$REPORT_DIR"
+
+  # Run claude with the dotfiles repo as cwd (project trust + local context);
+  # direct invocations then behave identically to launchd's WorkingDirectory.
+  cd "$HOME/dotfiles"
+
+  # Rotate the log once it exceeds 1 MiB (weekly appends stay small).
+  if [ -f "$LOG_FILE" ] && [ "$(stat -f%z "$LOG_FILE")" -gt 1048576 ]; then
+    mv "$LOG_FILE" "${LOG_FILE}.old"
+  fi
+
+  # Same-week guard: launchd coalesces missed fires on wake, and kickstart can
+  # re-fire manually; one billed run per week is the approved budget (#368).
+  # --force bypasses for smoke tests and deliberate manual reruns. ISO week
+  # (%G-W%V) matches the skill's own <YYYY-Www> report file naming.
+  THIS_WEEK="$(date +%G-W%V)"
+  if [ "${1:-}" != "--force" ] && [ -f "$STATE_DIR/last-run" ] &&
+    [ "$(cat "$STATE_DIR/last-run")" = "$THIS_WEEK" ]; then
+    log "skip: already ran this week ($THIS_WEEK)"
+    exit 0
+  fi
+
+  if ! command -v claude >/dev/null 2>&1; then
+    log "error: claude not found on PATH"
+    notify_error "Knowledge distill failed: claude not found on PATH — log: $LOG_FILE"
+    exit 1
+  fi
+
+  # Precheck CLV2 pipeline health (#368): count accumulated instincts BEFORE
+  # invoking claude, independently of whatever claude's own free-text response
+  # says. This is the signal the ntfy notification uses to explicitly flag a
+  # dry week, rather than trusting claude's prose to convey it faithfully.
+  INSTINCT_DIR="$HOMUNCULUS_DIR/instincts/personal"
+  # `|| true` guards the assignment itself: under pipefail, `find` on a not-yet-
+  # created instincts dir (the exact "zero instincts accumulated" case this
+  # precheck exists to handle) exits non-zero even with stderr silenced, which
+  # would otherwise trip `set -e` and abort before ever reaching claude/notify.
+  INSTINCT_COUNT="$(find "$INSTINCT_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')" || true
+  DRY=0
+  if [ "$INSTINCT_COUNT" -lt "$MIN_INSTINCTS" ]; then
+    DRY=1
+    log "precheck: dry pipeline (instinct ${INSTINCT_COUNT}/${MIN_INSTINCTS})"
+  fi
+
+  REPORT_FILE="$REPORT_DIR/$THIS_WEEK.md"
+  # Prompt is Japanese to match the skill-steering language policy (the report
+  # itself is a Japanese artifact, matching the skill's own conventions).
+  PROMPT=$(
+    cat <<EOF
+/knowledge-distill --week=this --min-instincts=${MIN_INSTINCTS} を headless 実行してください。
+- --dry-run は使わない。レポート全文を Write で ${REPORT_FILE} に保存する（同週ファイルが既に存在する場合、--force 再実行時は Read してから全文を上書き保存する）。
+- CLV2_HOMUNCULUS_DIR は既にこのプロセスの環境に export 済みです。SKILL.md の \`H="\${CLV2_HOMUNCULUS_DIR:-...}"\` という変数代入は行わず、\$CLV2_HOMUNCULUS_DIR を直接参照してください。
+- Phase 0 の各診断コマンド（jq/ls/grep/find/head/tail/wc/date 等）は 1 コマンド = 1 回の Bash 呼び出しとし、複数コマンドをセミコロンや && で連結しないでください。
+- 昇華提案（evolved skill化・curated skill改修・memory追加・ルール化）はレポートへの提示のみとし、一切適用しない。
+- 最終応答は「HEADLINE: <一行要約>」形式の1行のみとする（例: "HEADLINE: 縮退終了（instinct 3件、閾値未満）" または "HEADLINE: 昇華提案 4件 / instinct 12件"）。
+EOF
+  )
+
+  STDOUT_FILE="$(mktemp -t knowledge-distill-radar)"
+  trap 'rm -f "$STDOUT_FILE"' EXIT
+
+  CLAUDE_ARGS=(--model "$CLAUDE_MODEL" --max-turns "$MAX_TURNS")
+  # Let the skill read other repos' session summaries under the ghq root
+  # (Phase 2 collects session-summary material via the same two paths as
+  # worklog: ghq list -p plus ~/worktrees/*/*/).
+  if [ -d "$HOME/ghq" ]; then
+    CLAUDE_ARGS+=(--add-dir "$HOME/ghq")
+  fi
+  # --allowedTools is variadic and would swallow a trailing positional prompt,
+  # so it stays a single comma-joined value and the prompt binds to -p below.
+  CLAUDE_ARGS+=(--allowedTools "$ALLOWED_TOOLS")
+
+  log "start: claude -p /knowledge-distill (model=$CLAUDE_MODEL, max-turns=$MAX_TURNS, dry=$DRY)"
+
+  # Launch through the claude wrapper (~/.local/launchers/claude, first on PATH above). It injects
+  # the personal account's isolation env -- CLAUDE_CONFIG_DIR/ECC_AGENT_DATA_HOME, the
+  # CLV2_HOMUNCULUS_DIR this wrapper's own precheck above also reads (#336, deliberately outside the
+  # config dir so no headless session need approve a write to it), and the observer knobs. That
+  # injection lives in one source (#345); this wrapper does not re-copy it. Setting
+  # CLAUDE_CONFIG_DIR explicitly pins the personal account (the wrapper keeps an explicit value via
+  # its fill-gaps rule). Exporting empty EXA/FIRECRAWL keys opts out of web search -- the wrapper's
+  # `+x` guard then skips sourcing the MCP-keys file -- since this radar does not need them.
+  CLAUDE_CONFIG_DIR="$HOME/.claude" \
+    EXA_API_KEY="" \
+    FIRECRAWL_API_KEY="" \
+    claude "${CLAUDE_ARGS[@]}" -p "$PROMPT" >"$STDOUT_FILE" 2>>"$LOG_FILE" &
+  CLAUDE_PID=$!
+
+  # Watchdog: TERM after TIMEOUT_SECONDS, KILL 10s later (runaway-billing
+  # guard on top of --max-turns).
+  (
+    sleep "$TIMEOUT_SECONDS"
+    if kill -0 "$CLAUDE_PID" 2>/dev/null; then
+      kill "$CLAUDE_PID" 2>/dev/null || true
+      sleep 10
+      kill -9 "$CLAUDE_PID" 2>/dev/null || true
+    fi
+  ) &
+  WATCHDOG_PID=$!
+
+  STATUS=0
+  wait "$CLAUDE_PID" || STATUS=$?
+  kill "$WATCHDOG_PID" 2>/dev/null || true
+
+  cat "$STDOUT_FILE" >>"$LOG_FILE"
+
+  if [ "$STATUS" -ne 0 ]; then
+    # 143 = SIGTERM, 137 = SIGKILL: treat both as the watchdog timeout.
+    if [ "$STATUS" -eq 143 ] || [ "$STATUS" -eq 137 ]; then
+      log "error: claude timed out after ${TIMEOUT_SECONDS}s (exit $STATUS)"
+      notify_error "Knowledge distill timed out (${TIMEOUT_SECONDS}s) — log: $LOG_FILE"
+    else
+      log "error: claude exited $STATUS"
+      notify_error "Knowledge distill failed (exit $STATUS) — log: $LOG_FILE"
+    fi
+    exit 1
+  fi
+
+  # Trailing `|| true` keeps a missing HEADLINE line from aborting the script
+  # here: grep exits 1 on no match, which pipefail + set -e would turn into a
+  # script-level exit, skipping the fallback and the notification below.
+  HEADLINE="$(grep -E '^HEADLINE:' "$STDOUT_FILE" | tail -1 | sed 's/^HEADLINE:[[:space:]]*//' || true)"
+  if [ -z "$HEADLINE" ]; then
+    HEADLINE="report generated (no headline)"
+  fi
+
+  # Verify the report before stamping the week done: a missing/empty file means the
+  # run broke its output contract, so treat it as a failure (notify + exit 1) and
+  # leave the stamp absent so the week stays retryable.
+  if [ ! -s "$REPORT_FILE" ]; then
+    log "error: report file missing or empty at $REPORT_FILE"
+    notify_error "Knowledge distill failed: report file missing — log: $LOG_FILE"
+    exit 1
+  fi
+
+  # Written only on success: a failed run leaves the stamp absent so the same
+  # week can be retried manually (the approved budget is one successful run/week).
+  printf '%s\n' "$THIS_WEEK" >"$STATE_DIR/last-run"
+
+  # DRY was computed independently of claude's response (precheck above), so the
+  # dry state is always surfaced explicitly regardless of how claude worded its
+  # own HEADLINE.
+  if [ "$DRY" -eq 1 ]; then
+    MESSAGE="[縮退] instinct ${INSTINCT_COUNT}/${MIN_INSTINCTS} — ${HEADLINE}"
+  else
+    MESSAGE="$HEADLINE"
+  fi
+
+  log "done: $MESSAGE"
+  ntfy_publish 3 "Knowledge Distill" "$MESSAGE"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/home/run_onchange_after_30-register-launchd-agents.sh.tmpl
+++ b/home/run_onchange_after_30-register-launchd-agents.sh.tmpl
@@ -1,10 +1,11 @@
 {{ if eq .chezmoi.os "darwin" -}}
 #!/bin/bash
-# Register repo-managed launchd LaunchAgents (kryota-dev/dotfiles#257).
-# Re-runs whenever a managed plist changes (embedded hash below). Wrapper
+# Register repo-managed launchd LaunchAgents (kryota-dev/dotfiles#257, #368).
+# Re-runs whenever any managed plist changes (embedded hashes below). Wrapper
 # script changes need no re-registration: launchd execs the file fresh on
 # every fire.
 # dev.kryota.morning-radar plist hash: {{ include "Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl" | sha256sum }}
+# dev.kryota.knowledge-distill plist hash: {{ include "Library/LaunchAgents/dev.kryota.knowledge-distill.plist.tmpl" | sha256sum }}
 set -euo pipefail
 
 # CI runners have no gui launchd domain, so bootstrap can never succeed there.
@@ -16,15 +17,21 @@ if [ -n "${CI:-}" ]; then
   exit 0
 fi
 
-plist="$HOME/Library/LaunchAgents/dev.kryota.morning-radar.plist"
-label="dev.kryota.morning-radar"
 domain="gui/$(id -u)"
+labels=(dev.kryota.morning-radar dev.kryota.knowledge-distill)
 
-echo "[launchd-agents] registering ${label}..."
-launchctl bootout "${domain}/${label}" 2>/dev/null || true
-if ! launchctl bootstrap "${domain}" "${plist}"; then
-  echo "[launchd-agents] bootstrap failed (no GUI session?). Re-run 'chezmoi apply' from a GUI terminal." >&2
-  exit 1
-fi
-echo "[launchd-agents] ${label} registered."
+status=0
+for label in "${labels[@]}"; do
+  plist="$HOME/Library/LaunchAgents/${label}.plist"
+  echo "[launchd-agents] registering ${label}..."
+  launchctl bootout "${domain}/${label}" 2>/dev/null || true
+  if ! launchctl bootstrap "${domain}" "${plist}"; then
+    echo "[launchd-agents] bootstrap failed for ${label} (no GUI session?). Re-run 'chezmoi apply' from a GUI terminal." >&2
+    status=1
+    continue
+  fi
+  echo "[launchd-agents] ${label} registered."
+done
+
+exit "$status"
 {{ end -}}

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -126,6 +126,36 @@ load helpers/setup
   plutil -lint "${tmp}/agent.plist"
 }
 
+@test "knowledge-distill launchd agent source files exist" {
+  [ -f "${HOME_DIR}/Library/LaunchAgents/dev.kryota.knowledge-distill.plist.tmpl" ]
+  [ -f "${HOME_DIR}/dot_claude/executable_knowledge-distill-radar.sh" ]
+}
+
+@test "knowledge-distill plist schedules Friday only and never runs at load" {
+  local plist="${HOME_DIR}/Library/LaunchAgents/dev.kryota.knowledge-distill.plist.tmpl"
+  # RunAtLoad must stay absent so (re-)registration never triggers a billed run.
+  run grep -q '<key>RunAtLoad</key>' "$plist"
+  [ "$status" -ne 0 ]
+  # Weekly on Friday at 18:00 local time: exactly one Weekday/Hour entry (#368).
+  [ "$(grep -c '<key>Weekday</key>' "$plist")" -eq 1 ]
+  [ "$(grep -c '<key>Hour</key>' "$plist")" -eq 1 ]
+  local weekday hour
+  weekday="$(grep -A1 '<key>Weekday</key>' "$plist" | grep -oE '[0-9]+')"
+  [ "$weekday" = "5" ]
+  hour="$(grep -A1 '<key>Hour</key>' "$plist" | grep -oE '[0-9]+')"
+  [ "$hour" = "18" ]
+}
+
+@test "knowledge-distill plist template renders to valid plist XML" {
+  command -v plutil >/dev/null 2>&1 || skip "plutil unavailable"
+  local plist="${HOME_DIR}/Library/LaunchAgents/dev.kryota.knowledge-distill.plist.tmpl"
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  sed 's|{{ \.chezmoi\.homeDir }}|/Users/test|g' "$plist" >"${tmp}/agent.plist"
+  plutil -lint "${tmp}/agent.plist"
+}
+
 @test "launcher dir reaches interactive (precmd+sync) and login (zprofile) shells (#345)" {
   local zshrc="${HOME_DIR}/dot_zshrc.tmpl"
   local zprofile="${HOME_DIR}/dot_zprofile.tmpl"
@@ -222,8 +252,13 @@ load helpers/setup
 
 @test "launchd registration script embeds the plist hash and guards CI" {
   local script="${HOME_DIR}/run_onchange_after_30-register-launchd-agents.sh.tmpl"
-  # Re-registration is keyed to the plist content (embedded-hash trick).
+  # Re-registration is keyed to the plist content (embedded-hash trick), one
+  # hash line per managed agent (#368 generalized this to a label loop).
   grep -Fq 'plist hash: {{ include "Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl" | sha256sum }}' "$script"
+  grep -Fq 'plist hash: {{ include "Library/LaunchAgents/dev.kryota.knowledge-distill.plist.tmpl" | sha256sum }}' "$script"
+  # Both labels must be registered via the shared loop, not hardcoded once.
+  grep -Fq 'labels=(dev.kryota.morning-radar dev.kryota.knowledge-distill)' "$script"
+  grep -Fq 'for label in "${labels[@]}"; do' "$script"
   # CI runners have no gui launchd domain; the script must self-skip there.
   grep -Fq 'if [ -n "${CI:-}" ]; then' "$script"
   # Template-stripped body must be valid bash (same strip trick as make lint).

--- a/tests/knowledge_distill_radar.bats
+++ b/tests/knowledge_distill_radar.bats
@@ -76,6 +76,21 @@ run_fn() {
   [[ "$allowed_tools_line" != *'Artifact'* ]]
 }
 
+@test "allowlist pins the individual read-only Bash prefixes and excludes write commands" {
+  local allowed_tools_line
+  allowed_tools_line="$(grep '^ALLOWED_TOOLS=' "$WRAPPER")"
+  for prefix in 'Bash(ls:*)' 'Bash(cat:*)' 'Bash(date:*)' 'Bash(jq:*)' 'Bash(grep:*)' \
+    'Bash(find:*)' 'Bash(head:*)' 'Bash(tail:*)' 'Bash(wc:*)' 'Bash(printf:*)' 'Bash(ghq list:*)'; do
+    [[ "$allowed_tools_line" == *"$prefix"* ]]
+  done
+  # instinct-cli.py must be scoped to the read-only `evolve` subcommand, not a
+  # bare script-path wildcard (the CLI also has import/promote/prune, which
+  # mutate or delete instinct state).
+  [[ "$allowed_tools_line" == *'instinct-cli.py evolve:*'* ]]
+  run grep -qE 'Bash\((rm|mv|cp|dd|truncate|shred)([[:space:]:]|$)' <<<"$allowed_tools_line"
+  [ "$status" -ne 0 ]
+}
+
 @test "token hygiene: no -H/--header Authorization, no set -x, token via -K" {
   run grep -E -- '(-H|--header)["'"'"'[:space:]]*"?Authorization' "$WRAPPER"
   [ "$status" -ne 0 ]
@@ -86,9 +101,12 @@ run_fn() {
 @test "does not hand-copy per-account isolation env (delegates to the claude launcher, #336/#345)" {
   # Unlike morning-radar, this wrapper DOES legitimately reference the
   # ecc-homunculus-default fallback path (HOMUNCULUS_DIR, matching SKILL.md's
-  # own Phase 0 fallback) for its independent precheck -- only a literal
-  # re-assignment of the isolation env vars themselves is forbidden.
-  run grep -qE 'CLV2_HOMUNCULUS_DIR=|ECC_AGENT_DATA_HOME=|GATEGUARD_STATE_DIR=|ECC_MCP_HEALTH_STATE_PATH=' "$WRAPPER"
+  # own Phase 0 fallback) for its independent precheck, and its PROMPT text
+  # quotes SKILL.md's `CLV2_HOMUNCULUS_DIR="$H"` anti-pattern to tell claude
+  # NOT to replicate it -- only a line-start (real shell) re-assignment of the
+  # isolation env vars themselves is forbidden, so the check is anchored to
+  # `^` to ignore prose that merely mentions the var name mid-line.
+  run grep -qE '^CLV2_HOMUNCULUS_DIR=|^ECC_AGENT_DATA_HOME=|^GATEGUARD_STATE_DIR=|^ECC_MCP_HEALTH_STATE_PATH=' "$WRAPPER"
   [ "$status" -ne 0 ]
   grep -qF '$HOME/.local/launchers:' "$WRAPPER"
   grep -qF 'CLAUDE_CONFIG_DIR="$HOME/.claude"' "$WRAPPER"
@@ -104,6 +122,7 @@ run_fn() {
   [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "HEADLINE: 昇華提案 4件" ]
   [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "3" ]
   [ "$(jq -r 'has("click")' <"${STUB_DIR}/curl_stdin")" = "false" ]
+  [ "$(jq -r '.tags | join(",")' <"${STUB_DIR}/curl_stdin")" = "microscope,knowledge-distill" ]
 }
 
 @test "notify_error publishes priority 5 to claude-attention" {
@@ -143,6 +162,7 @@ run_fn() {
 }
 
 @test "same-week guard skips a second run within the same ISO week" {
+  [ "$(uname)" = "Darwin" ] || skip "main() is Darwin-only (uname guard exits early)"
   local tmp
   tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
@@ -223,6 +243,37 @@ EOF
   [[ "$message" == *"3/10"* ]]
 }
 
+@test "main(): instincts dir does not exist yet (zero accumulated) -> dry, does not abort under pipefail" {
+  [ "$(uname)" = "Darwin" ] || skip "main() is Darwin-only (uname guard exits early)"
+  local home="${BATS_TEST_TMPDIR}/home-no-instincts-dir"
+  # Deliberately do NOT create .local/share/ecc-homunculus-default/instincts/personal:
+  # this is the exact "zero instincts accumulated" case the precheck's `|| true`
+  # guard exists to handle (find on a nonexistent dir exits non-zero under pipefail).
+  mkdir -p "${home}/.local/launchers" "${home}/.config/ntfy"
+  cat >"${home}/.local/launchers/claude" <<'EOF'
+#!/bin/bash
+report="$(printf '%s' "$*" | grep -oE '[^ ]+\.kryota-dev/knowledge-distill/[^ ]+\.md' | head -1)"
+mkdir -p "$(dirname "$report")"
+printf '# Knowledge Distill (degraded)\n\ninstinct 蓄積なし。\n' >"$report"
+echo "HEADLINE: 縮退終了"
+EOF
+  chmod +x "${home}/.local/launchers/claude"
+  cp "${STUB_DIR}/curl" "${home}/.local/launchers/curl"
+  cp "$ENV_FILE" "${home}/.config/ntfy/notify-env"
+  chmod 600 "${home}/.config/ntfy/notify-env"
+  run env -i HOME="$home" XDG_STATE_HOME="${home}/state" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" NTFY_TEST_CURL_EXIT=0 \
+    KNOWLEDGE_DISTILL_RADAR_TIMEOUT_SECONDS=2 \
+    KNOWLEDGE_DISTILL_RADAR_LOG_FILE="${home}/radar.log" \
+    bash -c 'bash "$1" >/dev/null 2>&1' _ "$WRAPPER"
+  [ "$status" -eq 0 ]
+  [ -f "${home}/state/knowledge-distill-radar/last-run" ]
+  local message
+  message="$(jq -r .message <"${STUB_DIR}/curl_stdin")"
+  [[ "$message" == *"縮退"* ]]
+  [[ "$message" == *"0/10"* ]]
+}
+
 @test "main(): a failed run notifies attention priority 5 and leaves no stamp" {
   [ "$(uname)" = "Darwin" ] || skip "main() is Darwin-only (uname guard exits early)"
   local home="${BATS_TEST_TMPDIR}/home-fail"
@@ -239,6 +290,30 @@ EOF
     bash -c 'bash "$1" >/dev/null 2>&1' _ "$WRAPPER"
   [ "$status" -eq 1 ]
   [ ! -f "${home}/state/knowledge-distill-radar/last-run" ]
+  [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
+  [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "5" ]
+}
+
+@test "main(): claude exits 0 but writes no report file -> treated as failure, no stamp" {
+  [ "$(uname)" = "Darwin" ] || skip "main() is Darwin-only (uname guard exits early)"
+  local home="${BATS_TEST_TMPDIR}/home-no-report"
+  mkdir -p "${home}/.local/launchers" "${home}/.config/ntfy"
+  # Exits 0 and prints a HEADLINE, but never writes the report file -- this is
+  # the output-contract violation design.md Error Scenario 3 describes, distinct
+  # from the claude-exit-1 path covered by the test above.
+  printf '%s\n' '#!/bin/bash' 'echo "HEADLINE: ok"' >"${home}/.local/launchers/claude"
+  chmod +x "${home}/.local/launchers/claude"
+  cp "${STUB_DIR}/curl" "${home}/.local/launchers/curl"
+  cp "$ENV_FILE" "${home}/.config/ntfy/notify-env"
+  chmod 600 "${home}/.config/ntfy/notify-env"
+  run env -i HOME="$home" XDG_STATE_HOME="${home}/state" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" NTFY_TEST_CURL_EXIT=0 \
+    KNOWLEDGE_DISTILL_RADAR_TIMEOUT_SECONDS=2 \
+    KNOWLEDGE_DISTILL_RADAR_LOG_FILE="${home}/radar.log" \
+    bash -c 'bash "$1" >/dev/null 2>&1' _ "$WRAPPER"
+  [ "$status" -eq 1 ]
+  [ ! -f "${home}/state/knowledge-distill-radar/last-run" ]
+  grep -qF 'report file missing' "${home}/radar.log"
   [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
   [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "5" ]
 }

--- a/tests/knowledge_distill_radar.bats
+++ b/tests/knowledge_distill_radar.bats
@@ -1,0 +1,244 @@
+#!/usr/bin/env bats
+
+# knowledge-distill radar wrapper (home/dot_claude/executable_knowledge-distill-radar.sh, #368).
+# The wrapper is source-safe (side effects live in main() behind a BASH_SOURCE
+# guard), so these tests both source it to exercise the pure helpers and run it
+# end-to-end with claude + curl stubbed on PATH — no network, no server, CI-safe.
+# Covers: permission allowlist hygiene, token hygiene, fail-open ntfy delivery,
+# the same-week guard, the independent dry-pipeline precheck, and main()'s
+# stamp/notification wiring for both healthy and dry weeks.
+
+load helpers/setup
+
+WRAPPER="${HOME_DIR}/dot_claude/executable_knowledge-distill-radar.sh"
+
+setup() {
+  STUB_DIR="${BATS_TEST_TMPDIR}/stub"
+  mkdir -p "$STUB_DIR"
+  cat >"${STUB_DIR}/curl" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >"${NTFY_TEST_STUB_DIR}/curl_args"
+cat >"${NTFY_TEST_STUB_DIR}/curl_stdin"
+exit "${NTFY_TEST_CURL_EXIT:-0}"
+EOF
+  chmod +x "${STUB_DIR}/curl"
+
+  ENV_FILE="${BATS_TEST_TMPDIR}/notify-env"
+  cat >"$ENV_FILE" <<'EOF'
+NTFY_URL='http://127.0.0.1:9'
+NTFY_TOKEN='tk_bats_secret'
+NTFY_TOPIC_ATTENTION='claude-attention'
+NTFY_TOPIC_DONE='claude-done'
+NTFY_TOPIC_BRIEF='claude-brief'
+EOF
+  chmod 600 "$ENV_FILE"
+
+  LOG_FILE="${BATS_TEST_TMPDIR}/knowledge-distill-radar.log"
+}
+
+# Source the wrapper (main() is guarded, so nothing runs) and call one of its
+# functions with the stubbed PATH and fixture env.
+run_fn() {
+  run env \
+    PATH="${STUB_DIR}:${PATH}" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" \
+    NTFY_TEST_CURL_EXIT="${NTFY_TEST_CURL_EXIT:-0}" \
+    KNOWLEDGE_DISTILL_RADAR_NTFY_ENV_FILE="$ENV_FILE" \
+    KNOWLEDGE_DISTILL_RADAR_LOG_FILE="$LOG_FILE" \
+    bash -c 'source "$1"; shift; fn="$1"; shift; "$fn" "$@"' _ "$WRAPPER" "$@"
+}
+
+@test "knowledge-distill-radar.sh exists and passes bash -n" {
+  [ -f "$WRAPPER" ]
+  bash -n "$WRAPPER"
+}
+
+@test "no dangerously-skip-permissions / bypassPermissions bypass" {
+  run grep -q 'dangerously-skip-permissions' "$WRAPPER"
+  [ "$status" -ne 0 ]
+  run grep -q 'bypassPermissions' "$WRAPPER"
+  [ "$status" -ne 0 ]
+}
+
+@test "keeps the explicit permission allowlist and pinned model/turns" {
+  grep -q -- '--allowedTools' "$WRAPPER"
+  grep -q -- '--max-turns' "$WRAPPER"
+  grep -q -- '--model' "$WRAPPER"
+  grep -q 'CLAUDE_CONFIG_DIR' "$WRAPPER"
+}
+
+@test "allowlist grants Skill(knowledge-distill) and confines writes to the report dir" {
+  local allowed_tools_line
+  allowed_tools_line="$(grep '^ALLOWED_TOOLS=' "$WRAPPER")"
+  [[ "$allowed_tools_line" == *'Skill(knowledge-distill)'* ]]
+  [[ "$allowed_tools_line" == *'Edit(~/dotfiles/.kryota-dev/knowledge-distill/**)'* ]]
+  # No page-delivery tool for this radar (unlike morning-radar's brief page).
+  [[ "$allowed_tools_line" != *'Artifact'* ]]
+}
+
+@test "token hygiene: no -H/--header Authorization, no set -x, token via -K" {
+  run grep -E -- '(-H|--header)["'"'"'[:space:]]*"?Authorization' "$WRAPPER"
+  [ "$status" -ne 0 ]
+  ! grep -qF 'set -x' "$WRAPPER"
+  grep -qF 'curl -fs -K' "$WRAPPER"
+}
+
+@test "does not hand-copy per-account isolation env (delegates to the claude launcher, #336/#345)" {
+  # Unlike morning-radar, this wrapper DOES legitimately reference the
+  # ecc-homunculus-default fallback path (HOMUNCULUS_DIR, matching SKILL.md's
+  # own Phase 0 fallback) for its independent precheck -- only a literal
+  # re-assignment of the isolation env vars themselves is forbidden.
+  run grep -qE 'CLV2_HOMUNCULUS_DIR=|ECC_AGENT_DATA_HOME=|GATEGUARD_STATE_DIR=|ECC_MCP_HEALTH_STATE_PATH=' "$WRAPPER"
+  [ "$status" -ne 0 ]
+  grep -qF '$HOME/.local/launchers:' "$WRAPPER"
+  grep -qF 'CLAUDE_CONFIG_DIR="$HOME/.claude"' "$WRAPPER"
+  grep -qF 'EXA_API_KEY=""' "$WRAPPER"
+  grep -qF 'FIRECRAWL_API_KEY=""' "$WRAPPER"
+}
+
+@test "ntfy_publish -> claude-attention topic with given priority and message" {
+  run_fn ntfy_publish 3 "Knowledge Distill" "HEADLINE: 昇華提案 4件"
+  [ "$status" -eq 0 ]
+  [ -f "${STUB_DIR}/curl_stdin" ]
+  [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
+  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "HEADLINE: 昇華提案 4件" ]
+  [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "3" ]
+  [ "$(jq -r 'has("click")' <"${STUB_DIR}/curl_stdin")" = "false" ]
+}
+
+@test "notify_error publishes priority 5 to claude-attention" {
+  run_fn notify_error "claude not found"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
+  [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "5" ]
+  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "claude not found" ]
+}
+
+@test "token never reaches curl argv (travels via -K config file)" {
+  run_fn ntfy_publish 3 "Knowledge Distill" "HEADLINE: ok"
+  [ "$status" -eq 0 ]
+  [ -f "${STUB_DIR}/curl_args" ]
+  ! grep -q 'tk_bats_secret' "${STUB_DIR}/curl_args"
+  grep -qE -- '-K' "${STUB_DIR}/curl_args"
+}
+
+@test "publish failure is fail-open: returns 0, token never logged" {
+  NTFY_TEST_CURL_EXIT=1 run_fn ntfy_publish 5 "Knowledge Distill" "boom"
+  [ "$status" -eq 0 ]
+  ! grep -q 'tk_bats_secret' "$LOG_FILE"
+}
+
+@test "no env file -> silent no-op, no publish" {
+  rm -f "$ENV_FILE"
+  run_fn ntfy_publish 3 "Knowledge Distill" "HEADLINE: ok"
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/curl_stdin" ]
+}
+
+@test "group/other-readable env file fails open without publishing" {
+  chmod 644 "$ENV_FILE"
+  run_fn ntfy_publish 3 "Knowledge Distill" "HEADLINE: ok"
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/curl_stdin" ]
+}
+
+@test "same-week guard skips a second run within the same ISO week" {
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  mkdir -p "${tmp}/state/knowledge-distill-radar"
+  printf '%s\n' "$(date +%G-W%V)" >"${tmp}/state/knowledge-distill-radar/last-run"
+  # claude is not resolvable from the sandboxed HOME, so a bypassed guard would exit 1.
+  run env HOME="$tmp" XDG_STATE_HOME="${tmp}/state" bash "$WRAPPER"
+  [ "$status" -eq 0 ]
+}
+
+@test "main(): healthy pipeline publishes the plain HEADLINE and stamps the week" {
+  [ "$(uname)" = "Darwin" ] || skip "main() is Darwin-only (uname guard exits early)"
+  local home="${BATS_TEST_TMPDIR}/home-healthy"
+  mkdir -p "${home}/.local/launchers" "${home}/.config/ntfy" \
+    "${home}/.local/share/ecc-homunculus-default/instincts/personal"
+  # 10 instincts == the MIN_INSTINCTS default: not dry.
+  for i in $(seq 1 10); do
+    printf 'instinct %s\n' "$i" >"${home}/.local/share/ecc-homunculus-default/instincts/personal/inst-${i}.md"
+  done
+  cat >"${home}/.local/launchers/claude" <<'EOF'
+#!/bin/bash
+# Extract the report path from the -p prompt so the stub writes where the
+# wrapper expects (mirrors the wrapper's own $REPORT_FILE construction).
+report="$(printf '%s' "$*" | grep -oE '[^ ]+\.kryota-dev/knowledge-distill/[^ ]+\.md' | head -1)"
+mkdir -p "$(dirname "$report")"
+printf '# Knowledge Distill\n\n昇華提案 4件。\n' >"$report"
+echo "HEADLINE: 昇華提案 4件 / instinct 12件"
+EOF
+  chmod +x "${home}/.local/launchers/claude"
+  cp "${STUB_DIR}/curl" "${home}/.local/launchers/curl"
+  cp "$ENV_FILE" "${home}/.config/ntfy/notify-env"
+  chmod 600 "${home}/.config/ntfy/notify-env"
+  run env -i HOME="$home" XDG_STATE_HOME="${home}/state" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" NTFY_TEST_CURL_EXIT=0 \
+    KNOWLEDGE_DISTILL_RADAR_TIMEOUT_SECONDS=2 \
+    KNOWLEDGE_DISTILL_RADAR_LOG_FILE="${home}/radar.log" \
+    bash -c 'bash "$1" >/dev/null 2>&1' _ "$WRAPPER"
+  [ "$status" -eq 0 ]
+  [ -f "${home}/state/knowledge-distill-radar/last-run" ]
+  [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
+  [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "3" ]
+  # The "HEADLINE:" prefix is stripped before publishing (matches morning-radar).
+  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "昇華提案 4件 / instinct 12件" ]
+  run grep -qF '縮退' <(jq -r .message <"${STUB_DIR}/curl_stdin")
+  [ "$status" -ne 0 ]
+}
+
+@test "main(): dry pipeline is flagged explicitly regardless of claude's own wording" {
+  [ "$(uname)" = "Darwin" ] || skip "main() is Darwin-only (uname guard exits early)"
+  local home="${BATS_TEST_TMPDIR}/home-dry"
+  mkdir -p "${home}/.local/launchers" "${home}/.config/ntfy" \
+    "${home}/.local/share/ecc-homunculus-default/instincts/personal"
+  # 3 instincts < the MIN_INSTINCTS default (10): dry pipeline.
+  for i in 1 2 3; do
+    printf 'instinct %s\n' "$i" >"${home}/.local/share/ecc-homunculus-default/instincts/personal/inst-${i}.md"
+  done
+  cat >"${home}/.local/launchers/claude" <<'EOF'
+#!/bin/bash
+report="$(printf '%s' "$*" | grep -oE '[^ ]+\.kryota-dev/knowledge-distill/[^ ]+\.md' | head -1)"
+mkdir -p "$(dirname "$report")"
+printf '# Knowledge Distill (degraded)\n\ninstinct 蓄積不足。\n' >"$report"
+echo "HEADLINE: 縮退終了"
+EOF
+  chmod +x "${home}/.local/launchers/claude"
+  cp "${STUB_DIR}/curl" "${home}/.local/launchers/curl"
+  cp "$ENV_FILE" "${home}/.config/ntfy/notify-env"
+  chmod 600 "${home}/.config/ntfy/notify-env"
+  run env -i HOME="$home" XDG_STATE_HOME="${home}/state" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" NTFY_TEST_CURL_EXIT=0 \
+    KNOWLEDGE_DISTILL_RADAR_TIMEOUT_SECONDS=2 \
+    KNOWLEDGE_DISTILL_RADAR_LOG_FILE="${home}/radar.log" \
+    bash -c 'bash "$1" >/dev/null 2>&1' _ "$WRAPPER"
+  [ "$status" -eq 0 ]
+  [ -f "${home}/state/knowledge-distill-radar/last-run" ]
+  local message
+  message="$(jq -r .message <"${STUB_DIR}/curl_stdin")"
+  [[ "$message" == *"縮退"* ]]
+  [[ "$message" == *"3/10"* ]]
+}
+
+@test "main(): a failed run notifies attention priority 5 and leaves no stamp" {
+  [ "$(uname)" = "Darwin" ] || skip "main() is Darwin-only (uname guard exits early)"
+  local home="${BATS_TEST_TMPDIR}/home-fail"
+  mkdir -p "${home}/.local/launchers" "${home}/.config/ntfy"
+  printf '%s\n' '#!/bin/bash' 'exit 1' >"${home}/.local/launchers/claude"
+  chmod +x "${home}/.local/launchers/claude"
+  cp "${STUB_DIR}/curl" "${home}/.local/launchers/curl"
+  cp "$ENV_FILE" "${home}/.config/ntfy/notify-env"
+  chmod 600 "${home}/.config/ntfy/notify-env"
+  run env -i HOME="$home" XDG_STATE_HOME="${home}/state" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" NTFY_TEST_CURL_EXIT=0 \
+    KNOWLEDGE_DISTILL_RADAR_TIMEOUT_SECONDS=2 \
+    KNOWLEDGE_DISTILL_RADAR_LOG_FILE="${home}/radar.log" \
+    bash -c 'bash "$1" >/dev/null 2>&1' _ "$WRAPPER"
+  [ "$status" -eq 1 ]
+  [ ! -f "${home}/state/knowledge-distill-radar/last-run" ]
+  [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
+  [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "5" ]
+}


### PR DESCRIPTION
## 概要

`knowledge-distill` skill（CLV2 継続学習ループの週次診断・昇華提案 skill）を、
`dev.kryota.morning-radar`（#257/#361）と同じパターンの launchd エージェントで
毎週金曜 18:00 JST に headless 自動実行する。cron 化は skill 上でユーザー承認待ち
としてスコープ外にされていたが、2026-07-26 に週次 cadence での自動実行が承認された。

## 変更内容

- **新規 launchd エージェント**: `home/dot_claude/executable_knowledge-distill-radar.sh`
  （headless ラッパー）+ `home/Library/LaunchAgents/dev.kryota.knowledge-distill.plist.tmpl`
  （金曜 18:00 JST、週1回）。
- **CLV2 パイプライン健全性の precheck**: claude を起動する前に、wrapper が
  `$CLV2_HOMUNCULUS_DIR/instincts/personal/` 配下の instinct 蓄積数を独立に数え、
  閾値（既定 10、skill の `--min-instincts` と一致）未満なら dry pipeline として、
  claude の自由記述レスポンスに依存せず ntfy 通知に明示する（`[縮退] instinct N/10 — ...`）。
- **ntfy 通知**: 既存の `claude-attention` トピックを再利用（新規 topic は追加しない）。
  成功時は priority 3、claude 未検出/timeout/非ゼロ終了/レポート欠損時は priority 5。
- **launchd 登録スクリプトの汎化**: `run_onchange_after_30-register-launchd-agents.sh.tmpl`
  を単一 plist 専用のハードコードから、label 配列をループする複数 plist 対応へ書き換えた。
  今後の launchd agent 追加はこのスクリプトへの追記のみで済む。
- **ドキュメント**: `docs/architecture/notifications.md`/`.ja.md` に
  「Weekly knowledge-distill delivery」節を追加（英日同時）。`knowledge-distill`
  SKILL.md の運用メモを、cron 化スコープ外の記述から自動化済みの説明に更新した。

## テスト計画

- [x] `make lint`（shellcheck + shfmt + zsh 構文チェック）
- [x] `make test`（lint + 全 298 bats テスト、新規 `tests/knowledge_distill_radar.bats`
      16 件を含む）
- [x] `chezmoi execute-template` で新規 plist のレンダリングを確認し、`plutil -lint`
      で XML 妥当性を確認
- [x] `chezmoi execute-template` で登録スクリプトのハッシュ埋め込み・ループ構造の
      レンダリングを確認

closes #368
