### PR TITLE
fix(chezmoi): .chezmoiremove の大文字小文字衝突を解消する (#351)

### DIFF
--- a/home/.chezmoiremove
+++ b/home/.chezmoiremove
@@ -98,11 +98,6 @@
 .agents/skills/save-session
 .agents/skills/wtp-workspace
 
-# github-projects: skill.md was renamed to SKILL.md (#254 / PR #271) so Claude Code
-# skill discovery picks it up. On case-sensitive filesystems the old lowercase copy
-# would otherwise stay behind. Deployed path is ~/.agents/skills/github-projects/.
-.agents/skills/github-projects/skill.md
-
 # Curated skill inventory cleanup (2026-07-27 stocktake, #369). One skill retired from
 # the source tree: cleanup-plan — a 62-line wrapper over a single `> <plan-file>` shell
 # redirect with no non-obvious logic, unreferenced by any skill/agent/test/CLAUDE.md and

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -1465,6 +1465,44 @@ FAKE_CLAUDE
   [ "$status" -eq 1 ]
 }
 
+@test ".chezmoiremove entries never collide with a managed path by case only (#351)" {
+  # On macOS's default case-insensitive APFS, a .chezmoiremove entry that
+  # differs from a real managed path only by case (e.g. skill.md vs SKILL.md)
+  # resolves to the SAME file: every apply deletes the managed file it just
+  # wrote, then the next apply re-detects it as "changed since last written"
+  # and never converges (#351, github-projects/skill.md vs SKILL.md). Cross-
+  # check every entry against `chezmoi managed` to guard against reintroducing
+  # this class of bug.
+  command -v chezmoi >/dev/null 2>&1 || skip "chezmoi unavailable"
+  local remove_file="${HOME_DIR}/.chezmoiremove"
+  local managed
+  managed="$(chezmoi managed --source "${HOME_DIR}" 2>/dev/null)"
+  [ -n "$managed" ]
+
+  local entries=()
+  local line
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    entries+=("$line")
+  done <"$remove_file"
+  [ "${#entries[@]}" -gt 0 ]
+
+  local collisions="" entry lower_entry m lower_m
+  for entry in "${entries[@]}"; do
+    lower_entry="$(printf '%s' "$entry" | tr '[:upper:]' '[:lower:]')"
+    while IFS= read -r m; do
+      [ -z "$m" ] && continue
+      [ "$m" = "$entry" ] && continue
+      lower_m="$(printf '%s' "$m" | tr '[:upper:]' '[:lower:]')"
+      if [ "$lower_m" = "$lower_entry" ]; then
+        collisions+="${entry} <-> ${m}"$'\n'
+      fi
+    done <<<"$managed"
+  done
+
+  [ -z "$collisions" ] || { printf '%s' "$collisions" >&2; false; }
+}
+
 @test "mcp setup registers all servers as user scope for every account config dir" {
   local script="${HOME_DIR}/run_onchange_after_13-setup-mcp.sh.tmpl"
   [ -f "$script" ]


### PR DESCRIPTION
## 概要

`home/.chezmoiremove` の `github-projects/skill.md` エントリが、macOS の既定である大文字小文字を
区別しない APFS 上で `SKILL.md` 自身と衝突し、`chezmoi apply` のたびに `SKILL.md` を削除 → 次の
apply で「chezmoi last wrote it と異なる」プロンプトが出て収束しないループを起こしていた（#351）。

## 原因

このエントリは #254/PR #271 で `skill.md` → `SKILL.md` へのリネーム移行時に、大文字小文字を
区別する（Linux 等の）ファイルシステム向けの後始末として追加されたもの。しかし
macOS の既定ファイルシステム（APFS、大文字小文字を区別しない）では `skill.md` と `SKILL.md` は
同一のディレクトリエントリを指すため、この削除指示は「取り消し済みの旧ファイル」ではなく
「現在有効な `SKILL.md` そのもの」を毎回削除してしまっていた。移行は既に完了しており、このエントリは
もう役目を終えている。

## 変更内容

- `home/.chezmoiremove` から該当エントリ（コメント含む）を削除する。
- `tests/files.bats` に、`.chezmoiremove` の各エントリが `chezmoi managed` の出力と
  大文字小文字のみ異なっていないかを検知する回帰テストを追加する（`chezmoi` が無い環境では skip）。

## テスト計画

- [x] `make lint`（shellcheck + shfmt + zsh 構文チェック）
- [x] `make test`（lint + 全317 bats テスト、新規回帰テストを含む）
- [x] `chezmoi status --source <このブランチの home/>` で対象エントリの異常（`AD`/`DA` 状態）が
      解消されていることを確認

closes #351
