### PR TITLE
[PENDING] feat: chatshelf プラグインをアカウント分離込みで導入する

### DIFF
--- a/docs/agents/account-isolation.ja.md
+++ b/docs/agents/account-isolation.ja.md
@@ -22,10 +22,14 @@
 | `ECC_MCP_HEALTH_STATE_PATH` | `~/.claude/mcp-health-cache.json` | `~/.claude-r06/mcp-health-cache.json` |
 | `GATEGUARD_STATE_DIR` | `~/.claude/.gateguard` | `~/.claude-r06/.gateguard` |
 | `CODEX_HOME` | （デフォルト — `~/.codex`） | `~/.codex-r06` |
+| `CODE_EXPL_STORE_ROOT` | `~/.claude/code-explanations` | `~/.claude-r06/code-explanations` |
+| `CODE_EXPL_PORT` | `7788` | `7789` |
 
 r06 の Claude 設定ディレクトリ（`~/.claude-r06`）には、すべての設定アーティファクト（settings、agents、commands、skills）が `~/.claude` を指すシンボリックリンクのみが含まれます。アカウント間で異なるのは、これらの環境変数がツールに書き込むよう指示するランタイム状態のみです。
 
 `CLV2_HOMUNCULUS_DIR` だけは `~/.claude` / `~/.claude-r06` の外、`~/.local/share/` 配下に完全に置かれています。Claude Code は config dir 配下のすべてのパスを sensitive file として扱い Write に対話承認を要求しますが、CLV2 の解析セッションは headless（`claude --model haiku --print`）で動くためその承認を得ることができず、instinct の書き込みがすべて失敗していました（issue #336）。他のアカウント別変数（`CLAUDE_CONFIG_DIR`、`ECC_AGENT_DATA_HOME`、`ECC_MCP_HEALTH_STATE_PATH`、`GATEGUARD_STATE_DIR`）が config dir 配下のままなのは、それらが Claude Code の Write ツールを経由せず node / shell コードから直接書き込まれるため、このゲートに引っかからないからです。
+
+`CODE_EXPL_STORE_ROOT` と `CODE_EXPL_PORT` は [Chatshelf](claude-code.ja.md) プラグインをアカウント別に分離します。各アカウントの PostToolUse 登録フックと SessionStart の viewer サーバーはそれぞれ自分の `code-explanations/` ストアに書き込み、r06 の viewer は `7789` を bind するので両アカウントのサーバーを同時に起動できます（`server.mjs` は `EADDRINUSE` で `exit 0` するため、`7788` を共有すると後から起動したアカウントが黙って相手の shelf を配信してしまいます）。これらは他の node 書き込み変数と同様 config dir 配下に置かれ、claude ラッパー（後述）が注入します。だからこそフックと viewer は — exec された claude の子プロセスとして — これらを継承します。ひとつだけ上流由来の制約が残ります。`server.mjs` は transcript を `~/.claude/projects` 固定で読み `CLAUDE_CONFIG_DIR` を見ないため、r06 アカウントでは viewer のセッション preview と `claude://resume` 補助が r06 セッションを解決できません。これは transcript 紐付きの preview のみが劣化するもので、アカウント別の shelf 分離（プライバシー境界）には影響しません。
 
 ---
 

--- a/docs/agents/account-isolation.md
+++ b/docs/agents/account-isolation.md
@@ -22,10 +22,14 @@ These variables are set inline on the agent subprocess — they are never export
 | `ECC_MCP_HEALTH_STATE_PATH` | `~/.claude/mcp-health-cache.json` | `~/.claude-r06/mcp-health-cache.json` |
 | `GATEGUARD_STATE_DIR` | `~/.claude/.gateguard` | `~/.claude-r06/.gateguard` |
 | `CODEX_HOME` | (default — `~/.codex`) | `~/.codex-r06` |
+| `CODE_EXPL_STORE_ROOT` | `~/.claude/code-explanations` | `~/.claude-r06/code-explanations` |
+| `CODE_EXPL_PORT` | `7788` | `7789` |
 
 The r06 Claude config directory (`~/.claude-r06`) contains only symlinks pointing back to `~/.claude` for every config artifact (settings, agents, commands, skills). What differs between accounts is entirely in the state that these env vars direct the tools to write.
 
 `CLV2_HOMUNCULUS_DIR` is the one directory that lives entirely outside `~/.claude` / `~/.claude-r06`, under `~/.local/share/`: Claude Code treats every path under the config dir as a sensitive file requiring interactive Write approval, and the CLV2 analysis session runs headless (`claude --model haiku --print`), so it could never grant that approval and every instinct write failed (issue #336). The other per-account vars (`CLAUDE_CONFIG_DIR`, `ECC_AGENT_DATA_HOME`, `ECC_MCP_HEALTH_STATE_PATH`, `GATEGUARD_STATE_DIR`) stay under the config dir because they are written directly by node/shell code rather than through Claude Code's Write tool, so they never hit that gate.
+
+`CODE_EXPL_STORE_ROOT` and `CODE_EXPL_PORT` isolate the [Chatshelf](claude-code.md) plugin per account: each account's PostToolUse registration hook and SessionStart viewer server write to their own `code-explanations/` store, and the r06 viewer binds `7789` so both accounts' servers can run at once (`server.mjs` exits 0 on `EADDRINUSE`, so a shared `7788` would leave whichever account started second silently serving the other account's shelf). Like the other node-written vars, these live under the config dir; they are injected by the claude wrapper (below), which is why the hook and viewer — children of the exec'd claude — inherit them. One upstream limitation remains: `server.mjs` reads transcripts from a hardcoded `~/.claude/projects`, ignoring `CLAUDE_CONFIG_DIR`, so on the r06 account the viewer's session preview and `claude://resume` helper cannot resolve r06 sessions. This degrades only the transcript-linked preview — the per-account shelf isolation (the privacy boundary) is unaffected.
 
 ---
 

--- a/docs/agents/claude-code.ja.md
+++ b/docs/agents/claude-code.ja.md
@@ -74,15 +74,17 @@
 
 `statusLine` フィールドは `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/statusline.sh` を指し、同じ settings.json を両アカウントで共用できます。
 
-2つのプラグインを宣言しています：
+3つのプラグインを宣言しています：
 
 | プラグイン | 提供内容 |
 |---|---|
 | `codex@openai-codex` | Claude Code 内から Codex CLI（OpenAI）へ相談する機能 |
 | `claude-code-setup@claude-plugins-official` | Anthropic 公式の read-only コードベース分析ツール。hooks・skills・MCP サーバー・サブエージェントを推奨する |
+| `chatshelf@chatshelf` | Claude Code が scratchpad に書き出す「コード説明」HTML をセッション紐付きで管理するローカルライブラリ + viewer（ストア `$CLAUDE_CONFIG_DIR/code-explanations`、viewer `127.0.0.1:7788`（個人）/ `:7789`（r06）— [アカウント分離](account-isolation.ja.md) 参照） |
 
 `enabledPlugins` がプラグインを、`extraKnownMarketplaces` がその入手元となる非公式 marketplace を宣言します
-（`openai-codex` → `openai/codex-plugin-cc`、タグ `v1.0.6` に pin）。ただしどちらのキーも、それ自体は
+（`openai-codex` → `openai/codex-plugin-cc`、タグ `v1.0.6` に pin；`chatshelf` → `NoritakaIkeda/chatshelf`、
+タグ `v0.1.0` に pin）。ただしどちらのキーも、それ自体は
 インストールを行いません。CLI は `enabledPlugins` を「*すでにインストール済みの*プラグイン」の有効/無効
 スイッチとして扱い、settings.json に宣言があるだけでは marketplace を登録しません
 （[anthropics/claude-code#23737](https://github.com/anthropics/claude-code/issues/23737)（duplicate でクローズ）、

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -74,15 +74,17 @@ This document covers the Claude Code harness configuration deployed by this dotf
 
 The `statusLine` field points to `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/statusline.sh` so the same settings file works for both accounts.
 
-Two plugins are declared:
+Three plugins are declared:
 
 | Plugin | Provides |
 |---|---|
 | `codex@openai-codex` | Codex CLI (OpenAI) consultation from within Claude Code |
 | `claude-code-setup@claude-plugins-official` | Anthropic-official read-only codebase analyzer that recommends hooks, skills, MCP servers, and subagents |
+| `chatshelf@chatshelf` | Session-linked local library + viewer for the "code explanation" HTML Claude Code writes to a scratchpad (store `$CLAUDE_CONFIG_DIR/code-explanations`, viewer `127.0.0.1:7788` personal / `:7789` r06 — see [account isolation](account-isolation.md)) |
 
 `enabledPlugins` names the plugins, and `extraKnownMarketplaces` names the non-official marketplaces
-they come from (`openai-codex` → `openai/codex-plugin-cc`, pinned to tag `v1.0.6`). Neither key
+they come from (`openai-codex` → `openai/codex-plugin-cc`, pinned to tag `v1.0.6`; `chatshelf` →
+`NoritakaIkeda/chatshelf`, pinned to tag `v0.1.0`). Neither key
 installs anything by itself: the CLI treats `enabledPlugins` as a switch for plugins that are
 *already* installed, and it does not register a marketplace merely because settings.json declares one
 — see [anthropics/claude-code#23737](https://github.com/anthropics/claude-code/issues/23737) (closed

--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -515,7 +515,8 @@
   "effortLevel": "xhigh",
   "enabledPlugins": {
     "codex@openai-codex": true,
-    "claude-code-setup@claude-plugins-official": true
+    "claude-code-setup@claude-plugins-official": true,
+    "chatshelf@chatshelf": true
   },
   "extraKnownMarketplaces": {
     "openai-codex": {
@@ -523,6 +524,13 @@
         "source": "github",
         "repo": "openai/codex-plugin-cc",
         "ref": "v1.0.6"
+      }
+    },
+    "chatshelf": {
+      "source": {
+        "source": "github",
+        "repo": "NoritakaIkeda/chatshelf",
+        "ref": "v0.1.0"
       }
     }
   },

--- a/home/dot_local/launchers/executable_claude
+++ b/home/dot_local/launchers/executable_claude
@@ -62,6 +62,18 @@ export ECC_AGENT_DATA_HOME="$CLAUDE_CONFIG_DIR"
 export CLV2_HOMUNCULUS_DIR="$HOME/.local/share/ecc-homunculus-${homunculus_slug}"
 export ECC_MCP_HEALTH_STATE_PATH="$CLAUDE_CONFIG_DIR/mcp-health-cache.json"
 export GATEGUARD_STATE_DIR="$CLAUDE_CONFIG_DIR/.gateguard"
+# Chatshelf (NoritakaIkeda/chatshelf) keeps its explanation shelf and viewer server per-account,
+# on the same "state isolated via env" rule as the vars above. The PostToolUse registration hook
+# and the SessionStart viewer both run as children of this exec'd process, so they inherit this env
+# and each account writes to its own store. The r06 viewer takes 7789 so both accounts' servers can
+# run at once: server.mjs exits 0 on EADDRINUSE, so a shared 7788 would leave whichever account
+# started second silently serving the other account's shelf.
+export CODE_EXPL_STORE_ROOT="$CLAUDE_CONFIG_DIR/code-explanations"
+if [ "$homunculus_slug" = default ]; then
+  export CODE_EXPL_PORT=7788
+else
+  export CODE_EXPL_PORT=7789
+fi
 # Observer knobs, each overridable. The 300s watchdog (vs the 120s upstream default) lets the
 # Haiku analysis pass finish (#256); OBSERVER_ACTIVE_HOURS 0/0 disables the clock gate that
 # skipped cycles because sessions run past midnight (#336); MAX_TURNS 100 is the upstream cap,

--- a/tests/claude_launcher.bats
+++ b/tests/claude_launcher.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+load helpers/setup
+
+# Behavioral guard for the per-account Chatshelf isolation env the claude wrapper injects
+# (home/dot_local/launchers/executable_claude): each account must get its own explanation store
+# (CODE_EXPL_STORE_ROOT) and viewer port (CODE_EXPL_PORT), following the same "state isolated via
+# env" rule as CLAUDE_CONFIG_DIR et al. The hook and SessionStart viewer inherit this env because
+# they run as children of the exec'd claude, so asserting the wrapper's exports is the seam.
+#
+# The wrapper is exercised directly with a stub "real" claude wired in via CLAUDE_LAUNCHER_BIN
+# (mirroring brew_launcher.bats' BREW_LAUNCHER_BIN seam), so `mise which claude` is never called and
+# no real claude/mise install is needed (CI-safe). The stub prints the isolation env it inherited.
+
+WRAPPER="${HOME_DIR}/dot_local/launchers/executable_claude"
+
+setup() {
+  FAKE_HOME="$BATS_TEST_TMPDIR/home"
+  BINDIR="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$FAKE_HOME" "$BINDIR"
+
+  # Stub claude: print the per-account isolation env the wrapper exported, then exit 0.
+  STUB_CLAUDE="$BATS_TEST_TMPDIR/stub-claude"
+  cat >"$STUB_CLAUDE" <<'STUBEOF'
+#!/usr/bin/env bash
+printf 'CLAUDE_CONFIG_DIR=%s\n' "$CLAUDE_CONFIG_DIR"
+printf 'CODE_EXPL_STORE_ROOT=%s\n' "$CODE_EXPL_STORE_ROOT"
+printf 'CODE_EXPL_PORT=%s\n' "$CODE_EXPL_PORT"
+exit 0
+STUBEOF
+  chmod +x "$STUB_CLAUDE"
+}
+
+# Run the wrapper invoked as $1 (claude / cld / cld-r06) so its $0 dispatch fires, with a controlled
+# HOME and the stub claude wired in. Extra args are VAR=VAL env assignments (e.g. an inherited
+# CLAUDE_CONFIG_DIR for the fill-gaps case). env -i isolates from the runner's own environment;
+# EXA_API_KEY=/FIRECRAWL_API_KEY= are present-but-empty so the wrapper's ${VAR+x} guard skips
+# sourcing the 0600 secrets file (absent under the fake HOME).
+_run_as() {
+  local name="$1"
+  shift
+  local link="$BINDIR/$name"
+  ln -sf "$WRAPPER" "$link"
+  run env -i \
+    HOME="$FAKE_HOME" \
+    PATH="/usr/bin:/bin" \
+    EXA_API_KEY= \
+    FIRECRAWL_API_KEY= \
+    CLAUDE_LAUNCHER_BIN="$STUB_CLAUDE" \
+    "$@" \
+    bash "$link"
+}
+
+@test "claude launcher exists and has valid bash syntax" {
+  [ -f "$WRAPPER" ]
+  bash -n "$WRAPPER"
+}
+
+@test "claude launcher: personal account (cld) derives the ~/.claude store and port 7788" {
+  _run_as cld
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qxF "CLAUDE_CONFIG_DIR=$FAKE_HOME/.claude"
+  printf '%s\n' "$output" | grep -qxF "CODE_EXPL_STORE_ROOT=$FAKE_HOME/.claude/code-explanations"
+  printf '%s\n' "$output" | grep -qxF "CODE_EXPL_PORT=7788"
+}
+
+@test "claude launcher: bare 'claude' matches the personal account (#345 parity)" {
+  _run_as claude
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qxF "CODE_EXPL_STORE_ROOT=$FAKE_HOME/.claude/code-explanations"
+  printf '%s\n' "$output" | grep -qxF "CODE_EXPL_PORT=7788"
+}
+
+@test "claude launcher: work account (cld-r06) derives the ~/.claude-r06 store and port 7789" {
+  _run_as cld-r06
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qxF "CLAUDE_CONFIG_DIR=$FAKE_HOME/.claude-r06"
+  printf '%s\n' "$output" | grep -qxF "CODE_EXPL_STORE_ROOT=$FAKE_HOME/.claude-r06/code-explanations"
+  printf '%s\n' "$output" | grep -qxF "CODE_EXPL_PORT=7789"
+}
+
+@test "claude launcher: cld fills gaps — an inherited r06 config dir keeps store/port on r06" {
+  _run_as cld "CLAUDE_CONFIG_DIR=$FAKE_HOME/.claude-r06"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | grep -qxF "CODE_EXPL_STORE_ROOT=$FAKE_HOME/.claude-r06/code-explanations"
+  printf '%s\n' "$output" | grep -qxF "CODE_EXPL_PORT=7789"
+}
+
+@test "claude launcher passes shellcheck" {
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    skip "shellcheck not installed"
+  fi
+  shellcheck --shell=bash --exclude=SC1091,SC2034,SC2086,SC2317,SC2329 "$WRAPPER"
+}

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -877,6 +877,7 @@ case "${1:-} ${2:-}" in
         case "$repo" in
           anthropics/claude-plugins-official) key=claude-plugins-official ;;
           openai/codex-plugin-cc) key=openai-codex ;;
+          NoritakaIkeda/chatshelf) key=chatshelf ;;
           *) echo "unknown marketplace source: $src" >&2; exit 1 ;;
         esac
         ref=""
@@ -937,10 +938,13 @@ FAKE_CLAUDE
   grep -qF 'marketplace-add .claude openai/codex-plugin-cc#v1.0.6' "${sandbox}/calls.log"
   grep -qF 'marketplace-add .claude-r06 openai/codex-plugin-cc#v1.0.6' "${sandbox}/calls.log"
   grep -qF 'marketplace-add .claude anthropics/claude-plugins-official' "${sandbox}/calls.log"
+  # chatshelf is registered at its own pinned tag (a distinct marketplace + ref from openai-codex).
+  grep -qF 'marketplace-add .claude NoritakaIkeda/chatshelf#v0.1.0' "${sandbox}/calls.log"
+  grep -qF 'marketplace-add .claude-r06 NoritakaIkeda/chatshelf#v0.1.0' "${sandbox}/calls.log"
 
-  # Both plugins land in both accounts.
-  [ "$(grep -c '^install .claude ' "${sandbox}/calls.log")" -eq 2 ]
-  [ "$(grep -c '^install .claude-r06 ' "${sandbox}/calls.log")" -eq 2 ]
+  # All three plugins land in both accounts.
+  [ "$(grep -c '^install .claude ' "${sandbox}/calls.log")" -eq 3 ]
+  [ "$(grep -c '^install .claude-r06 ' "${sandbox}/calls.log")" -eq 3 ]
 
   # The hook annotations the fake CLI stripped are back, and the work account's symlink was repaired.
   jq -e '.hooks.SessionStart[0] | has("id") and has("description")' "${sandbox}/home/.claude/settings.json"


### PR DESCRIPTION
## 概要

Claude Code plugin **[Chatshelf](https://github.com/NoritakaIkeda/chatshelf)**（Claude Code が生成する「コード説明 HTML」をセッション紐付きで収集し、ローカル viewer で一覧・`claude://resume` で元セッションへ復帰できるツール）を、この dotfiles の既存の宣言的プラグイン管理へ導入する。**プラグイン本体を fork せず**、**personal / r06 のアカウント分離**を満たし、**chezmoi で宣言的に管理**する。

## 背景・設計判断

- **fork 不要**: Chatshelf のソース（`hooks/auto-register.mjs` / `viewer/register.mjs` / `viewer/server.mjs` の 3 経路すべて）が `CODE_EXPL_STORE_ROOT` / `CODE_EXPL_PORT` を尊重する。よって環境変数の注入だけで shelf/ポートをアカウント別に分離でき、このリポジトリの「設定は共有・状態は env で分離」原則にそのまま乗る。
- **注入点は claude wrapper**: hook と SessionStart viewer は exec した claude の子プロセスとして env を継承するため、`home/dot_local/launchers/executable_claude` に per-account の 2 変数を足すだけでよい（`.zshrc` では launchd/hook 起動の claude に届かない）。
- **宣言 SSOT は settings.json**: `run_onchange_after_17` が両アカウント（`~/.claude` / `~/.claude-r06`）を reconcile する既存機構をそのまま利用（スクリプトは無変更）。既存の `openai-codex` と同じくタグ pin（`v0.1.0`）。

## 変更内容

| ファイル | 変更 |
|---|---|
| `home/dot_claude/settings.json` | `enabledPlugins` に `chatshelf@chatshelf`、`extraKnownMarketplaces` に `chatshelf`（`NoritakaIkeda/chatshelf` / tag `v0.1.0`）を宣言 |
| `home/dot_local/launchers/executable_claude` | per-account で `CODE_EXPL_STORE_ROOT`（`$CLAUDE_CONFIG_DIR/code-explanations`）と `CODE_EXPL_PORT`（personal 7788 / r06 7789）を export |
| `tests/claude_launcher.bats`（新規） | wrapper の env 導出をアカウント別に検証（`CLAUDE_LAUNCHER_BIN` seam） |
| `tests/files.bats` | reconciler スタブに chatshelf の source→key を追加し install 数を 3 に更新 |
| `docs/agents/account-isolation.{md,ja.md}` | env テーブルに 2 変数追加＋r06 の transcript 制約を明記 |
| `docs/agents/claude-code.{md,ja.md}` | 宣言プラグインを Two→Three に更新し chatshelf を追記 |

## 動作確認

- `tests/claude_launcher.bats` 6/6 pass（personal=7788/`~/.claude/code-explanations`、r06=7789/`~/.claude-r06/code-explanations`、fill-gaps 継承）。
- wrapper は `shfmt -i 2 -ci` / `shellcheck` clean。
- reconciler contract テスト（`tests/files.bats` 76–83）pass。`chezmoi execute-template` 経由で chatshelf 宣言が両アカウントに正しく展開されることを確認。
- docs の EN/JA ミラーチェック pass。
- 注記: 既存の環境依存テスト `ntfy_notify.bats`「permission_prompt ... priority 4」は本 PR と無関係に失敗する（検証セッションが r06 アカウントで、通知バッジが `[default]` にならないため）。本 diff は ntfy を一切変更していない。

## 既知の制約（受容＋文書化）

`server.mjs` の `PROJECTS_ROOT` は `~/.claude/projects` 固定で `CLAUDE_CONFIG_DIR` を見ないため、r06 では viewer のセッション preview / `claude://resume` 補助が r06 セッションを解決できない。**shelf 分離（プライバシー境界）は `CODE_EXPL_STORE_ROOT` で完全に保たれる**ため、劣化するのは transcript 紐付き preview のみ。fork も upstream 待ちもせず docs に明記する方針。

## 適用手順（マージ後・user 操作）

本 PR は宣言のみでインストールは行わない。`chezmoi apply` で両アカウントに Chatshelf が実インストールされ viewer が起動する（副作用があるため CI/実装では apply を実行していない）。
