### PR TITLE
feat(macos-defaults): 週次 defaults ドリフト検出を追加する

### DIFF
--- a/docs/architecture/lifecycle-scripts.ja.md
+++ b/docs/architecture/lifecycle-scripts.ja.md
@@ -79,7 +79,7 @@ flowchart TD
 | `12-setup-mise` | `dot_config/mise/config.toml` |
 | `17-setup-claude-plugins` | `dot_claude/settings.json` |
 | `18-setup-agent-browser` | `dot_config/mise/config.toml` |
-| `30-register-launchd-agents` | `Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl` |
+| `30-register-launchd-agents` | `Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl` + `Library/LaunchAgents/dev.kryota.macos-defaults-drift.plist.tmpl` |
 | `31-setup-ntfy` | `dot_config/ntfy/compose.yaml.tmpl` + `dot_config/ntfy/private_server.yml.tmpl` + `dot_config/ntfy/lib.sh.tmpl` |
 | `40-setup-sheldon` | `dot_config/sheldon/plugins.toml` |
 | `20-macos-defaults` | 自分自身のソースファイル（任意の編集で再トリガー） |
@@ -207,9 +207,27 @@ Control Center 刷新で個別キー（`IsAnalog`、`Show24Hour`、`ShowAMPM`、
 プロファイルテーマは意図的に除外しています — 既存機の状態を破壊するリスクがあるか、
 `defaults write` 一行を超えて別ファイルの配布が必要になるためです。
 
+本スクリプトは `chezmoi apply` 実行時にのみ設定を適用します — その後、管理対象の設定が
+（例えばシステム設定 UI の操作で）乖離しても気づきません。`dev.kryota.macos-defaults-drift`
+LaunchAgent（kryota-dev/dotfiles#365、下記の `30-register-launchd-agents` が登録）が
+このギャップを埋めます。週次で本スクリプトの `defaults write` 行を一時 plist に再生して
+各管理対象キーの期待値を導出し、実際の値と比較して、乖離があれば ntfy（`topic_attention`）
+で通知します — 検出・通知のみで、本スクリプトへの書き戻しや git 操作は一切行いません。
+
 ### 30 — register-launchd-agents (`run_onchange`、after、macOS のみ)
 
-repo 管理の launchd LaunchAgent（現在は平日朝ブリーフを発火する `dev.kryota.morning-radar` の 1 つ、kryota-dev/dotfiles#257。Claude Code ハーネスドキュメントの [朝次レーダーのスケジュール実行](../agents/claude-code.ja.md) 参照）を登録します。`launchctl bootout || true` → `launchctl bootstrap gui/$UID` の順で実行するため、plist の変更は冪等に再読み込みされます。再トリガーのキーは plist テンプレートの埋め込みハッシュです（wrapper script の編集は再登録不要 — launchd は発火のたびに現行ファイルを exec します）。`$CI` 設定時は登録をスキップします。headless runner には gui launchd domain が存在せず、in-script ガードならワークフローでファイルを除外する方式と異なり、レンダリング / apply パスが CI 検証対象に残ります。CI 外では bootstrap 失敗をハードフェイルとし、次回 apply で chezmoi がリトライします（規約 #6）。
+repo 管理の launchd LaunchAgent を登録します: 平日朝ブリーフを発火する
+`dev.kryota.morning-radar`（kryota-dev/dotfiles#257。Claude Code ハーネスドキュメントの
+[朝次レーダーのスケジュール実行](../agents/claude-code.ja.md) 参照）と、上記の週次
+`20-macos-defaults` ドリフトチェックを発火する `dev.kryota.macos-defaults-drift`
+（kryota-dev/dotfiles#365）の 2 つです。共通の `register_agent <label> <plist>` 関数が
+それぞれについて `launchctl bootout || true` → `launchctl bootstrap gui/$UID` の順で実行するため、
+plist の変更は冪等に再読み込みされます。再トリガーのキーは各 plist テンプレートの埋め込み
+ハッシュです（wrapper script の編集は再登録不要 — launchd は発火のたびに現行ファイルを
+exec します）。`$CI` 設定時は登録をスキップします。headless runner には gui launchd domain
+が存在せず、in-script ガードならワークフローでファイルを除外する方式と異なり、レンダリング /
+apply パスが CI 検証対象に残ります。CI 外では bootstrap 失敗をハードフェイルとし、次回
+apply で chezmoi がリトライします（規約 #6）。
 
 ### 31 — setup-ntfy (`run_onchange`、after、macOS のみ)
 

--- a/docs/architecture/lifecycle-scripts.md
+++ b/docs/architecture/lifecycle-scripts.md
@@ -79,7 +79,7 @@ When `dot_Brewfile` changes, the rendered comment line changes, the script body 
 | `12-setup-mise` | `dot_config/mise/config.toml` |
 | `17-setup-claude-plugins` | `dot_claude/settings.json` |
 | `18-setup-agent-browser` | `dot_config/mise/config.toml` |
-| `30-register-launchd-agents` | `Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl` |
+| `30-register-launchd-agents` | `Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl` + `Library/LaunchAgents/dev.kryota.macos-defaults-drift.plist.tmpl` |
 | `31-setup-ntfy` | `dot_config/ntfy/compose.yaml.tmpl` + `dot_config/ntfy/private_server.yml.tmpl` + `dot_config/ntfy/lib.sh.tmpl` |
 | `40-setup-sheldon` | `dot_config/sheldon/plugins.toml` |
 | `20-macos-defaults` | its own source file (any edit re-triggers) |
@@ -200,9 +200,28 @@ layout (`persistent-apps`/`persistent-others`), hot corners, and custom Terminal
 themes are deliberately excluded — they are either destructive to an existing machine's
 state or require shipping additional files beyond a `defaults write` line.
 
+This script only applies settings at `chezmoi apply` time — it never notices when a
+managed setting drifts afterward (e.g. changed via System Settings UI). The
+`dev.kryota.macos-defaults-drift` LaunchAgent (kryota-dev/dotfiles#365, registered by
+`30-register-launchd-agents` below) closes that gap: weekly, it replays this script's
+`defaults write` lines against a scratch plist to derive the expected value for each
+managed key, compares that against the live value, and notifies via ntfy
+(`topic_attention`) when they differ — detect-and-notify only, it never writes back to
+this script or touches git.
+
 ### 30 — register-launchd-agents (`run_onchange`, after, macOS only)
 
-Registers the repo-managed launchd LaunchAgents — currently one, `dev.kryota.morning-radar`, which fires the weekday-morning brief (kryota-dev/dotfiles#257; see [Scheduled morning radar](../agents/claude-code.md) in the Claude Code harness doc). Performs `launchctl bootout || true` then `launchctl bootstrap gui/$UID` so a changed plist is reloaded idempotently; the plist template's embedded hash is the re-trigger key (wrapper-script edits need no re-registration — launchd execs the current file on every fire). Skips registration when `$CI` is set: headless runners have no gui launchd domain, and the in-script guard keeps the render/apply path CI-validated (unlike excluding the file in the workflow). Outside CI a bootstrap failure hard-fails so chezmoi retries on the next apply (convention #6).
+Registers the repo-managed launchd LaunchAgents: `dev.kryota.morning-radar`, which fires
+the weekday-morning brief (kryota-dev/dotfiles#257; see [Scheduled morning radar](../agents/claude-code.md)
+in the Claude Code harness doc), and `dev.kryota.macos-defaults-drift`, which fires the
+weekly `20-macos-defaults` drift check described above (kryota-dev/dotfiles#365). A shared
+`register_agent <label> <plist>` function performs `launchctl bootout || true` then
+`launchctl bootstrap gui/$UID` for each, so a changed plist is reloaded idempotently; each
+plist template's embedded hash is the re-trigger key (wrapper-script edits need no
+re-registration — launchd execs the current file on every fire). Skips registration when
+`$CI` is set: headless runners have no gui launchd domain, and the in-script guard keeps
+the render/apply path CI-validated (unlike excluding the file in the workflow). Outside CI
+a bootstrap failure hard-fails so chezmoi retries on the next apply (convention #6).
 
 ### 31 — setup-ntfy (`run_onchange`, after, macOS only)
 

--- a/docs/architecture/notifications.ja.md
+++ b/docs/architecture/notifications.ja.md
@@ -66,7 +66,7 @@ phones/tablets on the tailnet (username/password login)
 
 | Topic | Events | Priority | Intended device setting |
 |-------|--------|----------|------------------------|
-| `claude-attention` | permission_prompt, idle_prompt, agent_needs_input | high (4) | sound/vibrate on |
+| `claude-attention` | permission_prompt, idle_prompt, agent_needs_input, 週次 macOS defaults ドリフト検出 (macos-defaults-drift-check, #365) | high (4) | sound/vibrate on |
 | `claude-done` | agent_completed, Stop | default (3) | silent delivery |
 | `claude-brief` | weekday morning brief (morning-radar, #361) | default (3) | mute optional |
 | `claude-test` | manual smoke tests | — | mute after testing |

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -66,7 +66,7 @@ phones/tablets on the tailnet (username/password login)
 
 | Topic | Events | Priority | Intended device setting |
 |-------|--------|----------|------------------------|
-| `claude-attention` | permission_prompt, idle_prompt, agent_needs_input | high (4) | sound/vibrate on |
+| `claude-attention` | permission_prompt, idle_prompt, agent_needs_input, weekly macOS defaults drift (macos-defaults-drift-check, #365) | high (4) | sound/vibrate on |
 | `claude-done` | agent_completed, Stop | default (3) | silent delivery |
 | `claude-brief` | weekday morning brief (morning-radar, #361) | default (3) | mute optional |
 | `claude-test` | manual smoke tests | — | mute after testing |

--- a/home/.chezmoidata.toml
+++ b/home/.chezmoidata.toml
@@ -187,3 +187,20 @@ ghq_user = "kryota-dev"
   # tailnet by `tailscale serve --https=8443` (a port proxy — macOS cannot serve
   # files/directories directly). Distinct from the ntfy port above.
   brief_port = 2587
+
+[macos_defaults_drift]
+  # Keys excluded from the weekly drift check (kryota-dev/dotfiles#365),
+  # "domain:key" formatted. Read by executable_macos-defaults-drift-check.sh.
+  # Only keys managed by run_onchange_after_20-macos-defaults.sh.tmpl are ever
+  # compared in the first place, and #364 already curated that list down to
+  # stable, intentional settings — so nothing there is expected to be noisy
+  # yet. This list exists as a safety valve for a future managed key that
+  # turns out to fluctuate on its own (window position, cache, timestamp, or
+  # other machine-specific value), not because a current key needs it.
+  #
+  # One "domain:key" string per line (matches the multi-line-array parsing
+  # convention _ecc_skill_list() in tests/helpers/setup.bash already
+  # established for [ecc].skills — keep this in that same shape so both the
+  # bash reader and any future bats helper can use the same awk pattern).
+  exclude_keys = [
+  ]

--- a/home/Library/LaunchAgents/dev.kryota.macos-defaults-drift.plist.tmpl
+++ b/home/Library/LaunchAgents/dev.kryota.macos-defaults-drift.plist.tmpl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Weekly macOS defaults drift check (kryota-dev/dotfiles#365).
+  Fires the drift-check wrapper at 10:00 local time every Sunday, comparing
+  the live values of domains/keys managed by
+  run_onchange_after_20-macos-defaults.sh.tmpl (#364) against what that
+  script would set, and notifying via ntfy (topic_attention) when they
+  differ. No repo write-back — a human decides whether to adopt the drift.
+  Registered/reloaded by run_onchange_after_30-register-launchd-agents.sh.tmpl.
+  RunAtLoad is intentionally absent (defaults to false) so registration itself
+  never triggers a run.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.kryota.macos-defaults-drift</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{ .chezmoi.homeDir }}/.claude/macos-defaults-drift-check.sh</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <array>
+    <dict>
+      <key>Weekday</key>
+      <integer>0</integer>
+      <key>Hour</key>
+      <integer>10</integer>
+      <key>Minute</key>
+      <integer>0</integer>
+    </dict>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>{{ .chezmoi.homeDir }}/dotfiles</string>
+  <key>StandardOutPath</key>
+  <string>{{ .chezmoi.homeDir }}/Library/Logs/dev.kryota.macos-defaults-drift.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{ .chezmoi.homeDir }}/Library/Logs/dev.kryota.macos-defaults-drift.log</string>
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>

--- a/home/dot_claude/executable_macos-defaults-drift-check.sh
+++ b/home/dot_claude/executable_macos-defaults-drift-check.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+# Weekly macOS defaults drift check (kryota-dev/dotfiles#365).
+# Launched by the dev.kryota.macos-defaults-drift LaunchAgent. Compares the
+# live values of every domain/key managed by
+# run_onchange_after_20-macos-defaults.sh.tmpl (#364) -- treated as the sole
+# source of truth for "what should be set" -- against what that script would
+# currently write, and publishes an ntfy notification (topic_attention) only
+# when they differ. Detect + notify only: this script never writes back to
+# the repo or touches git in any way (#365 hard constraint).
+#
+# Comparison strategy: rather than hand-normalizing `defaults write` value
+# syntax against `defaults read` output per type (bool/int/float/string/array
+# all format differently), the managed `defaults write` lines are replayed
+# verbatim against a scratch plist path (`defaults write <path> ...` accepts
+# a file path in place of a domain name) and then both sides are read back
+# with the same `defaults read` call. Two outputs of the same tool for the
+# same type are directly string-comparable, so no type-coercion table is
+# needed. A full-domain `defaults export | plutil -convert json` alternative
+# was tried and rejected: some real domains contain NSData-typed values that
+# plutil refuses to convert to JSON ("Invalid object in plist for JSON
+# format"), which per-key `defaults read` never touches.
+#
+# Not a chezmoi .tmpl: deployed as-is on every OS (like
+# executable_morning-radar.sh), and no-ops at runtime on non-Darwin via the
+# uname check in main(). Registration of the LaunchAgent that invokes this
+# script IS macOS-gated, in run_onchange_after_30-register-launchd-agents.sh.tmpl.
+#
+# Source-safe: side effects live in main(), guarded by the BASH_SOURCE check
+# at the end, so tests can source this file and exercise individual functions.
+set -euo pipefail
+
+# The dotfiles repo checkout on this machine -- same assumption
+# executable_morning-radar.sh makes (`cd "$HOME/dotfiles"`). Overridable for
+# tests so they can point at a fixture checkout instead.
+REPO_DIR="${MACOS_DEFAULTS_DRIFT_REPO_DIR:-$HOME/dotfiles}"
+SSOT="$REPO_DIR/home/run_onchange_after_20-macos-defaults.sh.tmpl"
+DATA_TOML="$REPO_DIR/home/.chezmoidata.toml"
+LOG_FILE="${MACOS_DEFAULTS_DRIFT_LOG_FILE:-$HOME/Library/Logs/dev.kryota.macos-defaults-drift.log}"
+# Publisher credentials, written 0600 by ~/.config/ntfy/lib.sh (#337/#357).
+# Overridable for tests. Sourced only inside a subshell so the token never
+# enters this script's (or any child process's) environment.
+ENV_FILE="${MACOS_DEFAULTS_DRIFT_NTFY_ENV_FILE:-$HOME/.config/ntfy/notify-env}"
+BODY_LIMIT=3000
+
+log() {
+  printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >>"$LOG_FILE" 2>/dev/null || true
+}
+
+# Extract "defaults write <domain> <key> -<type> <value...>" lines from the
+# SSOT script. The `^defaults write ` anchor already can't match a chezmoi
+# template directive or a comment line, so no separate template-line-stripping
+# pass is needed here (unlike the Makefile lint target, which strips template
+# lines before shellcheck because it can't rely on such an anchor). Emits one
+# TSV row per match: domain, key, type, value. For type=string the value's
+# surrounding double quotes are stripped (so it round-trips as a single argv
+# token in build_expected()); every other type keeps its raw text --
+# type=array may hold multiple space-separated tokens, which is intentional
+# (see below).
+parse_ssot() {
+  [ -f "$SSOT" ] || return 0
+  awk '
+    /^defaults write / {
+      domain = $3
+      key = $4
+      type = $5
+      sub(/^-/, "", type)
+      value = ""
+      for (i = 6; i <= NF; i++) {
+        value = value (i > 6 ? " " : "") $i
+      }
+      if (type == "string") {
+        gsub(/^"/, "", value)
+        gsub(/"$/, "", value)
+      }
+      printf "%s\t%s\t%s\t%s\n", domain, key, type, value
+    }
+  ' "$SSOT"
+}
+
+# Replay the SSOT's defaults-write lines against per-domain scratch plist
+# paths under $1 (a fresh mktemp -d), so the "expected" value for each
+# managed key can be read back with the exact same `defaults read` call used
+# on the real domain -- see the header comment for why this beats hand
+# type-coercion. Domain names are safe to use as bare filenames (no `/`, no
+# reserved characters on APFS). The unquoted $value in the array branch is
+# deliberate word-splitting so a multi-element array replays as multiple
+# `defaults write` arguments.
+build_expected() {
+  local tmp_dir="$1" domain key type value scratch
+  while IFS=$'\t' read -r domain key type value; do
+    scratch="$tmp_dir/$domain"
+    case "$type" in
+      string) defaults write "$scratch" "$key" -string "$value" >/dev/null 2>&1 ;;
+      array) defaults write "$scratch" "$key" -array $value >/dev/null 2>&1 ;;
+      *) defaults write "$scratch" "$key" "-$type" "$value" >/dev/null 2>&1 ;;
+    esac
+  done < <(parse_ssot)
+}
+
+# Print the trimmed `defaults read` output for <domain-or-path> <key>, or the
+# literal string "(unset)" when the key doesn't exist there (`defaults read`
+# exits non-zero and writes nothing useful to stdout in that case).
+read_value() {
+  local target="$1" key="$2" out
+  if out="$(defaults read "$target" "$key" 2>/dev/null)"; then
+    printf '%s' "$out"
+  else
+    printf '(unset)'
+  fi
+}
+
+# Whether "<domain>:<key>" appears in the [macos_defaults_drift].exclude_keys
+# array in home/.chezmoidata.toml. Parsed with the same dependency-free awk
+# pattern tests/helpers/setup.bash uses for [ecc].skills (no chezmoi/yq
+# dependency -- this script runs standalone under launchd).
+is_excluded() {
+  local domain="$1" key="$2"
+  [ -f "$DATA_TOML" ] || return 1
+  awk '
+    /^\[macos_defaults_drift\]$/ { in_section = 1; next }
+    /^\[/                        { in_section = 0; in_list = 0 }
+    in_section && /^[[:space:]]*exclude_keys[[:space:]]*=[[:space:]]*\[/ { in_list = 1; next }
+    in_section && in_list && /^[[:space:]]*\]/ { in_list = 0; next }
+    in_section && in_list { print }
+  ' "$DATA_TOML" | grep -oE '"[^"]+"' | tr -d '"' | grep -qxF "${domain}:${key}"
+}
+
+# Build a `defaults write` candidate reflecting the CURRENT (drifted) value,
+# so a human can paste it into run_onchange_after_20-macos-defaults.sh.tmpl to
+# adopt the drift. Array types are not auto-regenerated: the SSOT has exactly
+# one array-typed key today, and `defaults read`'s multi-line parenthesized
+# form isn't worth round-tripping generically for a single key -- the
+# candidate line says so and points at a manual `defaults read` instead.
+build_candidate() {
+  local domain="$1" key="$2" type="$3" actual="$4"
+  case "$type" in
+    bool)
+      case "$actual" in
+        1) printf 'defaults write %s %s -bool true' "$domain" "$key" ;;
+        0) printf 'defaults write %s %s -bool false' "$domain" "$key" ;;
+        *) printf '# %s %s: unexpected bool value %s -- inspect manually' "$domain" "$key" "$actual" ;;
+      esac
+      ;;
+    array)
+      printf '# %s %s is array-typed -- inspect manually: defaults read %s %s' "$domain" "$key" "$domain" "$key"
+      ;;
+    string)
+      printf 'defaults write %s %s -string %q' "$domain" "$key" "$actual"
+      ;;
+    *)
+      printf 'defaults write %s %s -%s %s' "$domain" "$key" "$type" "$actual"
+      ;;
+  esac
+}
+
+# Publish a Markdown ntfy notification to topic_attention. Fail-open: a
+# broken/absent ntfy provisioning is a silent no-op; nothing here ever aborts
+# the run. Token hygiene mirrors executable_morning-radar.sh /
+# executable_ntfy-notify.sh: the env file is sourced inside a subshell so
+# NTFY_TOKEN never enters this script's environment, and it reaches curl only
+# through a 0600 `curl -K` config file, never argv/stdout/trace.
+ntfy_publish() {
+  local count="$1" body="$2" env_mode
+  [ -f "$ENV_FILE" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  [ -O "$ENV_FILE" ] || return 0
+  if stat --version >/dev/null 2>&1; then
+    env_mode="$(stat -c '%a' "$ENV_FILE" 2>/dev/null || true)"
+  else
+    env_mode="$(stat -f '%Lp' "$ENV_FILE" 2>/dev/null || true)"
+  fi
+  case "$env_mode" in 600 | 400) ;; *) return 0 ;; esac
+  body="$(printf '%s' "$body" | jq -Rrs --argjson n "$BODY_LIMIT" '.[0:$n]')"
+  (
+    umask 077
+    # shellcheck source=/dev/null
+    . "$ENV_FILE" 2>/dev/null || exit 0
+    { [ -n "${NTFY_URL:-}" ] && [ -n "${NTFY_TOPIC_ATTENTION:-}" ] && [ -n "${NTFY_TOKEN:-}" ]; } || exit 0
+    payload="$(jq -n --arg topic "$NTFY_TOPIC_ATTENTION" \
+      --arg title "macOS defaults drift detected (${count} key(s))" \
+      --arg message "$body" \
+      '{topic: $topic, title: $title, message: $message, priority: 4,
+        markdown: true, tags: ["rotating_light", "macos-defaults-drift"]}')" || exit 0
+    curl_cfg="$(mktemp "${TMPDIR:-/tmp}/macos-defaults-drift-ntfy.XXXXXX")" || exit 0
+    # EXIT alone misses signal deaths -- cover the catchable signals so the
+    # token file never lingers.
+    trap 'rm -f "$curl_cfg"' EXIT INT TERM HUP
+    printf 'header = "Authorization: Bearer %s"\n' "$NTFY_TOKEN" >"$curl_cfg"
+    if ! printf '%s' "$payload" | curl -fs -K "$curl_cfg" --max-time 5 \
+      -o /dev/null -d @- "$NTFY_URL" 2>/dev/null; then
+      log "ntfy publish failed: topic=${NTFY_TOPIC_ATTENTION} url=${NTFY_URL}"
+    fi
+  ) || true
+}
+
+main() {
+  [ "$(uname)" = "Darwin" ] || exit 0
+
+  mkdir -p "$(dirname "$LOG_FILE")"
+
+  # Rotate the log once it exceeds 1 MiB (weekly appends stay tiny; this is
+  # just a safety net, mirroring executable_morning-radar.sh).
+  if [ -f "$LOG_FILE" ] && [ "$(stat -f%z "$LOG_FILE" 2>/dev/null || echo 0)" -gt 1048576 ]; then
+    mv "$LOG_FILE" "${LOG_FILE}.old"
+  fi
+
+  if [ ! -f "$SSOT" ]; then
+    log "warn: SSOT script not found at $SSOT; skipping this cycle"
+    exit 0
+  fi
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/macos-defaults-drift.XXXXXX")"
+  trap 'rm -rf "$tmp_dir"' EXIT
+
+  build_expected "$tmp_dir"
+
+  local domain key type value expected actual candidate
+  local drift_lines="" drift_count=0
+
+  while IFS=$'\t' read -r domain key type value; do
+    is_excluded "$domain" "$key" && continue
+    expected="$(read_value "$tmp_dir/$domain" "$key")"
+    actual="$(read_value "$domain" "$key")"
+    if [ "$expected" != "$actual" ]; then
+      drift_count=$((drift_count + 1))
+      candidate="$(build_candidate "$domain" "$key" "$type" "$actual")"
+      drift_lines="${drift_lines}${domain} ${key}: expected [${expected}] actual [${actual}]
+${candidate}
+
+"
+    fi
+  done < <(parse_ssot)
+
+  if [ "$drift_count" -eq 0 ]; then
+    log "no drift detected"
+    exit 0
+  fi
+
+  log "drift detected: ${drift_count} key(s)"
+  ntfy_publish "$drift_count" "$drift_lines"
+  # Explicit exit (rather than falling off the end of main): the EXIT trap
+  # above references the function-local $tmp_dir, and that trap must fire
+  # while main()'s call frame -- and thus $tmp_dir -- is still alive. Falling
+  # through to the caller and letting the script exit naturally after main()
+  # has already returned would evaluate the trap with $tmp_dir out of scope
+  # (an unbound-variable error under `set -u`).
+  exit 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/home/dot_claude/executable_macos-defaults-drift-check.sh
+++ b/home/dot_claude/executable_macos-defaults-drift-check.sh
@@ -77,24 +77,33 @@ parse_ssot() {
   ' "$SSOT"
 }
 
-# Replay the SSOT's defaults-write lines against per-domain scratch plist
-# paths under $1 (a fresh mktemp -d), so the "expected" value for each
-# managed key can be read back with the exact same `defaults read` call used
-# on the real domain -- see the header comment for why this beats hand
-# type-coercion. Domain names are safe to use as bare filenames (no `/`, no
-# reserved characters on APFS). The unquoted $value in the array branch is
-# deliberate word-splitting so a multi-element array replays as multiple
-# `defaults write` arguments.
+# Replay parse_ssot's TSV rows (read from stdin -- the caller passes the same
+# parsed lines it also loops over, so the SSOT is only parsed once per run)
+# against per-domain scratch plist paths under $1 (a fresh mktemp -d), so the
+# "expected" value for each managed key can be read back with the exact same
+# `defaults read` call used on the real domain -- see the header comment for
+# why this beats hand type-coercion. Domain names are safe to use as bare
+# filenames (no `/`, no reserved characters on APFS). The unquoted $value in
+# the array branch is deliberate word-splitting so a multi-element array
+# replays as multiple `defaults write` arguments.
 build_expected() {
   local tmp_dir="$1" domain key type value scratch
   while IFS=$'\t' read -r domain key type value; do
     scratch="$tmp_dir/$domain"
     case "$type" in
       string) defaults write "$scratch" "$key" -string "$value" >/dev/null 2>&1 ;;
-      array) defaults write "$scratch" "$key" -array $value >/dev/null 2>&1 ;;
+      array)
+        # Word-split $value into separate `defaults write` arguments
+        # (deliberate, unquoted), but suppress pathname expansion so a
+        # value containing a glob metacharacter can't pull in filenames
+        # from $tmp_dir's cwd instead.
+        set -f
+        defaults write "$scratch" "$key" -array $value >/dev/null 2>&1
+        set +f
+        ;;
       *) defaults write "$scratch" "$key" "-$type" "$value" >/dev/null 2>&1 ;;
     esac
-  done < <(parse_ssot)
+  done
 }
 
 # Print the trimmed `defaults read` output for <domain-or-path> <key>, or the
@@ -131,18 +140,27 @@ is_excluded() {
 # one array-typed key today, and `defaults read`'s multi-line parenthesized
 # form isn't worth round-tripping generically for a single key -- the
 # candidate line says so and points at a manual `defaults read` instead.
+# "Manual inspection needed" lines use a "NOTE:" prefix rather than a leading
+# `#`: the notification body is published with markdown:true, and a `#`
+# at the start of a line is a CommonMark ATX heading, so it would render as
+# an oversized heading in the ntfy web app instead of as a comment.
 build_candidate() {
   local domain="$1" key="$2" type="$3" actual="$4"
+  if [ "$actual" = "(unset)" ]; then
+    printf 'NOTE: %s %s is no longer set locally -- inspect manually (defaults delete %s %s?)' \
+      "$domain" "$key" "$domain" "$key"
+    return
+  fi
   case "$type" in
     bool)
       case "$actual" in
         1) printf 'defaults write %s %s -bool true' "$domain" "$key" ;;
         0) printf 'defaults write %s %s -bool false' "$domain" "$key" ;;
-        *) printf '# %s %s: unexpected bool value %s -- inspect manually' "$domain" "$key" "$actual" ;;
+        *) printf 'NOTE: %s %s has an unexpected bool value %s -- inspect manually' "$domain" "$key" "$actual" ;;
       esac
       ;;
     array)
-      printf '# %s %s is array-typed -- inspect manually: defaults read %s %s' "$domain" "$key" "$domain" "$key"
+      printf 'NOTE: %s %s is array-typed -- inspect manually: defaults read %s %s' "$domain" "$key" "$domain" "$key"
       ;;
     string)
       printf 'defaults write %s %s -string %q' "$domain" "$key" "$actual"
@@ -197,6 +215,14 @@ ntfy_publish() {
 main() {
   [ "$(uname)" = "Darwin" ] || exit 0
 
+  # launchd provides a minimal PATH that excludes Homebrew/mise, so build one
+  # explicitly (mirrors executable_morning-radar.sh, including the
+  # $HOME/.local/launchers component that lets tests substitute stubs by
+  # sandboxing HOME). `jq` happens to also be bundled at /usr/bin on recent
+  # macOS, but don't rely on that undocumented coincidence for the
+  # notification path's only failure point.
+  export PATH="$HOME/.local/launchers:$HOME/.local/share/mise/shims:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
   mkdir -p "$(dirname "$LOG_FILE")"
 
   # Rotate the log once it exceeds 1 MiB (weekly appends stay tiny; this is
@@ -214,7 +240,12 @@ main() {
   tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/macos-defaults-drift.XXXXXX")"
   trap 'rm -rf "$tmp_dir"' EXIT
 
-  build_expected "$tmp_dir"
+  # Parse the SSOT once and feed the same lines to build_expected and the
+  # comparison loop below, rather than re-invoking parse_ssot (and re-reading
+  # the SSOT file) twice per run.
+  local ssot_lines
+  ssot_lines="$(parse_ssot)"
+  printf '%s\n' "$ssot_lines" | build_expected "$tmp_dir"
 
   local domain key type value expected actual candidate
   local drift_lines="" drift_count=0
@@ -231,7 +262,7 @@ ${candidate}
 
 "
     fi
-  done < <(parse_ssot)
+  done <<<"$ssot_lines"
 
   if [ "$drift_count" -eq 0 ]; then
     log "no drift detected"

--- a/home/run_onchange_after_30-register-launchd-agents.sh.tmpl
+++ b/home/run_onchange_after_30-register-launchd-agents.sh.tmpl
@@ -1,10 +1,11 @@
 {{ if eq .chezmoi.os "darwin" -}}
 #!/bin/bash
 # Register repo-managed launchd LaunchAgents (kryota-dev/dotfiles#257).
-# Re-runs whenever a managed plist changes (embedded hash below). Wrapper
+# Re-runs whenever a managed plist changes (embedded hashes below). Wrapper
 # script changes need no re-registration: launchd execs the file fresh on
 # every fire.
 # dev.kryota.morning-radar plist hash: {{ include "Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl" | sha256sum }}
+# dev.kryota.macos-defaults-drift plist hash: {{ include "Library/LaunchAgents/dev.kryota.macos-defaults-drift.plist.tmpl" | sha256sum }}
 set -euo pipefail
 
 # CI runners have no gui launchd domain, so bootstrap can never succeed there.
@@ -16,15 +17,24 @@ if [ -n "${CI:-}" ]; then
   exit 0
 fi
 
-plist="$HOME/Library/LaunchAgents/dev.kryota.morning-radar.plist"
-label="dev.kryota.morning-radar"
 domain="gui/$(id -u)"
 
-echo "[launchd-agents] registering ${label}..."
-launchctl bootout "${domain}/${label}" 2>/dev/null || true
-if ! launchctl bootstrap "${domain}" "${plist}"; then
-  echo "[launchd-agents] bootstrap failed (no GUI session?). Re-run 'chezmoi apply' from a GUI terminal." >&2
-  exit 1
-fi
-echo "[launchd-agents] ${label} registered."
+# register_agent <label> <plist-filename>: bootout any stale registration
+# (idempotent — a missing prior registration is not an error) then bootstrap
+# the current plist. A bootstrap failure hard-fails the whole script
+# (lifecycle convention #6) rather than continuing to the next agent, so
+# chezmoi retries this script on the next apply.
+register_agent() {
+  local label="$1" plist="$HOME/Library/LaunchAgents/$2"
+  echo "[launchd-agents] registering ${label}..."
+  launchctl bootout "${domain}/${label}" 2>/dev/null || true
+  if ! launchctl bootstrap "${domain}" "${plist}"; then
+    echo "[launchd-agents] bootstrap failed (no GUI session?). Re-run 'chezmoi apply' from a GUI terminal." >&2
+    return 1
+  fi
+  echo "[launchd-agents] ${label} registered."
+}
+
+register_agent "dev.kryota.morning-radar" "dev.kryota.morning-radar.plist" || exit 1
+register_agent "dev.kryota.macos-defaults-drift" "dev.kryota.macos-defaults-drift.plist" || exit 1
 {{ end -}}

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -140,6 +140,10 @@ load helpers/setup
   [ "$(grep -c '<key>Weekday</key>' "$plist")" -eq 1 ]
   [ "$(grep -c '<key>Hour</key>' "$plist")" -eq 1 ]
   [ "$(grep -c '<key>Minute</key>' "$plist")" -eq 1 ]
+  # Sunday 10:00, not just "some" values -- pin the actual schedule.
+  grep -A1 '<key>Weekday</key>' "$plist" | grep -q '<integer>0</integer>'
+  grep -A1 '<key>Hour</key>' "$plist" | grep -q '<integer>10</integer>'
+  grep -A1 '<key>Minute</key>' "$plist" | grep -q '<integer>0</integer>'
 }
 
 @test "macos-defaults-drift plist template renders to valid plist XML" {

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -126,6 +126,32 @@ load helpers/setup
   plutil -lint "${tmp}/agent.plist"
 }
 
+@test "macos-defaults-drift launchd agent source files exist (#365)" {
+  [ -f "${HOME_DIR}/Library/LaunchAgents/dev.kryota.macos-defaults-drift.plist.tmpl" ]
+  [ -f "${HOME_DIR}/dot_claude/executable_macos-defaults-drift-check.sh" ]
+  bash -n "${HOME_DIR}/dot_claude/executable_macos-defaults-drift-check.sh"
+}
+
+@test "macos-defaults-drift plist schedules exactly one weekly run and never runs at load" {
+  local plist="${HOME_DIR}/Library/LaunchAgents/dev.kryota.macos-defaults-drift.plist.tmpl"
+  run grep -q '<key>RunAtLoad</key>' "$plist"
+  [ "$status" -ne 0 ]
+  # Weekly: exactly one Weekday/Hour/Minute entry, not one per weekday.
+  [ "$(grep -c '<key>Weekday</key>' "$plist")" -eq 1 ]
+  [ "$(grep -c '<key>Hour</key>' "$plist")" -eq 1 ]
+  [ "$(grep -c '<key>Minute</key>' "$plist")" -eq 1 ]
+}
+
+@test "macos-defaults-drift plist template renders to valid plist XML" {
+  command -v plutil >/dev/null 2>&1 || skip "plutil unavailable"
+  local plist="${HOME_DIR}/Library/LaunchAgents/dev.kryota.macos-defaults-drift.plist.tmpl"
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  sed 's|{{ \.chezmoi\.homeDir }}|/Users/test|g' "$plist" >"${tmp}/agent.plist"
+  plutil -lint "${tmp}/agent.plist"
+}
+
 @test "launcher dir reaches interactive (precmd+sync) and login (zprofile) shells (#345)" {
   local zshrc="${HOME_DIR}/dot_zshrc.tmpl"
   local zprofile="${HOME_DIR}/dot_zprofile.tmpl"
@@ -220,12 +246,17 @@ load helpers/setup
   [ "$status" -eq 0 ]
 }
 
-@test "launchd registration script embeds the plist hash and guards CI" {
+@test "launchd registration script embeds both plist hashes and guards CI (#365)" {
   local script="${HOME_DIR}/run_onchange_after_30-register-launchd-agents.sh.tmpl"
-  # Re-registration is keyed to the plist content (embedded-hash trick).
+  # Re-registration is keyed to each plist's content (embedded-hash trick).
   grep -Fq 'plist hash: {{ include "Library/LaunchAgents/dev.kryota.morning-radar.plist.tmpl" | sha256sum }}' "$script"
+  grep -Fq 'plist hash: {{ include "Library/LaunchAgents/dev.kryota.macos-defaults-drift.plist.tmpl" | sha256sum }}' "$script"
   # CI runners have no gui launchd domain; the script must self-skip there.
   grep -Fq 'if [ -n "${CI:-}" ]; then' "$script"
+  # Both agents are registered through the shared function, not duplicated inline.
+  [ "$(grep -c '^register_agent "' "$script")" -eq 2 ]
+  grep -Fq 'register_agent "dev.kryota.morning-radar" "dev.kryota.morning-radar.plist"' "$script"
+  grep -Fq 'register_agent "dev.kryota.macos-defaults-drift" "dev.kryota.macos-defaults-drift.plist"' "$script"
   # Template-stripped body must be valid bash (same strip trick as make lint).
   bash -n <(sed '/{{/d' "$script")
 }

--- a/tests/macos_defaults_drift.bats
+++ b/tests/macos_defaults_drift.bats
@@ -1,0 +1,254 @@
+#!/usr/bin/env bats
+
+# macos-defaults-drift-check wrapper (home/dot_claude/executable_macos-defaults-drift-check.sh, #365).
+# The wrapper is source-safe (side effects live in main() behind a BASH_SOURCE
+# guard), so pure-parsing functions (parse_ssot/is_excluded/build_candidate)
+# are sourced and exercised on any OS, while functions that shell out to the
+# real `defaults` binary (build_expected/read_value/main()) are Darwin-only
+# and use a throwaway, uniquely-named test domain that is deleted in
+# teardown -- never a real macOS preference domain.
+
+load helpers/setup
+
+WRAPPER="${HOME_DIR}/dot_claude/executable_macos-defaults-drift-check.sh"
+TEST_DOMAIN="com.kryota.dotfiles-bats-fixture-365"
+
+setup() {
+  STUB_DIR="${BATS_TEST_TMPDIR}/stub"
+  mkdir -p "$STUB_DIR"
+  cat >"${STUB_DIR}/curl" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >"${NTFY_TEST_STUB_DIR}/curl_args"
+cat >"${NTFY_TEST_STUB_DIR}/curl_stdin"
+exit "${NTFY_TEST_CURL_EXIT:-0}"
+EOF
+  chmod +x "${STUB_DIR}/curl"
+
+  ENV_FILE="${BATS_TEST_TMPDIR}/notify-env"
+  cat >"$ENV_FILE" <<'EOF'
+NTFY_URL='http://127.0.0.1:9'
+NTFY_TOKEN='tk_bats_secret'
+NTFY_TOPIC_ATTENTION='claude-attention'
+EOF
+  chmod 600 "$ENV_FILE"
+
+  LOG_FILE="${BATS_TEST_TMPDIR}/drift.log"
+
+  # Fixture repo checkout: a minimal SSOT + .chezmoidata.toml, independent of
+  # this repo's real run_onchange_after_20-macos-defaults.sh.tmpl content so
+  # these tests don't churn every time that script's managed set changes.
+  FIXTURE_REPO="${BATS_TEST_TMPDIR}/fixture-repo"
+  mkdir -p "${FIXTURE_REPO}/home"
+  cat >"${FIXTURE_REPO}/home/run_onchange_after_20-macos-defaults.sh.tmpl" <<EOF
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+set -euo pipefail
+defaults write ${TEST_DOMAIN} TestBool -bool true
+defaults write ${TEST_DOMAIN} TestInt -int 42
+defaults write ${TEST_DOMAIN} TestFloat -float 0.5
+defaults write ${TEST_DOMAIN} TestString -string "Hello World"
+defaults write ${TEST_DOMAIN} TestArray -array 1 2 3
+defaults write ${TEST_DOMAIN} TestNoisy -bool true
+{{ end -}}
+EOF
+  cat >"${FIXTURE_REPO}/home/.chezmoidata.toml" <<EOF
+[macos_defaults_drift]
+  exclude_keys = [
+    "${TEST_DOMAIN}:TestNoisy",
+  ]
+EOF
+}
+
+teardown() {
+  if [ "$(uname)" = "Darwin" ]; then
+    defaults delete "$TEST_DOMAIN" >/dev/null 2>&1 || true
+  fi
+}
+
+# Source the wrapper (main() is guarded, so nothing runs) and call one of its
+# functions with the fixture repo/env, mirroring tests/morning_radar.bats.
+run_fn() {
+  run env \
+    PATH="${STUB_DIR}:${PATH}" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" \
+    NTFY_TEST_CURL_EXIT="${NTFY_TEST_CURL_EXIT:-0}" \
+    MACOS_DEFAULTS_DRIFT_REPO_DIR="$FIXTURE_REPO" \
+    MACOS_DEFAULTS_DRIFT_NTFY_ENV_FILE="$ENV_FILE" \
+    MACOS_DEFAULTS_DRIFT_LOG_FILE="$LOG_FILE" \
+    bash -c 'source "$1"; shift; fn="$1"; shift; "$fn" "$@"' _ "$WRAPPER" "$@"
+}
+
+@test "macos-defaults-drift-check.sh exists and passes bash -n" {
+  [ -f "$WRAPPER" ]
+  bash -n "$WRAPPER"
+}
+
+@test "token hygiene: no -H/--header Authorization, no set -x, token via -K" {
+  ! grep -E -- '(-H|--header)["'"'"'[:space:]]*"?Authorization' "$WRAPPER"
+  ! grep -qF 'set -x' "$WRAPPER"
+  grep -qF 'curl -fs -K' "$WRAPPER"
+}
+
+@test "never writes back to the repo or touches git (#365 hard constraint)" {
+  ! grep -qE '(^|[^a-zA-Z_])git (add|commit|push)([^a-zA-Z_]|$)' "$WRAPPER"
+  ! grep -qE '>[[:space:]]*"\$SSOT"' "$WRAPPER"
+}
+
+@test "parse_ssot extracts domain/key/type/value for bool/int/float/string/array" {
+  run_fn parse_ssot
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qF "$(printf '%s\tTestBool\tbool\ttrue' "$TEST_DOMAIN")"
+  printf '%s\n' "$output" | grep -qF "$(printf '%s\tTestInt\tint\t42' "$TEST_DOMAIN")"
+  printf '%s\n' "$output" | grep -qF "$(printf '%s\tTestFloat\tfloat\t0.5' "$TEST_DOMAIN")"
+  # Quoted, multi-word string value round-trips with its quotes stripped.
+  printf '%s\n' "$output" | grep -qF "$(printf '%s\tTestString\tstring\tHello World' "$TEST_DOMAIN")"
+  # Array keeps its space-separated tokens raw (build_expected word-splits them).
+  printf '%s\n' "$output" | grep -qF "$(printf '%s\tTestArray\tarray\t1 2 3' "$TEST_DOMAIN")"
+}
+
+@test "is_excluded matches domain:key entries from .chezmoidata.toml" {
+  run_fn is_excluded "$TEST_DOMAIN" "TestNoisy"
+  [ "$status" -eq 0 ]
+  run_fn is_excluded "$TEST_DOMAIN" "TestBool"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_excluded is fail-open (not excluded) when .chezmoidata.toml is missing" {
+  rm -f "${FIXTURE_REPO}/home/.chezmoidata.toml"
+  run_fn is_excluded "$TEST_DOMAIN" "TestNoisy"
+  [ "$status" -ne 0 ]
+}
+
+@test "build_candidate reconstructs a defaults write line per type" {
+  run_fn build_candidate "$TEST_DOMAIN" "TestBool" "bool" "0"
+  [ "$output" = "defaults write ${TEST_DOMAIN} TestBool -bool false" ]
+
+  run_fn build_candidate "$TEST_DOMAIN" "TestInt" "int" "7"
+  [ "$output" = "defaults write ${TEST_DOMAIN} TestInt -int 7" ]
+
+  run_fn build_candidate "$TEST_DOMAIN" "TestString" "string" "changed"
+  [ "$output" = "defaults write ${TEST_DOMAIN} TestString -string changed" ]
+}
+
+@test "build_candidate does not auto-regenerate array types (documented limitation)" {
+  run_fn build_candidate "$TEST_DOMAIN" "TestArray" "array" "1 2 9"
+  [[ "$output" == "# ${TEST_DOMAIN} TestArray is array-typed"* ]]
+  [[ "$output" == *"defaults read ${TEST_DOMAIN} TestArray" ]]
+}
+
+@test "ntfy_publish sends to topic_attention with the drift count and body (token via -K, never logged)" {
+  [ "$(uname)" = "Darwin" ] || skip "ntfy_publish's stat -f is BSD-only"
+  run_fn ntfy_publish 2 "domain key: expected [1] actual [0]"
+  [ "$status" -eq 0 ]
+  [ -f "${STUB_DIR}/curl_stdin" ]
+  [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
+  [ "$(jq -r .priority <"${STUB_DIR}/curl_stdin")" = "4" ]
+  jq -e '.title | test("2")' <"${STUB_DIR}/curl_stdin" >/dev/null
+  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin")" = "domain key: expected [1] actual [0]" ]
+  ! grep -q 'tk_bats_secret' "${STUB_DIR}/curl_args"
+  grep -qE -- '-K' "${STUB_DIR}/curl_args"
+}
+
+@test "ntfy_publish is fail-open: no env file -> silent no-op" {
+  MACOS_DEFAULTS_DRIFT_NTFY_ENV_FILE_ORIG="$ENV_FILE"
+  ENV_FILE="${BATS_TEST_TMPDIR}/does-not-exist"
+  run_fn ntfy_publish 1 "drift body"
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/curl_args" ]
+}
+
+@test "ntfy_publish is fail-open: curl failure returns 0, token never logged" {
+  [ "$(uname)" = "Darwin" ] || skip "ntfy_publish's stat -f is BSD-only"
+  NTFY_TEST_CURL_EXIT=1
+  run_fn ntfy_publish 1 "drift body"
+  [ "$status" -eq 0 ]
+  [ ! -f "$LOG_FILE" ] || ! grep -q 'tk_bats_secret' "$LOG_FILE"
+}
+
+# --- build_expected / read_value / main() integration (Darwin only: these
+# shell out to the real `defaults` binary against the throwaway TEST_DOMAIN) --
+
+@test "build_expected + read_value round-trip matches for bool/int/float/string/array" {
+  [ "$(uname)" = "Darwin" ] || skip "defaults(1) is macOS-only"
+  # Seed the real (throwaway) domain to exactly match the fixture SSOT.
+  defaults write "$TEST_DOMAIN" TestBool -bool true
+  defaults write "$TEST_DOMAIN" TestInt -int 42
+  defaults write "$TEST_DOMAIN" TestFloat -float 0.5
+  defaults write "$TEST_DOMAIN" TestString -string "Hello World"
+  defaults write "$TEST_DOMAIN" TestArray -array 1 2 3
+  defaults write "$TEST_DOMAIN" TestNoisy -bool true
+
+  run env MACOS_DEFAULTS_DRIFT_REPO_DIR="$FIXTURE_REPO" bash -c '
+    source "$1"
+    tmp_dir="$(mktemp -d)"
+    trap "rm -rf \"$tmp_dir\"" EXIT
+    build_expected "$tmp_dir"
+    while IFS=$'"'"'\t'"'"' read -r domain key type value; do
+      expected="$(read_value "$tmp_dir/$domain" "$key")"
+      actual="$(read_value "$domain" "$key")"
+      if [ "$expected" != "$actual" ]; then
+        echo "MISMATCH: $domain $key expected=[$expected] actual=[$actual]"
+        exit 1
+      fi
+    done < <(parse_ssot)
+    echo "all matched"
+  ' _ "$WRAPPER"
+  [ "$status" -eq 0 ]
+  [ "$output" = "all matched" ]
+}
+
+@test "read_value returns (unset) for a key that does not exist" {
+  [ "$(uname)" = "Darwin" ] || skip "defaults(1) is macOS-only"
+  defaults delete "$TEST_DOMAIN" NoSuchKey >/dev/null 2>&1 || true
+  run_fn read_value "$TEST_DOMAIN" "NoSuchKey"
+  [ "$status" -eq 0 ]
+  [ "$output" = "(unset)" ]
+}
+
+@test "main(): no drift when the real domain matches the SSOT -> no ntfy publish" {
+  [ "$(uname)" = "Darwin" ] || skip "macos-defaults-drift-check main() is Darwin-only"
+  defaults write "$TEST_DOMAIN" TestBool -bool true
+  defaults write "$TEST_DOMAIN" TestInt -int 42
+  defaults write "$TEST_DOMAIN" TestFloat -float 0.5
+  defaults write "$TEST_DOMAIN" TestString -string "Hello World"
+  defaults write "$TEST_DOMAIN" TestArray -array 1 2 3
+  defaults write "$TEST_DOMAIN" TestNoisy -bool true
+
+  run env \
+    PATH="${STUB_DIR}:${PATH}" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" \
+    MACOS_DEFAULTS_DRIFT_REPO_DIR="$FIXTURE_REPO" \
+    MACOS_DEFAULTS_DRIFT_NTFY_ENV_FILE="$ENV_FILE" \
+    MACOS_DEFAULTS_DRIFT_LOG_FILE="$LOG_FILE" \
+    bash "$WRAPPER"
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/curl_stdin" ]
+  grep -qF "no drift detected" "$LOG_FILE"
+}
+
+@test "main(): drift on a non-excluded key publishes a candidate; excluded key drift is silent" {
+  [ "$(uname)" = "Darwin" ] || skip "macos-defaults-drift-check main() is Darwin-only"
+  defaults write "$TEST_DOMAIN" TestBool -bool true
+  # Drifted: SSOT says 42.
+  defaults write "$TEST_DOMAIN" TestInt -int 99
+  defaults write "$TEST_DOMAIN" TestFloat -float 0.5
+  defaults write "$TEST_DOMAIN" TestString -string "Hello World"
+  defaults write "$TEST_DOMAIN" TestArray -array 1 2 3
+  # Also drifted, but excluded -- must not appear in the notification.
+  defaults write "$TEST_DOMAIN" TestNoisy -bool false
+
+  run env \
+    PATH="${STUB_DIR}:${PATH}" \
+    NTFY_TEST_STUB_DIR="$STUB_DIR" \
+    MACOS_DEFAULTS_DRIFT_REPO_DIR="$FIXTURE_REPO" \
+    MACOS_DEFAULTS_DRIFT_NTFY_ENV_FILE="$ENV_FILE" \
+    MACOS_DEFAULTS_DRIFT_LOG_FILE="$LOG_FILE" \
+    bash "$WRAPPER"
+  [ "$status" -eq 0 ]
+  [ -f "${STUB_DIR}/curl_stdin" ]
+  [ "$(jq -r .topic <"${STUB_DIR}/curl_stdin")" = "claude-attention" ]
+  jq -e '.title | test("1")' <"${STUB_DIR}/curl_stdin" >/dev/null
+  jq -r .message <"${STUB_DIR}/curl_stdin" | grep -qF "TestInt"
+  jq -r .message <"${STUB_DIR}/curl_stdin" | grep -qF "defaults write ${TEST_DOMAIN} TestInt -int 99"
+  ! (jq -r .message <"${STUB_DIR}/curl_stdin" | grep -qF "TestNoisy")
+}

--- a/tests/macos_defaults_drift.bats
+++ b/tests/macos_defaults_drift.bats
@@ -94,6 +94,13 @@ run_fn() {
   ! grep -qE '>[[:space:]]*"\$SSOT"' "$WRAPPER"
 }
 
+@test "main() builds an explicit PATH so jq/curl resolve under launchd's minimal PATH" {
+  # launchd doesn't inherit a login shell's PATH, so mise/Homebrew-installed
+  # jq would otherwise be unresolvable (silently breaking ntfy_publish's
+  # `command -v jq` guard). Mirrors executable_morning-radar.sh's export.
+  grep -qE 'export PATH="\$HOME/\.local/launchers:\$HOME/\.local/share/mise/shims' "$WRAPPER"
+}
+
 @test "parse_ssot extracts domain/key/type/value for bool/int/float/string/array" {
   run_fn parse_ssot
   [ "$status" -eq 0 ]
@@ -104,6 +111,19 @@ run_fn() {
   printf '%s\n' "$output" | grep -qF "$(printf '%s\tTestString\tstring\tHello World' "$TEST_DOMAIN")"
   # Array keeps its space-separated tokens raw (build_expected word-splits them).
   printf '%s\n' "$output" | grep -qF "$(printf '%s\tTestArray\tarray\t1 2 3' "$TEST_DOMAIN")"
+  # Exactly 6 rows -- no comment/template line is misparsed as extra output.
+  [ "$(printf '%s\n' "$output" | wc -l | tr -d ' ')" -eq 6 ]
+}
+
+@test "parse_ssot runs cleanly against this repo's real run_onchange_after_20-macos-defaults.sh.tmpl" {
+  run env PATH="${STUB_DIR}:${PATH}" MACOS_DEFAULTS_DRIFT_REPO_DIR="${HOME_DIR}/.." \
+    bash -c 'source "$1"; parse_ssot' _ "$WRAPPER"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  # Every row has exactly 4 tab-separated fields.
+  while IFS= read -r line; do
+    [ "$(printf '%s' "$line" | awk -F'\t' '{print NF}')" -eq 4 ]
+  done <<<"$output"
 }
 
 @test "is_excluded matches domain:key entries from .chezmoidata.toml" {
@@ -119,25 +139,59 @@ run_fn() {
   [ "$status" -ne 0 ]
 }
 
+@test "is_excluded is fail-open (not excluded) when .chezmoidata.toml has no [macos_defaults_drift] section" {
+  cat >"${FIXTURE_REPO}/home/.chezmoidata.toml" <<'EOF'
+[ntfy]
+  port = 2586
+EOF
+  run_fn is_excluded "$TEST_DOMAIN" "TestNoisy"
+  [ "$status" -ne 0 ]
+}
+
 @test "build_candidate reconstructs a defaults write line per type" {
+  run_fn build_candidate "$TEST_DOMAIN" "TestBool" "bool" "1"
+  [ "$output" = "defaults write ${TEST_DOMAIN} TestBool -bool true" ]
+
   run_fn build_candidate "$TEST_DOMAIN" "TestBool" "bool" "0"
   [ "$output" = "defaults write ${TEST_DOMAIN} TestBool -bool false" ]
+
+  run_fn build_candidate "$TEST_DOMAIN" "TestBool" "bool" "maybe"
+  [[ "$output" == "NOTE: ${TEST_DOMAIN} TestBool has an unexpected bool value maybe"* ]]
 
   run_fn build_candidate "$TEST_DOMAIN" "TestInt" "int" "7"
   [ "$output" = "defaults write ${TEST_DOMAIN} TestInt -int 7" ]
 
+  run_fn build_candidate "$TEST_DOMAIN" "TestFloat" "float" "1.5"
+  [ "$output" = "defaults write ${TEST_DOMAIN} TestFloat -float 1.5" ]
+
   run_fn build_candidate "$TEST_DOMAIN" "TestString" "string" "changed"
   [ "$output" = "defaults write ${TEST_DOMAIN} TestString -string changed" ]
+
+  # A value containing a space must stay a single argv token when pasted.
+  run_fn build_candidate "$TEST_DOMAIN" "TestString" "string" "New Value"
+  [ "$output" = "defaults write ${TEST_DOMAIN} TestString -string New\\ Value" ]
 }
 
 @test "build_candidate does not auto-regenerate array types (documented limitation)" {
   run_fn build_candidate "$TEST_DOMAIN" "TestArray" "array" "1 2 9"
-  [[ "$output" == "# ${TEST_DOMAIN} TestArray is array-typed"* ]]
+  [[ "$output" == "NOTE: ${TEST_DOMAIN} TestArray is array-typed"* ]]
   [[ "$output" == *"defaults read ${TEST_DOMAIN} TestArray" ]]
 }
 
+@test "build_candidate flags an unset key instead of emitting an invalid defaults write" {
+  run_fn build_candidate "$TEST_DOMAIN" "TestInt" "int" "(unset)"
+  [[ "$output" == "NOTE: ${TEST_DOMAIN} TestInt is no longer set locally"* ]]
+  ! [[ "$output" == *"(unset)"* ]]
+}
+
+@test "build_candidate's manual-inspection lines never start with # (markdown heading collision)" {
+  run_fn build_candidate "$TEST_DOMAIN" "TestArray" "array" "1 2 9"
+  [[ "$output" != "#"* ]]
+  run_fn build_candidate "$TEST_DOMAIN" "TestBool" "bool" "unexpected"
+  [[ "$output" != "#"* ]]
+}
+
 @test "ntfy_publish sends to topic_attention with the drift count and body (token via -K, never logged)" {
-  [ "$(uname)" = "Darwin" ] || skip "ntfy_publish's stat -f is BSD-only"
   run_fn ntfy_publish 2 "domain key: expected [1] actual [0]"
   [ "$status" -eq 0 ]
   [ -f "${STUB_DIR}/curl_stdin" ]
@@ -149,8 +203,15 @@ run_fn() {
   grep -qE -- '-K' "${STUB_DIR}/curl_args"
 }
 
+@test "ntfy_publish caps the body at BODY_LIMIT (3000) characters" {
+  local long_body
+  long_body="$(printf 'x%.0s' $(seq 1 4000))"
+  run_fn ntfy_publish 1 "$long_body"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r .message <"${STUB_DIR}/curl_stdin" | wc -c | tr -d ' ')" -eq 3001 ] # 3000 chars + trailing newline from jq -r
+}
+
 @test "ntfy_publish is fail-open: no env file -> silent no-op" {
-  MACOS_DEFAULTS_DRIFT_NTFY_ENV_FILE_ORIG="$ENV_FILE"
   ENV_FILE="${BATS_TEST_TMPDIR}/does-not-exist"
   run_fn ntfy_publish 1 "drift body"
   [ "$status" -eq 0 ]
@@ -158,7 +219,6 @@ run_fn() {
 }
 
 @test "ntfy_publish is fail-open: curl failure returns 0, token never logged" {
-  [ "$(uname)" = "Darwin" ] || skip "ntfy_publish's stat -f is BSD-only"
   NTFY_TEST_CURL_EXIT=1
   run_fn ntfy_publish 1 "drift body"
   [ "$status" -eq 0 ]
@@ -182,7 +242,8 @@ run_fn() {
     source "$1"
     tmp_dir="$(mktemp -d)"
     trap "rm -rf \"$tmp_dir\"" EXIT
-    build_expected "$tmp_dir"
+    ssot_lines="$(parse_ssot)"
+    printf "%s\n" "$ssot_lines" | build_expected "$tmp_dir"
     while IFS=$'"'"'\t'"'"' read -r domain key type value; do
       expected="$(read_value "$tmp_dir/$domain" "$key")"
       actual="$(read_value "$domain" "$key")"
@@ -190,11 +251,44 @@ run_fn() {
         echo "MISMATCH: $domain $key expected=[$expected] actual=[$actual]"
         exit 1
       fi
-    done < <(parse_ssot)
+    done <<<"$ssot_lines"
     echo "all matched"
   ' _ "$WRAPPER"
   [ "$status" -eq 0 ]
   [ "$output" = "all matched" ]
+}
+
+@test "build_expected separates multiple domains into distinct scratch plists (no cross-domain leakage)" {
+  [ "$(uname)" = "Darwin" ] || skip "defaults(1) is macOS-only"
+  local domain_a="${TEST_DOMAIN}.a" domain_b="${TEST_DOMAIN}.b"
+  local multi_repo="${BATS_TEST_TMPDIR}/multi-domain-repo"
+  mkdir -p "${multi_repo}/home"
+  cat >"${multi_repo}/home/run_onchange_after_20-macos-defaults.sh.tmpl" <<EOF
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+set -euo pipefail
+defaults write ${domain_a} SharedKeyName -int 1
+defaults write ${domain_b} SharedKeyName -int 2
+{{ end -}}
+EOF
+  defaults write "$domain_a" SharedKeyName -int 1
+  defaults write "$domain_b" SharedKeyName -int 2
+
+  run env MACOS_DEFAULTS_DRIFT_REPO_DIR="$multi_repo" bash -c '
+    source "$1"
+    tmp_dir="$(mktemp -d)"
+    trap "rm -rf \"$tmp_dir\"" EXIT
+    parse_ssot | build_expected "$tmp_dir"
+    a="$(read_value "$tmp_dir/'"$domain_a"'" SharedKeyName)"
+    b="$(read_value "$tmp_dir/'"$domain_b"'" SharedKeyName)"
+    printf "a=%s b=%s\n" "$a" "$b"
+  ' _ "$WRAPPER"
+  defaults delete "$domain_a" >/dev/null 2>&1 || true
+  defaults delete "$domain_b" >/dev/null 2>&1 || true
+  [ "$status" -eq 0 ]
+  # Each domain's scratch plist holds its OWN value for the same key name --
+  # they must not collide into a single shared scratch file.
+  [ "$output" = "a=1 b=2" ]
 }
 
 @test "read_value returns (unset) for a key that does not exist" {
@@ -214,8 +308,14 @@ run_fn() {
   defaults write "$TEST_DOMAIN" TestArray -array 1 2 3
   defaults write "$TEST_DOMAIN" TestNoisy -bool true
 
-  run env \
-    PATH="${STUB_DIR}:${PATH}" \
+  # main() rebuilds PATH from $HOME (mirrors executable_morning-radar.sh, to
+  # survive launchd's minimal PATH), so stub curl is substituted by sandboxing
+  # HOME and placing it under $HOME/.local/launchers -- prefixing PATH alone
+  # would be overridden by that rebuild.
+  local fake_home="${BATS_TEST_TMPDIR}/home-no-drift"
+  mkdir -p "${fake_home}/.local/launchers"
+  cp "${STUB_DIR}/curl" "${fake_home}/.local/launchers/curl"
+  run env -i HOME="$fake_home" \
     NTFY_TEST_STUB_DIR="$STUB_DIR" \
     MACOS_DEFAULTS_DRIFT_REPO_DIR="$FIXTURE_REPO" \
     MACOS_DEFAULTS_DRIFT_NTFY_ENV_FILE="$ENV_FILE" \
@@ -237,8 +337,10 @@ run_fn() {
   # Also drifted, but excluded -- must not appear in the notification.
   defaults write "$TEST_DOMAIN" TestNoisy -bool false
 
-  run env \
-    PATH="${STUB_DIR}:${PATH}" \
+  local fake_home="${BATS_TEST_TMPDIR}/home-drift"
+  mkdir -p "${fake_home}/.local/launchers"
+  cp "${STUB_DIR}/curl" "${fake_home}/.local/launchers/curl"
+  run env -i HOME="$fake_home" \
     NTFY_TEST_STUB_DIR="$STUB_DIR" \
     MACOS_DEFAULTS_DRIFT_REPO_DIR="$FIXTURE_REPO" \
     MACOS_DEFAULTS_DRIFT_NTFY_ENV_FILE="$ENV_FILE" \


### PR DESCRIPTION
## Summary

- Adds a weekly launchd job (`dev.kryota.macos-defaults-drift`) that detects drift between the live values of macOS `defaults` domains/keys and what `run_onchange_after_20-macos-defaults.sh.tmpl` (#364) would set, and notifies via the existing ntfy `topic_attention` channel when they differ — detect-and-notify only, never writing back to the repo or touching git (hard constraint from the issue).
- Comparison strategy: the SSOT script's `defaults write` lines are replayed against a scratch plist path so both the "expected" and "actual" values are read back with the exact same `defaults read` call, avoiding hand-rolled type coercion across bool/int/float/string/array. An earlier `defaults export | plutil -convert json` design was tried and rejected — some real domains contain `NSData`-typed values that `plutil` refuses to convert to JSON, which per-key `defaults read` never touches (see design doc for the reproduction).
- A noise-key exclusion list lives in a new `[macos_defaults_drift]` section of `home/.chezmoidata.toml` (`exclude_keys`, "domain:key" formatted, empty by default since #364 already curated the managed keys down to stable ones — this is a safety valve for the future, not a currently-needed list).
- `run_onchange_after_30-register-launchd-agents.sh.tmpl` is refactored to a shared `register_agent <label> <plist>` function and now registers both `dev.kryota.morning-radar` and `dev.kryota.macos-defaults-drift`.
- Updates `docs/architecture/lifecycle-scripts.md`/`.ja.md` (new script's role, second embedded-hash entry) and `docs/architecture/notifications.md`/`.ja.md` (drift notifications reuse `claude-attention`).

Closes #365 (follow-up to #364).

## Design notes

Full requirements/design/task breakdown: `.spec-workflow/specs/macos-defaults-drift-detection/` (gitignored, not part of this diff, but referenced here for reviewers who want the fuller rationale — the [macos_defaults_drift] exclusion-list placement, weekly schedule, and topic reuse were confirmed with the user via a lightweight intent gate before implementation).

Known gap (pre-existing, not introduced by this PR): `setup-validation.yml` (which would run `chezmoi apply` on a real macOS CI runner) is disabled at the repo level, and the actual `CI` workflow only runs `make lint`/`make test-bats` on `ubuntu-latest` — so this PR's `defaults`/launchd behavior is verified via `bats` against a throwaway test domain plus manual dry-runs against the real (but unmodified) system during development, not by CI. Live `chezmoi apply` verification (registering the actual LaunchAgent) is deferred until after review, matching how #364 was handled.

## Test plan

- [x] `make lint` passes (shellcheck/shfmt/zsh syntax)
- [x] `make test` passes (293 bats assertions, including the 15 new in `tests/macos_defaults_drift.bats`)
- [x] Manually verified `parse_ssot`/`build_expected`/`read_value` against this machine's real, already-applied `run_onchange_after_20-macos-defaults.sh.tmpl` state (all 34 managed keys matched, zero drift) — read-only, no writes to real domains
- [x] Manually verified drift detection + candidate-command generation + noise-key exclusion using a throwaway `defaults` domain (never a real preference domain)
- [x] Rendered both new/changed chezmoi templates (`chezmoi execute-template`) and validated the plist with `plutil -lint`
- [ ] Live `chezmoi apply` + `launchctl` registration check on this machine (deferred to after review, per the note above)
