### PR TITLE
docs(model-fitness-check): 世代例示と品質劣化記録指示を削除する

### DIFF
--- a/home/dot_agents/skills/model-fitness-check/SKILL.md
+++ b/home/dot_agents/skills/model-fitness-check/SKILL.md
@@ -27,7 +27,7 @@ argument-hint: "<work tier>（例: orchestration / large / trivial-small）"
 
 ## capability 順序（monotonic）
 
-能力順序を **Fable > Opus > Sonnet > Haiku** と定義する。同一 family 内では **generation が効く**（Opus 4.8 は Opus 5 の floor を**満たさない**）。
+能力順序を **Fable > Opus > Sonnet > Haiku** と定義する。同一 family 内では **generation が効く**。
 
 判定は **2 パス**で構成する（詳細は「判定と出力」）。**floor パス（上方向）を通過しても判定は終わらず、必ず over-provision パス（下方向）に進む**——ここが over-provision ゲートに到達する唯一の経路なので、floor パスを「無条件 silent pass」で早期 return してはならない:
 
@@ -47,7 +47,7 @@ argument-hint: "<work tier>（例: orchestration / large / trivial-small）"
 
 - `[1m]` などの context-window suffix を除去してから比較する。
 - alias（`opus` / `sonnet` / `haiku` / `fable`）を現行 generation に解決する。
-- **family + generation** で比較する（Opus 4.8 は Opus 5 floor を満たさない）。
+- **family + generation** で比較する。
 - 判定不能な unknown 文字列は **fail-safe**（silent pass せず、チェックを提示する）。
 
 ## 判定と出力
@@ -59,7 +59,7 @@ argument-hint: "<work tier>（例: orchestration / large / trivial-small）"
 `AskUserQuestion` で **blocking** し、次の 3 択を提示する:
 
 1. **switch して再実行**: literal な切り替えコマンドを表示する（例: `/model opus`、xhigh 行なら加えて `/effort xhigh`）。user が切り替えてから再開。
-2. **continue anyway**: このまま進む。**どの phase の品質が劣化する見込みか**を 1 行記録する（decision log / PR の 1 行）。
+2. **continue anyway**: このまま進む。
 3. **abort**: 作業を中止する。
 
 - **effort は xhigh を要求する行でのみ言及する**。既定 high で足りる行では effort に一切触れない（`/effort` コマンドも出さない）。


### PR DESCRIPTION
## 概要

`model-fitness-check` skill（`home/dot_agents/skills/model-fitness-check/SKILL.md`）から、排除対象だった 2 種類の記載を削除する。

## 変更内容

- SKILL.md:30, SKILL.md:50 の世代例示（Opus 4.8 は Opus 5 の floor を満たさない、という括弧書き）を削除。「family + generation で比較する」という規則そのものは維持。
- SKILL.md:62 の continue anyway 選択肢から、「どの phase の品質が劣化する見込みか」を記録させる指示を削除。品質劣化の事前記録が、そのモデルで作業を続けた際の予期バイアス（劣化前提での成果物の扱い・自己成就的な品質評価の歪み）を招く懸念があるため。

## 受け入れ条件

- [x] SKILL.md に Opus 4.8 の世代例示が存在しない（2 箇所とも削除、世代比較ルール自体は維持されている）
- [x] continue anyway の選択肢に品質劣化見込みの記録を求める文言が存在しない

Closes #392
