### PR TITLE
feat: pr-workflow/multi-review の follow-up 改善（#407, tier 堅牢化・端末エスケープ無害化・SSOT整理）

### DIFF
--- a/docs/agents/skills-provenance.ja.md
+++ b/docs/agents/skills-provenance.ja.md
@@ -203,12 +203,13 @@ awk '
 - **必須の位置引数を先頭に**、山括弧記法で記述する: `<slug>`、`<path>`、`<issue-url-or-feature-description>`
 - **省略可能な位置引数**は山括弧トークンを角括弧で包む: `[<name>]`（例: `[<テーマ>]`）
 - **オプションはその後**に `[--name=<value>]` 形式（角括弧 = 省略可能）
+- **パス値を取るオプションは空白区切りの引数**（`--spec-context <dir>`）を `=<value>` の代わりに使ってよい。ファイルシステムパスではこの形が自然で、実際のパース方法とも一致する。パス以外の値オプションは `--name=<value>` 形式を保つ。
 - **単一スロット内の代替案**は `<...>` 内で `|`（スペースなし）で連結する: `<pr|session|topic>`
 - **短フラグ**（`-q`、`-w`、`-o`）は既知の慣例では許容
 
 具体例: `<slug> [--from=<pr|session|topic>] [--out=<dir>]`
 
-この形に従っている既存スキル: `zenn-draft`（`[<テーマ>] [--from=pr:...|session:...|topic:...] [--slug=<slug>]` — `[<テーマ>]` は上記の省略可能な位置引数ルールに従う）、`pr-workflow`（`<task description> [--size=trivial|small|standard|large] [--operation=add-feature|change-feature|fix-defect|refactor|mvp] [--strict]`）、`issue-fleet`（`<issue 番号列 or 検索条件> [--max-parallel=N] [--repo=owner/name] [--dry-run]`）、`multi-review`（`<PR番号 | owner/repo#PR番号 | PR URL> [--arch]`）。
+この形に従っている既存スキル: `zenn-draft`（`[<テーマ>] [--from=pr:...|session:...|topic:...] [--slug=<slug>]` — `[<テーマ>]` は上記の省略可能な位置引数ルールに従う）、`pr-workflow`（`<task description> [--size=trivial|small|standard|large] [--operation=add-feature|change-feature|fix-defect|refactor|mvp] [--strict]`）、`issue-fleet`（`<issue 番号列 or 検索条件> [--max-parallel=N] [--repo=owner/name] [--dry-run]`）、`multi-review`（`<PR番号 | owner/repo#PR番号 | PR URL> [--tier=trivial|small|standard|large] [--arch] [--spec-context <dir>]` — `--spec-context <dir>` は上記の空白区切りルールに従うパス値オプション）。
 
 ### `(Recommended)` マーカー規約
 

--- a/docs/agents/skills-provenance.md
+++ b/docs/agents/skills-provenance.md
@@ -203,12 +203,13 @@ Rules:
 - **Required positionals come first**, in angle-bracket notation: `<slug>`, `<path>`, `<issue-url-or-feature-description>`
 - **Optional positionals** wrap the angle-bracket token in square brackets: `[<name>]` (e.g., `[<テーマ>]`)
 - **Options come after**, in `[--name=<value>]` form (square brackets = optional)
+- **Path-valued options may take a space-separated argument** (`--spec-context <dir>`) instead of `=<value>`; this reads more naturally for filesystem paths and matches how the option is parsed. Non-path value options keep the `--name=<value>` form.
 - **Alternatives within a single positional slot** are joined with `|` (no spaces) inside `<...>`: `<pr|session|topic>`
 - **Short flags** (`-q`, `-w`, `-o`) are acceptable for well-known conventions
 
 Concrete example: `<slug> [--from=<pr|session|topic>] [--out=<dir>]`
 
-Skills that already follow this shape: `zenn-draft` (`[<テーマ>] [--from=pr:...|session:...|topic:...] [--slug=<slug>]` — `[<テーマ>]` is an optional positional per the rule above), `pr-workflow` (`<task description> [--size=trivial|small|standard|large] [--operation=add-feature|change-feature|fix-defect|refactor|mvp] [--strict]`), `issue-fleet` (`<issue 番号列 or 検索条件> [--max-parallel=N] [--repo=owner/name] [--dry-run]`), `multi-review` (`<PR番号 | owner/repo#PR番号 | PR URL> [--arch]`).
+Skills that already follow this shape: `zenn-draft` (`[<テーマ>] [--from=pr:...|session:...|topic:...] [--slug=<slug>]` — `[<テーマ>]` is an optional positional per the rule above), `pr-workflow` (`<task description> [--size=trivial|small|standard|large] [--operation=add-feature|change-feature|fix-defect|refactor|mvp] [--strict]`), `issue-fleet` (`<issue 番号列 or 検索条件> [--max-parallel=N] [--repo=owner/name] [--dry-run]`), `multi-review` (`<PR番号 | owner/repo#PR番号 | PR URL> [--tier=trivial|small|standard|large] [--arch] [--spec-context <dir>]` — `--spec-context <dir>` is a path-valued option per the space-separated rule above).
 
 ### `(Recommended)` marker convention
 

--- a/home/dot_agents/skills/multi-review/SKILL.md
+++ b/home/dot_agents/skills/multi-review/SKILL.md
@@ -72,12 +72,19 @@ case "$OWNER" in *--*|*-|-*) echo "invalid owner shape: $OWNER" >&2; exit 2 ;; e
 
 **tier がレビュー起動数とモデル配分を決める主レバー**。手順 0 の `TIER` を使い、下表の層だけを spawn する。tier を見ずに全 roster を組む旧挙動は廃止（小 PR の過剰起動を防ぐ）。
 
-### tier の確定（TIER 未指定時の自動推定）
+### tier の確定（自動推定 + security フロア）
 
-- `TIER` が渡っていればそれを使う（pr-workflow からは Phase 6 で明示 `--tier=<Phase0 の tier>` が渡る）。**ただし手順 0 で未定義値（4 値以外）は既に空扱いに落とされている**ため、ここに載る `TIER` は常に `trivial|small|standard|large` のいずれか（fail-open 禁止の担保）。
-- **未指定（standalone）なら diff から自動推定**する。判定軸は **pr-workflow『size tier の判定軸』表を SSOT として流用**する（`~/.agents/skills/pr-workflow/SKILL.md` の Phase 0）。**ここで軸を再掲・paraphrase しない**（新閾値を発明せず、pr-workflow 表との drift を作らない）。`${DIFF}`（Phase 1 手順 2）の変更行数・変更ファイル数・変更特性をその表に当てて tier を選ぶ。
-- **fail-safe 切り上げ**: 迷う・境界上・契約/migration/security surface（認証/認可/機密/外部通信）の兆候があれば**上位 tier に切り上げる**。誤分類は over-tiering 側に倒す。
-- **security フロア（standalone の機械的ルール）**: 差分の変更パスに security surface の兆候 —— `auth` / `session` / `token` / `secret` / `credential` / `permission` / `.env`（`.env.*` を含む）等 —— を検出したら、自動推定の結果に関わらず**無条件で tier ≥ standard**とする。pr-workflow 経由なら分類側でこのフロアが効くが、standalone `/multi-review` は分類を経ないため、ここで機械的に担保する（security 変更が trivial/small の薄い roster を素通りするのを防ぐ）。検出は変更ファイルのパス一覧（`diff --git` ヘッダ / `--name-only`）に対する部分一致で行う。
+**手順（順序が重要）**: (1) `TIER` を確定（明示 or 自動推定）→ (2) 確定後に security フロアを**無条件適用**する。フロアを (1) の枝分岐に埋め込まず、確定 `TIER` に対する後段の上書きとして書くことで、明示 `--tier` 経路もフロアの対象に含める。
+
+1. **`TIER` の確定**:
+   - `TIER` が渡っていればそれを使う（pr-workflow からは Phase 6 で明示 `--tier=<Phase0 の tier>` が渡る）。**ただし手順 0 で未定義値（4 値以外）は既に空扱いに落とされている**ため、ここに載る `TIER` は常に `trivial|small|standard|large` のいずれか（fail-open 禁止の担保）。`--tier` が複数回渡った場合は**最後の有効値**を採る（残りは無視）。
+   - **未指定（standalone）なら diff から自動推定**する。判定軸は **pr-workflow『size tier の判定軸』表を SSOT として流用**する（`~/.agents/skills/pr-workflow/SKILL.md` の Phase 0）。**ここで軸を再掲・paraphrase しない**（新閾値を発明せず、pr-workflow 表との drift を作らない）。`${DIFF}`（Phase 1 手順 2）の変更行数・変更ファイル数・変更特性をその表に当てて tier を選ぶ。
+   - **fail-safe 切り上げ**: 迷う・境界上・契約/migration/security surface（認証/認可/機密/外部通信）の兆候があれば**上位 tier に切り上げる**。誤分類は over-tiering 側に倒す。
+
+2. **security フロア（tier 確定後に無条件適用・決定的バックストップ）**: 上記で確定した `TIER` に対し、**明示指定か自動推定かに関わらず**、差分の変更パスに security surface の兆候を検出したら `TIER` を **`standard` 未満なら `standard` へ引き上げる**（`final = max(TIER, standard)`）。**明示 `--tier=trivial|small` であっても上書きする**（フロアは明示指定より優先。security 変更が薄い roster を素通りするのを防ぐ）。
+   - **検出対象キーワード（大文字小文字を無視した部分一致）**: `auth` / `session` / `token` / `secret` / `credential` / `permission` / `jwt` / `oauth` / `cookie` / `apikey` / `cert` / `ssh` / `.env`（`.env.*` を含む）等。変更ファイルのパス一覧（`diff --git` ヘッダ / `--name-only`）に対して評価する。
+   - **これは floor であって ceiling ではない**: パス名ベースの機械的な最低保証であり、diff 本文の内容判定（上記 fail-safe 切り上げ）を置き換えない。汎用ファイル名で中身が security-critical な変更は引き続き fail-safe 判断が主軸。
+   - **pr-workflow 経由との関係**: pr-workflow は Phase 0 の分類でも security surface を `standard` 以上とみなすが、それは LLM 判断（プローズ）。本フロアは multi-review 側の**決定的なバックストップ**として、pr-workflow が明示 `--tier` を forward した場合でも（分類の見落とし・誤操作・自動化による `--tier` 注入に対して）機械的に効く。
 
 ### roster gating table（spawn する = ✓、モデルと effort 付き）
 

--- a/home/dot_agents/skills/multi-review/SKILL.md
+++ b/home/dot_agents/skills/multi-review/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: multi-review
 description: |
-  3つのレビューツール（cc-code-review / cc-security-review / Codex）を並列でバックグラウンド実行し、
+  tier に応じたレビュー roster（Claude 汎用/セキュリティ + Codex generalist/specialist）を
+  並列でバックグラウンド実行し、レビュー負荷の大半を Codex へ offload する。
   結果を統合サマリーにまとめた上で、GitHub PR にレビュー（body サマリー + インラインコメント）として投稿する。
   PRの包括的レビューを一度に実行したい場合に使用する。
-  トリガー: "multi-review", "マルチレビュー", "全レビュー", "並列レビュー", "フルレビュー", "3ツールレビュー"
+  トリガー: "multi-review", "マルチレビュー", "全レビュー", "並列レビュー", "フルレビュー", "tierレビュー"
   使用場面: PRのコードレビュー・セキュリティレビュー・Codexレビューを一括で実行したい場合
 argument-hint: "<PR番号 | owner/repo#PR番号 | PR URL> [--tier=trivial|small|standard|large] [--arch] [--spec-context <dir>]"
 ---
@@ -27,7 +28,7 @@ roster は tier で gating し（過剰起動を抑制）、レビュー負荷�
 
 ## 引数の解釈
 
-**手順 0（フラグ抽出を最優先）**: `$ARGUMENTS` からまず `--arch` を取り除き `ARCH=true`（未指定なら `ARCH=false`）にする。次に `--spec-context <dir>` があれば取り除き `SPEC_CONTEXT=<dir>`（未指定なら空）にする（spec ドキュメントのディレクトリパス。「spec-context 入力」節参照）。さらに `--tier=<t>`（`trivial|small|standard|large`）があれば取り除き `TIER=<t>` にする（未指定なら空 → 「tier → roster 予算」節の diff 自動推定に回す。fail-safe 切り上げ）。残った 0/1 個のトークンを **target** として下記の優先順で判定する。フラグを先に剥がしておくことで `owner/repo#N --arch` のような複合引数のパース順序事故を避ける。
+**手順 0（フラグ抽出を最優先）**: `$ARGUMENTS` からまず `--arch` を取り除き `ARCH=true`（未指定なら `ARCH=false`）にする。次に `--spec-context <dir>` があれば取り除き `SPEC_CONTEXT=<dir>`（未指定なら空）にする（spec ドキュメントのディレクトリパス。「spec-context 入力」節参照）。さらに `--tier=<t>` があれば取り除き、**`<t>` が `trivial|small|standard|large` のいずれかのときのみ** `TIER=<t>` にする。**それ以外の未定義値（例 `--tier=foo`）は空扱い**とし `TIER` に載せず、未指定と同様に「tier → roster 予算」節の diff 自動推定へ回す（**未知値で roster gating を無効化しない = fail-open 禁止**。fail-safe 切り上げ）。残った 0/1 個のトークンを **target** として下記の優先順で判定する。フラグを先に剥がしておくことで `owner/repo#N --arch` のような複合引数のパース順序事故を避ける。
 
 target を以下の優先順で判定し、**owner/repo と PR 番号の 2 つ組**を確定する。以降の全 `gh` 呼び出しには `--repo <owner/repo>` を明示すること（cross-repo バッチで cwd の repo に暗黙解決される事故を防ぐ）。**cross-repo バッチ（review-fleet 等）から委譲されるときは PR 番号のみを渡さない**（case 3 の cwd 暗黙解決を踏むため）:
 
@@ -73,9 +74,10 @@ case "$OWNER" in *--*|*-|-*) echo "invalid owner shape: $OWNER" >&2; exit 2 ;; e
 
 ### tier の確定（TIER 未指定時の自動推定）
 
-- `TIER` が渡っていればそれを使う（pr-workflow からは Phase 6 で明示 `--tier=<Phase0 の tier>` が渡る）。
-- **未指定（standalone）なら diff から自動推定**する。`${DIFF}`（Phase 1 手順 2）の変更行数・変更ファイル数・変更特性を、pr-workflow 既存の tier 判定軸で評価する（新閾値を発明せず流用）: `trivial`=1〜数行/単一ファイル/振る舞い不変 ・ `small`=数ファイル/契約変更なし ・ `standard`=複数横断 or 新機能 ・ `large`=広範/外部契約/migration。
+- `TIER` が渡っていればそれを使う（pr-workflow からは Phase 6 で明示 `--tier=<Phase0 の tier>` が渡る）。**ただし手順 0 で未定義値（4 値以外）は既に空扱いに落とされている**ため、ここに載る `TIER` は常に `trivial|small|standard|large` のいずれか（fail-open 禁止の担保）。
+- **未指定（standalone）なら diff から自動推定**する。判定軸は **pr-workflow『size tier の判定軸』表を SSOT として流用**する（`~/.agents/skills/pr-workflow/SKILL.md` の Phase 0）。**ここで軸を再掲・paraphrase しない**（新閾値を発明せず、pr-workflow 表との drift を作らない）。`${DIFF}`（Phase 1 手順 2）の変更行数・変更ファイル数・変更特性をその表に当てて tier を選ぶ。
 - **fail-safe 切り上げ**: 迷う・境界上・契約/migration/security surface（認証/認可/機密/外部通信）の兆候があれば**上位 tier に切り上げる**。誤分類は over-tiering 側に倒す。
+- **security フロア（standalone の機械的ルール）**: 差分の変更パスに security surface の兆候 —— `auth` / `session` / `token` / `secret` / `credential` / `permission` / `.env`（`.env.*` を含む）等 —— を検出したら、自動推定の結果に関わらず**無条件で tier ≥ standard**とする。pr-workflow 経由なら分類側でこのフロアが効くが、standalone `/multi-review` は分類を経ないため、ここで機械的に担保する（security 変更が trivial/small の薄い roster を素通りするのを防ぐ）。検出は変更ファイルのパス一覧（`diff --git` ヘッダ / `--name-only`）に対する部分一致で行う。
 
 ### roster gating table（spawn する = ✓、モデルと effort 付き）
 
@@ -504,6 +506,14 @@ codex exec --profile shared --sandbox read-only --cd "$WT" --color never --json 
 - 各 leg 起動後、`$STREAM_leg` 先頭の `thread.started` イベントから `thread_id` を捕捉（codex/SKILL.md の grep 例）。
 - `<scratch>/codex-review/<owner>__<repo>__<PR>/sessions.json`（**非コミット**）に `{leg → thread_id}` を記録する（`multi-review` が所有。round 2+ の resume がこれを読む）。**区切りは `__`（owner/repo にも PR にも出現しない）**にして、`foo/bar-baz#1` と `foo-bar/baz#1` のようなハイフン曖昧による cross-repo 衝突を避ける。
 
+#### TTL / クリーンアップ契機（OQ-005: 解決済み）
+
+`sessions.json` と scratch の `codex-review/` 配下は次の方針で寿命管理する（PR #406 の未解決事項 OQ-005 の確定）:
+
+- **所有と idempotency**: `multi-review` が round 1 開始時に自 `(owner,repo,PR)` の `codex-review/<owner>__<repo>__<PR>/` を idempotent に作り直す（前 run の stale な `sessions.json` を置換）。これにより同一 PR の再レビューで古い `thread_id` が混ざらない。
+- **TTL 掃除（mtime ベース）**: round 1 開始時に、`codex-review/` 直下のサブディレクトリのうち **mtime が 7 日以上前**のものを best-effort で削除する（`find "<scratch>/codex-review" -mindepth 1 -maxdepth 1 -type d -mtime +7 -exec rm -rf {} +` 相当）。scratch はセッション隔離だが、standalone 多用や cross-repo バッチで dir が溜まるのを防ぐ。掃除の失敗（権限・不在）は無視する（レビュー本体を止めない）。
+- **契機は round 1 のみ**: 掃除は round 1 開始時の 1 回に限定し、round 2+ の resume 中には行わない（resume 対象の状態ファイルを消さないため）。
+
 ### 並列上限とバッチ（CODEX_MAX_CONCURRENCY）
 
 - `CODEX_MAX_CONCURRENCY = 3`（named constant。read-only の codex exec 3 本同時に競合/レートエラーが出ないことを実機確認済みの床）。
@@ -524,7 +534,7 @@ codex exec --profile shared --sandbox read-only --cd "$WT" --color never --json 
   - **create（round 開始）**: `tmux kill-session -t <name> 2>/dev/null` してから `tmux new-session -d`（idempotent。同名の orphan / 前回分を置換し、accumulation を (owner,repo,PR) ごと最大 1 に bound）。
   - **teardown（round 終了 = Phase 5 投稿後）**: multi-review が自分のセッションを `tmux kill-session -t <name> 2>/dev/null` で破棄する。**ただし client が attach 中（`tmux list-clients -t <name>` が非空）なら破棄せず残置**し、「見終わったら手動 kill、または次 run が置換する」と注記する（観測中の画面を消さない）。
   - **caller（pr-workflow）側の teardown は不要**: round ごとに multi-review が自己完結するため、pr-workflow の GATE 3 等での破棄には依存しない（standalone 多用でも PR ごとに溜まらない）。
-- **観測（tmux）と resume（`sessions.json`）は独立**: tmux セッションはライブ観測専用で、round 2+ の resume は `sessions.json` の `thread_id` を使う（tmux セッションに依存しない）。よって teardown で resume は壊れず、round 2 は fresh にセッションを作り直して新 STREAM を tail する。STREAM の JSONL はディスクに残置（post-hoc 検分用。掃除は scratch TTL = OQ-005 に委ねる）。
+- **観測（tmux）と resume（`sessions.json`）は独立**: tmux セッションはライブ観測専用で、round 2+ の resume は `sessions.json` の `thread_id` を使う（tmux セッションに依存しない）。よって teardown で resume は壊れず、round 2 は fresh にセッションを作り直して新 STREAM を tail する。STREAM の JSONL はディスクに残置（post-hoc 検分用。掃除は上記「TTL / クリーンアップ契機（OQ-005: 解決済み）」の scratch TTL に委ねる）。
 
 ### round 判定と resume 再レビュー
 
@@ -685,7 +695,7 @@ multi-review が投稿するインラインコメントの本文先頭には、�
 | シナリオ | 対応 |
 |---------|------|
 | cc-code-review / cc-security サブエージェントの失敗・スキップ | 1回リトライ。再失敗なら該当ツールをスキップして残りで続行 |
-| 動的 specialist の失敗・未定義（`<lang>-reviewer` 未配備） | 1回リトライ。再失敗なら該当 specialist のみスキップし、常設 3 ツール + 他 specialist で続行（specialist は補強レイヤのため必須ではない） |
+| 動的 specialist の失敗・未定義（`<lang>-reviewer` 未配備） | 1回リトライ。再失敗なら該当 specialist のみスキップし、その回の tier roster（generalist + フロア anchor + 他 specialist）で続行（specialist は補強レイヤのため必須ではない） |
 | `cc-code-review` / `cc-security-review` サブエージェント未定義 | `~/.claude/agents/` に定義があるか確認を案内（chezmoi apply 済みか）。該当ツールをスキップ |
 | `codex` コマンド未発見 | 警告を出力し、その回に spawn 済みの Claude leg（tier により cc-code-review **or** cc-security-review）と Claude specialist は無いため、**generalist 観点が失われる旨を明示**して続行。standard/large では generalist を Codex が独占するため、緊急フォールバックとして cc-code-review（Claude 汎用）の spawn を検討する |
 | codex が `No prompt provided via stdin.` で終了 | 差分を事前変数確保するパターンで1回リトライ（codex skill 参照） |

--- a/home/dot_agents/skills/multi-review/executable_codex-stream-fmt
+++ b/home/dot_agents/skills/multi-review/executable_codex-stream-fmt
@@ -15,13 +15,23 @@
 #   item.completed   → reasoning / command_execution / agent_message / error を種別表示
 #   その他/未知      → · <type>                 （握り潰さず種別だけ出す）
 #   パース不能行      → 生行を leg タグ付きで素通し
+#
+# 全出力経路で端末エスケープ（ANSI CSI / OSC・ESC・BEL 等の制御文字）を無害化する。
+# tmux ペインへ出力するため、未検証の Codex 出力に混じった制御シーケンスをそのまま
+# 流すと terminal escape injection になりうる（OSC 52 クリップボード書込み等）。
 set -uo pipefail
 
 leg="${1:-codex}"
 
 if ! command -v jq >/dev/null 2>&1; then
-  # jq 不在: 整形せず leg タグだけ付けて素通し（フォールバック）
+  # jq 不在: 整形せず leg タグだけ付けて素通し（フォールバック）。
+  # 端末エスケープ注入対策として C0 制御文字（ESC/BEL 含む）と DEL を除去する。
+  # builtin のパラメータ展開のみで行う（このフォールバックは jq も外部コマンドも
+  # 無い環境で動く必要があるため tr 等を使わない）。C1（0x80-0x9f）は UTF-8 継続
+  # バイトと衝突するため触らず、実攻撃面である ESC/C0 を確実に落とす。
   while IFS= read -r line; do
+    line="${line//[$'\x01'-$'\x1f']/}"
+    line="${line//$'\x7f'/}"
     [ -n "$line" ] && printf '[%s] %s\n' "$leg" "$line"
   done
   exit 0
@@ -31,23 +41,29 @@ fi
 # ライブ tail に追従させる。-R で各行を生文字列として受け、JSON 化に失敗した行は素通す。
 exec jq -rR --unbuffered --arg leg "$leg" '
   def short(s): (s // "") | gsub("\\s+"; " ") | if (length > 80) then (.[0:80] + "…") else . end;
+  # 端末エスケープ無害化: C0 制御文字（ESC=27 / BEL=7 含む）・DEL(127)・C1(128-159) を
+  # 除去する。コードポイント数値で判定するため制御文字リテラルを regex に持たず、
+  # 日本語（U+3000 以降）や記号（▸ ✎ ⚙ … 等, いずれも >159）は保持される。整形分岐・
+  # 生行素通し・種別表示の全経路を最終段の 1 箇所でカバーする。
+  def sanitize: explode | map(select(. >= 32 and . != 127 and (. < 128 or . > 159))) | implode;
   . as $raw
   | if ($raw | length) == 0 then empty
     else
       (try ($raw | fromjson) catch null) as $ev
-      | if ($ev | type) != "object" then "[\($leg)] \($raw)"
-        elif $ev.type == "thread.started" then "[\($leg)] ▸ session \(($ev.thread_id // "")[0:8])"
-        elif $ev.type == "turn.started"   then "[\($leg)] ▸ start"
-        elif $ev.type == "turn.completed" then "[\($leg)] ✓ done (tokens: \($ev.usage.output_tokens // 0))"
-        elif $ev.type == "item.completed" then
-          ($ev.item.type) as $it
-          | if   $it == "reasoning"         then "[\($leg)] … " + short($ev.item.text // $ev.item.summary)
-            elif $it == "command_execution" then "[\($leg)] ⚙ " + short($ev.item.command // $ev.item.cmd)
-            elif $it == "agent_message"     then "[\($leg)] ✎ " + short($ev.item.text)
-            elif $it == "error"             then "[\($leg)] ⚠ " + short($ev.item.message)
-            else "[\($leg)] · " + ($it // "item")
-            end
-        else "[\($leg)] · " + ($ev.type // "event")
-        end
+      | ( if ($ev | type) != "object" then "[\($leg)] \($raw)"
+          elif $ev.type == "thread.started" then "[\($leg)] ▸ session \(($ev.thread_id // "")[0:8])"
+          elif $ev.type == "turn.started"   then "[\($leg)] ▸ start"
+          elif $ev.type == "turn.completed" then "[\($leg)] ✓ done (tokens: \($ev.usage.output_tokens // 0))"
+          elif $ev.type == "item.completed" then
+            ($ev.item.type) as $it
+            | if   $it == "reasoning"         then "[\($leg)] … " + short($ev.item.text // $ev.item.summary)
+              elif $it == "command_execution" then "[\($leg)] ⚙ " + short($ev.item.command // $ev.item.cmd)
+              elif $it == "agent_message"     then "[\($leg)] ✎ " + short($ev.item.text)
+              elif $it == "error"             then "[\($leg)] ⚠ " + short($ev.item.message)
+              else "[\($leg)] · " + ($it // "item")
+              end
+          else "[\($leg)] · " + ($ev.type // "event")
+          end
+        ) | sanitize
     end
 '

--- a/home/dot_agents/skills/multi-review/executable_codex-stream-fmt
+++ b/home/dot_agents/skills/multi-review/executable_codex-stream-fmt
@@ -22,14 +22,22 @@
 set -uo pipefail
 
 leg="${1:-codex}"
+# leg（第一引数）も出力に混じるため無害化する。jq 経路は最終一括 sanitize で leg も覆うが、
+# フォールバック経路と対称にするため入力段で C0/DEL を除去しておく（両経路で leg を保護）。
+leg="${leg//[$'\x01'-$'\x1f']/}"
+leg="${leg//$'\x7f'/}"
 
 if ! command -v jq >/dev/null 2>&1; then
   # jq 不在: 整形せず leg タグだけ付けて素通し（フォールバック）。
   # 端末エスケープ注入対策として C0 制御文字（ESC/BEL 含む）と DEL を除去する。
   # builtin のパラメータ展開のみで行う（このフォールバックは jq も外部コマンドも
   # 無い環境で動く必要があるため tr 等を使わない）。C1（0x80-0x9f）は UTF-8 継続
-  # バイトと衝突するため触らず、実攻撃面である ESC/C0 を確実に落とす。
-  while IFS= read -r line; do
+  # バイトと衝突する（素朴なバイト除去は日本語等のマルチバイトを壊す）ため触らず、
+  # 実攻撃面である ESC/C0 を確実に落とす。**保証範囲**: フォールバックは C0/DEL/ESC まで
+  # （jq 経路のみ codepoint 単位で C1 8bit 形式まで完全網羅。多くの UTF-8 端末は raw 8bit
+  # C1 を CSI 解釈しないため、フォールバックでの残存 C1 の実害は限定的）。
+  # `|| [ -n "$line" ]`: 末尾に改行の無い最終行も取りこぼさず処理する。
+  while IFS= read -r line || [ -n "$line" ]; do
     line="${line//[$'\x01'-$'\x1f']/}"
     line="${line//$'\x7f'/}"
     [ -n "$line" ] && printf '[%s] %s\n' "$leg" "$line"

--- a/home/dot_agents/skills/review-fleet/SKILL.md
+++ b/home/dot_agents/skills/review-fleet/SKILL.md
@@ -102,7 +102,7 @@ gh search prs --review-requested=@me --state=open --limit "${LIMIT:-30}" \
 > ここでの **A/B/C は review-fleet 独自の可否分類**であって、`multi-review` の size tier（trivial/small/standard/large）とは別軸。実際の reviewer 構成は `multi-review` が diff から推定する size tier で gating される。
 
 - **reviewer 構成は固定 3 ツールではない（tier gating + Codex offload）**: `multi-review` は size tier に応じて roster を絞り、レビュー負荷の大半を **Codex（generalist / specialist）へ offload** する。Claude 側は多様性フロア anchor（small=cc-code-review、standard/large=cc-security-review）と architecture/adversarial に集中する。構成の SSOT は `multi-review`「tier → roster 予算」節。review-fleet は diff の変更ファイルから自動検出した specialist を計画表に添えるが、確定 roster は委譲先が決める。
-- **コスト警告を必ず明示する**: 総コストは **PR 件数 × tier 別 roster**で積み上がる（Codex leg が主、Claude leg は tier ごとに 0〜1 の anchor）。計画表の直後にこの旨を一文で明記する。security-critical / large tier の PR では Codex generalist が effort=xhigh に上がり、`--arch` 追加時は architecture-reviewer の分も増える。
+- **コスト警告を必ず明示する**: 総コストは **PR 件数 × tier 別 roster**で積み上がる（Codex leg が主、Claude leg は tier ごとに 0〜1 の anchor）。計画表の直後にこの旨を一文で明記する。security-critical / large tier の PR では Codex generalist が effort=xhigh に上がり、`--arch` 追加時は architecture-reviewer の分も増える。**なお architecture-reviewer は `--arch` **または** multi-review が size tier を `large` と自動推定したとき**に起動するため、review-fleet が `--tier` を渡さない運用では、大規模 diff が `large` 推定されると `--arch` 未指定でも architecture-reviewer が立ちうる（そのコストも見込む）。
 - **`--tier` は既定で渡さない**: review-fleet は A/B/C 可否分類のみを持ち、pr-workflow のような size tier を持たない。よって `--tier` を明示せず、`multi-review` の diff 自動推定（fail-safe 切り上げ + security フロア）に委ねる。B 分類（大規模 diff）には `--arch` を付す現行運用のみ維持する。
 - **B 分類 PR に `--arch` を付けるかは Phase 3 の追加質問で確定する**（B が 0 件のときはこの質問を省略）。B が 1 件以上あれば下記の 2 問目を提示する。
 
@@ -120,7 +120,7 @@ gh search prs --review-requested=@me --state=open --limit "${LIMIT:-30}" \
   |--------|------|
   | B 分類にのみ `--arch` を付ける (Recommended) | 大規模 diff だけ architecture-reviewer を追加する |
   | 全 PR に `--arch` を付ける | A・B すべてで aggregate-view レビュアーを走らせる（コスト増を許容） |
-  | どの PR にも `--arch` を付けない | tier 別 roster（Codex generalist + Claude フロア anchor + 動的 specialist）だけで処理する |
+  | どの PR にも `--arch` を付けない | tier 別 roster（Codex generalist + Claude フロア anchor + 動的 specialist）だけで処理する（ただし multi-review が `large` と自動推定した PR は `--arch` 未指定でも architecture-reviewer が立つ） |
 
 - `--dry-run` は**この計画表提示までで終了**し、Phase 4 には進まない（AskUserQuestion も呼ばない）。
 - 承認が得られなければ Phase 4 に進まない。

--- a/home/dot_agents/skills/review-fleet/SKILL.md
+++ b/home/dot_agents/skills/review-fleet/SKILL.md
@@ -93,14 +93,17 @@ gh search prs --review-requested=@me --state=open --limit "${LIMIT:-30}" \
 
 以下の計画表を提示する:
 
-| repo | PR | tier | reviewer 構成 | 備考 |
+| repo | PR | 分類 | reviewer 構成（tier 別 roster） | 備考 |
 |------|----|----|--------------|------|
-| owner/repo-a | #123 | A | cc-code-review + cc-security-review + codex + (自動検出 specialist) | |
+| owner/repo-a | #123 | A | `multi-review` が diff から size tier を自動推定 → tier 別 roster（Codex generalist + Claude フロア anchor + 自動検出 specialist） | |
 | owner/repo-b | #456 | B | 同上（`--arch` 推奨） | 大規模diff |
 | owner/repo-c | #789 | C（除外） | - | WIP ラベルあり |
 
-- **コスト警告を必ず明示する**: `multi-review` の常設 reviewer（cc-code-review / cc-security-review）は frontmatter で `model: sonnet` + `effort: xhigh` に固定されているが、総コストは **PR 件数 × reviewer 構成**で積み上がる。計画表の直後にこの旨を一文で明記する。security-critical / large tier の PR では呼び出し側の判断で `model: "opus"` に引き上げられるため、その分のコスト増も見込む。
-- reviewer 構成は `multi-review` の動的 specialist roster（言語/ドメイン検出）を踏襲し、diff の変更ファイルから自動検出したものを表示する。
+> ここでの **A/B/C は review-fleet 独自の可否分類**であって、`multi-review` の size tier（trivial/small/standard/large）とは別軸。実際の reviewer 構成は `multi-review` が diff から推定する size tier で gating される。
+
+- **reviewer 構成は固定 3 ツールではない（tier gating + Codex offload）**: `multi-review` は size tier に応じて roster を絞り、レビュー負荷の大半を **Codex（generalist / specialist）へ offload** する。Claude 側は多様性フロア anchor（small=cc-code-review、standard/large=cc-security-review）と architecture/adversarial に集中する。構成の SSOT は `multi-review`「tier → roster 予算」節。review-fleet は diff の変更ファイルから自動検出した specialist を計画表に添えるが、確定 roster は委譲先が決める。
+- **コスト警告を必ず明示する**: 総コストは **PR 件数 × tier 別 roster**で積み上がる（Codex leg が主、Claude leg は tier ごとに 0〜1 の anchor）。計画表の直後にこの旨を一文で明記する。security-critical / large tier の PR では Codex generalist が effort=xhigh に上がり、`--arch` 追加時は architecture-reviewer の分も増える。
+- **`--tier` は既定で渡さない**: review-fleet は A/B/C 可否分類のみを持ち、pr-workflow のような size tier を持たない。よって `--tier` を明示せず、`multi-review` の diff 自動推定（fail-safe 切り上げ + security フロア）に委ねる。B 分類（大規模 diff）には `--arch` を付す現行運用のみ維持する。
 - **B 分類 PR に `--arch` を付けるかは Phase 3 の追加質問で確定する**（B が 0 件のときはこの質問を省略）。B が 1 件以上あれば下記の 2 問目を提示する。
 
 **AskUserQuestion で対象を確認する**（house 規約: 自由入力は auto-provided Other に任せ、選択肢には free-form の受け皿を置かない）:
@@ -117,7 +120,7 @@ gh search prs --review-requested=@me --state=open --limit "${LIMIT:-30}" \
   |--------|------|
   | B 分類にのみ `--arch` を付ける (Recommended) | 大規模 diff だけ architecture-reviewer を追加する |
   | 全 PR に `--arch` を付ける | A・B すべてで aggregate-view レビュアーを走らせる（コスト増を許容） |
-  | どの PR にも `--arch` を付けない | 通常の常設 3 ツール（+ 動的 specialist）だけで処理する |
+  | どの PR にも `--arch` を付けない | tier 別 roster（Codex generalist + Claude フロア anchor + 動的 specialist）だけで処理する |
 
 - `--dry-run` は**この計画表提示までで終了**し、Phase 4 には進まない（AskUserQuestion も呼ばない）。
 - 承認が得られなければ Phase 4 に進まない。
@@ -125,8 +128,8 @@ gh search prs --review-requested=@me --state=open --limit "${LIMIT:-30}" \
 ## Phase 4: バッチ実行（PR 単位は直列）
 
 承認された PR を **1 件ずつ直列**で処理する。並列にしない理由は明確: `/multi-review` は 1 PR あたり
-すでに 3〜5 個のサブエージェント（常設 3 ツール + 動的 specialist、`--arch` 時はさらに 1 つ）を
-**並列**起動する。PR 単位まで並列化すると同時実行エージェント数が N 倍に膨れ上がり、
+tier に応じて複数の leg（Codex generalist + Claude フロア anchor + 自動検出 specialist、`--arch`/large 時は
+architecture-reviewer も）を **並列**起動する。PR 単位まで並列化すると同時実行エージェント数が N 倍に膨れ上がり、
 ワークフローの並行数上限とコストの両方を超過する。したがって review-fleet は「PR は直列、
 reviewer は `/multi-review` 内で並列」という 2 層構造を維持する。
 

--- a/tests/codex_stream_fmt.bats
+++ b/tests/codex_stream_fmt.bats
@@ -2,7 +2,8 @@
 
 # codex-stream-fmt（multi-review の Codex ライブ観測ペイン整形ヘルパー）のテスト。
 # codex exec --json の JSONL イベント（codex-cli 0.145.0 実測形）を簡潔な 1 行へ
-# 整形できること、未知/不正入力を握り潰さないこと、jq 不在時に素通しすることを検証する。
+# 整形できること、未知/不正入力を握り潰さないこと、jq 不在時に素通しすること、
+# 端末エスケープ（ANSI/OSC 等）を無害化することを検証する。
 
 load helpers/setup
 
@@ -10,78 +11,132 @@ setup() {
   SCRIPT="${HOME_DIR}/dot_agents/skills/multi-review/executable_codex-stream-fmt"
 }
 
+# 整形は jq に依存する。jq が無い環境（最小 CI コンテナ等）では jq 必須ケースを
+# fail させず skip する（jq 不在フォールバック自体のテストは別途 PATH を空にして起動する）。
+require_jq() {
+  command -v jq >/dev/null 2>&1 || skip "jq not installed"
+}
+
 @test "codex-stream-fmt: スクリプトが存在する" {
   [ -f "$SCRIPT" ]
 }
 
 @test "codex-stream-fmt: thread.started → session 短縮（resume 用 thread_id 先頭）" {
+  require_jq
   run bash "$SCRIPT" gen <<< '{"type":"thread.started","thread_id":"019fb164-17a2-7fc2-8264-62e27c10b3c8"}'
   [ "$status" -eq 0 ]
   [[ "$output" == *"[gen]"* ]]
   [[ "$output" == *"▸ session 019fb164"* ]]
 }
 
-@test "codex-stream-fmt: turn.started → start" {
+@test "codex-stream-fmt: turn.started → start（完全一致）" {
+  require_jq
   run bash "$SCRIPT" gen <<< '{"type":"turn.started"}'
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[gen] ▸ start"* ]]
+  # 単一イベントは substring ではなく完全一致で契約を固定する。
+  [ "$output" = "[gen] ▸ start" ]
 }
 
 @test "codex-stream-fmt: turn.completed → done + output_tokens" {
+  require_jq
   run bash "$SCRIPT" gen <<< '{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":237}}'
   [ "$status" -eq 0 ]
-  [[ "$output" == *"✓ done (tokens: 237)"* ]]
+  [ "$output" = "[gen] ✓ done (tokens: 237)" ]
+}
+
+@test "codex-stream-fmt: turn.completed の usage 欠落時は output_tokens 既定 0" {
+  require_jq
+  # usage/output_tokens が無いイベントでも `// 0` フォールバックで 0 を出す。
+  run bash "$SCRIPT" gen <<< '{"type":"turn.completed"}'
+  [ "$status" -eq 0 ]
+  [ "$output" = "[gen] ✓ done (tokens: 0)" ]
 }
 
 @test "codex-stream-fmt: item.completed reasoning → …" {
+  require_jq
   run bash "$SCRIPT" ts <<< '{"type":"item.completed","item":{"id":"i1","type":"reasoning","text":"エラーハンドリングを確認"}}'
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[ts] … エラーハンドリングを確認"* ]]
+  [ "$output" = "[ts] … エラーハンドリングを確認" ]
+}
+
+@test "codex-stream-fmt: reasoning の text 欠落時は summary にフォールバック" {
+  require_jq
+  # text が無ければ summary を使う（short() の `$ev.item.text // $ev.item.summary`）。
+  run bash "$SCRIPT" ts <<< '{"type":"item.completed","item":{"type":"reasoning","summary":"要約のみ"}}'
+  [ "$status" -eq 0 ]
+  [ "$output" = "[ts] … 要約のみ" ]
 }
 
 @test "codex-stream-fmt: item.completed command_execution → ⚙" {
+  require_jq
   run bash "$SCRIPT" ts <<< '{"type":"item.completed","item":{"id":"i2","type":"command_execution","command":"rg catch src/"}}'
   [ "$status" -eq 0 ]
-  [[ "$output" == *"⚙ rg catch src/"* ]]
+  [ "$output" = "[ts] ⚙ rg catch src/" ]
+}
+
+@test "codex-stream-fmt: command_execution の command 欠落時は cmd にフォールバック" {
+  require_jq
+  # command が無ければ cmd を使う（short() の `$ev.item.command // $ev.item.cmd`）。
+  run bash "$SCRIPT" ts <<< '{"type":"item.completed","item":{"type":"command_execution","cmd":"ls -la"}}'
+  [ "$status" -eq 0 ]
+  [ "$output" = "[ts] ⚙ ls -la" ]
 }
 
 @test "codex-stream-fmt: item.completed agent_message → ✎" {
+  require_jq
   run bash "$SCRIPT" ts <<< '{"type":"item.completed","item":{"id":"i3","type":"agent_message","text":"[MUST] auth.ts:31 未 await"}}'
   [ "$status" -eq 0 ]
   [[ "$output" == *"✎ [MUST] auth.ts:31 未 await"* ]]
 }
 
 @test "codex-stream-fmt: item.completed error → ⚠（握り潰さない）" {
+  require_jq
   run bash "$SCRIPT" ts <<< '{"type":"item.completed","item":{"id":"i0","type":"error","message":"Skill descriptions were shortened"}}'
   [ "$status" -eq 0 ]
   [[ "$output" == *"⚠ Skill descriptions were shortened"* ]]
 }
 
 @test "codex-stream-fmt: 未知の item type は種別だけ出す（· type）" {
+  require_jq
   run bash "$SCRIPT" ts <<< '{"type":"item.completed","item":{"id":"iX","type":"widget"}}'
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[ts] · widget"* ]]
+  [ "$output" = "[ts] · widget" ]
 }
 
 @test "codex-stream-fmt: 未知のトップレベル type も種別だけ出す" {
+  require_jq
   run bash "$SCRIPT" ts <<< '{"type":"session.updated"}'
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[ts] · session.updated"* ]]
+  [ "$output" = "[ts] · session.updated" ]
 }
 
 @test "codex-stream-fmt: パース不能な行は leg タグ付きで素通し" {
+  require_jq
   run bash "$SCRIPT" gen <<< 'not a json line'
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[gen] not a json line"* ]]
+  [ "$output" = "[gen] not a json line" ]
 }
 
 @test "codex-stream-fmt: 空行は出力しない" {
+  require_jq
   run bash "$SCRIPT" gen <<< ''
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
 
+@test "codex-stream-fmt: 複数行 JSONL は入力順に 1 行ずつ整形する（順序契約）" {
+  require_jq
+  # tail -f が渡す複数行を、順序を保って 1:1 で整形することを固定する。
+  run bash "$SCRIPT" ts <<< $'{"type":"thread.started","thread_id":"aabbccdd-0000-0000-0000-000000000000"}\n{"type":"turn.started"}\n{"type":"turn.completed","usage":{"output_tokens":5}}'
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 3 ]
+  [ "${lines[0]}" = "[ts] ▸ session aabbccdd" ]
+  [ "${lines[1]}" = "[ts] ▸ start" ]
+  [ "${lines[2]}" = "[ts] ✓ done (tokens: 5)" ]
+}
+
 @test "codex-stream-fmt: 長い本文は 80 文字で切り詰めて … を付ける" {
+  require_jq
   local long
   long=$(printf 'x%.0s' {1..100})
   run bash "$SCRIPT" ts <<< "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"${long}\"}}"
@@ -92,9 +147,10 @@ setup() {
 }
 
 @test "codex-stream-fmt: leg 名を省略すると codex になる" {
+  require_jq
   run bash "$SCRIPT" <<< '{"type":"turn.started"}'
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[codex] ▸ start"* ]]
+  [ "$output" = "[codex] ▸ start" ]
 }
 
 @test "codex-stream-fmt: jq 不在時は leg タグ付きで生 JSONL を素通し（フォールバック）" {
@@ -103,4 +159,42 @@ setup() {
   run env PATH="${BATS_TEST_TMPDIR:-/tmp}" /bin/bash "$SCRIPT" fb <<< '{"type":"turn.started"}'
   [ "$status" -eq 0 ]
   [[ "$output" == *'[fb] {"type":"turn.started"}'* ]]
+}
+
+# --- 端末エスケープ無害化（terminal escape injection 対策） ---
+
+@test "codex-stream-fmt: agent_message 内の ANSI/OSC エスケープを無害化する（valid JSON 経路）" {
+  require_jq
+  # ESC を含む値を jq で valid JSON（ エスケープ）に組み立て、fromjson→short 経由で
+  # 出力される。無害化前は ESC/BEL が素通しされる（このテストが RED を示す）。
+  local esc bel input
+  esc=$(printf '\033'); bel=$(printf '\007')
+  input=$(jq -cn --arg t "start${esc}[31mRED${esc}[0m${esc}]0;pwn${bel}end" \
+    '{type:"item.completed",item:{type:"agent_message",text:$t}}')
+  run bash "$SCRIPT" ts <<< "$input"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *$'\033'* ]]   # ESC 除去
+  [[ "$output" != *$'\007'* ]]   # BEL 除去
+  [[ "$output" == *"RED"* ]]     # 可視テキストは残る（不活性化のみ）
+}
+
+@test "codex-stream-fmt: パース不能な生行のエスケープも無害化する（raw 素通し経路）" {
+  require_jq
+  local input
+  input=$(printf 'not json \033[2Jclear \033]0;pwn\007 tail')
+  run bash "$SCRIPT" gen <<< "$input"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *$'\033'* ]]
+  [[ "$output" != *$'\007'* ]]
+  [[ "$output" == *"tail"* ]]
+}
+
+@test "codex-stream-fmt: jq 不在フォールバックでもエスケープを無害化する" {
+  local input
+  input=$(printf 'raw \033[31mx\007y')
+  run env PATH="${BATS_TEST_TMPDIR:-/tmp}" /bin/bash "$SCRIPT" fb <<< "$input"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *$'\033'* ]]
+  [[ "$output" != *$'\007'* ]]
+  [[ "$output" == *"[fb]"* ]]
 }

--- a/tests/codex_stream_fmt.bats
+++ b/tests/codex_stream_fmt.bats
@@ -165,7 +165,7 @@ require_jq() {
 
 @test "codex-stream-fmt: agent_message 内の ANSI/OSC エスケープを無害化する（valid JSON 経路）" {
   require_jq
-  # ESC を含む値を jq で valid JSON（ エスケープ）に組み立て、fromjson→short 経由で
+  # ESC を含む値を jq で valid JSON に組み立て（値のバイトは実行時 printf で生成）、fromjson→short 経由で
   # 出力される。無害化前は ESC/BEL が素通しされる（このテストが RED を示す）。
   local esc bel input
   esc=$(printf '\033'); bel=$(printf '\007')
@@ -197,4 +197,19 @@ require_jq() {
   [[ "$output" != *$'\033'* ]]
   [[ "$output" != *$'\007'* ]]
   [[ "$output" == *"[fb]"* ]]
+}
+
+@test "codex-stream-fmt: jq 経路は C1 制御文字(0x80-0x9F)を除去し日本語は保持する" {
+  require_jq
+  # C1（U+009B = 8bit CSI 導入子）を含む値を jq で valid JSON に組み立てる。jq 経路は
+  # codepoint 単位で無害化するため C1 は除去され、日本語（U+3000 以降）は保持される。
+  # フォールバック経路はバイト単位のため C1 を残す（保証範囲の差、スクリプト冒頭コメント参照）。
+  local input c1
+  input=$(jq -cn '{type:"item.completed",item:{type:"agent_message",text:("日本語" + ([155]|implode) + "X")}}')
+  c1=$(jq -rn '[155]|implode')   # U+009B 実体（byte 誤検知を避けるため codepoint で照合）
+  run bash "$SCRIPT" ts <<< "$input"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"$c1"* ]]     # C1 は出力に残らない
+  [[ "$output" == *"日本語"* ]]   # 日本語は保持される
+  [[ "$output" == *"X"* ]]
 }

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -605,15 +605,26 @@ load helpers/setup
   grep -q -- '-o <RESULT_FILE>' "$skill"
   grep -q 'CODEX_MAX_CONCURRENCY' "$skill"
   grep -q 'fresh フォールバック' "$skill"
-  # #407 robustness: fail-open guard on undefined --tier, standalone security
-  # floor, and the resolved OQ-005 (sessions.json TTL / cleanup).
+  # #407 robustness — phrase-level assertions that guard semantic regression, not
+  # mere word presence (a bare 'fail-open'/'--tier' elsewhere must not satisfy these):
+  # fail-open guard — an undefined --tier value is treated as empty, not fail-open.
   grep -q 'fail-open' "$skill"
+  grep -qE '未定義値.*空扱い' "$skill"
+  # security floor is a post-determination, UNCONDITIONAL backstop that overrides
+  # even an explicit --tier=trivial/small (M1) — assert the max() formula + override.
   grep -q 'security フロア' "$skill"
-  grep -q '無条件で tier ≥ standard' "$skill"
+  grep -qF 'final = max(TIER, standard)' "$skill"
+  grep -qE '明示.*--tier.*上書き' "$skill"
+  grep -q '決定的' "$skill"
+  # floor keyword coverage is case-insensitive and floor-not-ceiling (S3).
+  grep -q '大文字小文字を無視' "$skill"
+  grep -q 'jwt' "$skill"; grep -q 'oauth' "$skill"
+  grep -q 'floor であって ceiling ではない' "$skill"
+  # resolved OQ-005 (sessions.json TTL / cleanup).
   grep -q 'OQ-005: 解決済み' "$skill"
   # tier auto-inference points at pr-workflow's tier table as SSOT (no paraphrase).
+  grep -qE 'size tier の判定軸.*SSOT' "$skill"
   grep -q 'size tier の判定軸' "$pw"
-  grep -q 'pr-workflow' "$skill"
   # pr-workflow Phase 6 explicitly forwards the determined tier to multi-review.
   grep -q -- '--tier' "$pw"
   # The stale "always-on 3 tools" framing must be gone from the tier-aware roster.
@@ -630,6 +641,8 @@ load helpers/setup
   grep -q 'tier gating' "$skill"
   grep -q 'offload' "$skill"
   grep -q -- '--tier' "$skill"
+  # review-fleet must not pass --tier by default (phrase-level, not mere '--tier').
+  grep -q '既定で渡さない' "$skill"
 }
 
 # The pipeline Plan (<slug>.plan.md) must be git-trackable while ad-hoc

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -590,6 +590,48 @@ load helpers/setup
   grep -q -- '--spec-context' "${HOME_DIR}/dot_agents/skills/pr-workflow/SKILL.md"
 }
 
+@test "multi-review tier-aware roster / Codex-offload contract (#407)" {
+  local skill="${HOME_DIR}/dot_agents/skills/multi-review/SKILL.md"
+  local pw="${HOME_DIR}/dot_agents/skills/pr-workflow/SKILL.md"
+  [ -f "$skill" ]
+  # The four size tiers each own a row in the roster gating table.
+  local t
+  for t in trivial small standard large; do
+    grep -qE "^\| \*\*${t}\*\*" "$skill" || { echo "missing gating row for tier: $t"; return 1; }
+  done
+  # Codex observation/offload wiring: --json stream + -o result file + named
+  # concurrency cap + resume's fresh fallback.
+  grep -q -- '--json' "$skill"
+  grep -q -- '-o <RESULT_FILE>' "$skill"
+  grep -q 'CODEX_MAX_CONCURRENCY' "$skill"
+  grep -q 'fresh フォールバック' "$skill"
+  # #407 robustness: fail-open guard on undefined --tier, standalone security
+  # floor, and the resolved OQ-005 (sessions.json TTL / cleanup).
+  grep -q 'fail-open' "$skill"
+  grep -q 'security フロア' "$skill"
+  grep -q '無条件で tier ≥ standard' "$skill"
+  grep -q 'OQ-005: 解決済み' "$skill"
+  # tier auto-inference points at pr-workflow's tier table as SSOT (no paraphrase).
+  grep -q 'size tier の判定軸' "$pw"
+  grep -q 'pr-workflow' "$skill"
+  # pr-workflow Phase 6 explicitly forwards the determined tier to multi-review.
+  grep -q -- '--tier' "$pw"
+  # The stale "always-on 3 tools" framing must be gone from the tier-aware roster.
+  ! grep -q '3ツールレビュー' "$skill"
+  ! grep -q '常設 3 ツール' "$skill"
+}
+
+@test "review-fleet reflects tier gating + Codex offload, not a fixed 3-tool roster (#407)" {
+  local skill="${HOME_DIR}/dot_agents/skills/review-fleet/SKILL.md"
+  [ -f "$skill" ]
+  # No stale "always-on 3 tools" wording remains.
+  ! grep -q '常設 3 ツール' "$skill"
+  # Tier gating + Codex offload framing and the --tier decision are documented.
+  grep -q 'tier gating' "$skill"
+  grep -q 'offload' "$skill"
+  grep -q -- '--tier' "$skill"
+}
+
 # The pipeline Plan (<slug>.plan.md) must be git-trackable while ad-hoc
 # timestamp plans stay ignored — the handoff artifact would break otherwise.
 @test "Plan-PRD pipeline plans are un-ignored in the global gitignore" {


### PR DESCRIPTION
## 概要

Issue #407（PR #406 のドッグフード由来 follow-up）の全 10 項目を実装する。重要度は SHOULD / NITS 相当だが、
項目 6（端末エスケープ無害化）と項目 7（security フロア）は security surface に触れるため fail-safe を優先した。

`closes #407`

## 変更内容

### テスト品質（項目 1・2）
- `codex_stream_fmt.bats`: 完全一致検証・複数行 JSONL の順序契約・フォールバック分岐（`reasoning.summary` /
  `command_execution.cmd` / `output_tokens` 既定 0）を網羅。jq 必須テストに skip ガード（環境非依存化）。
- `files.bats`: multi-review / review-fleet の tier 契約（roster 4 種・`CODEX_MAX_CONCURRENCY`・`--json`/`-o`・
  resume の fresh fallback・fail-open 防止・security フロア・OQ-005 解決・Phase 6 の `--tier` 伝達）を grep で固定。

### 設計 drift / SSOT（項目 3・4）
- `review-fleet/SKILL.md`: 「常設 3 ツール」記述を tier gating + Codex offload の実態へ更新。`--tier` を既定で
  渡さない決定を明記。
- `multi-review/SKILL.md`: tier 自動推定の判定軸を pr-workflow「size tier の判定軸」表への pointer に寄せ、
  paraphrase 重複を削減。

### セキュリティ・堅牢性（項目 5・6・7）
- **項目 6（defect fix, RED→GREEN）**: `codex-stream-fmt` の全出力経路で ANSI/OSC・ESC/BEL 等の制御文字を
  無害化（terminal escape injection 対策）。jq 経路はコードポイント数値ベース、jq 不在フォールバックは builtin のみ。
- **項目 5**: 未定義 `--tier` 値を空扱い→自動推定にフォールバック（fail-open 防止）。
- **項目 7**: standalone `/multi-review` で security surface パス検出時は無条件 tier ≥ standard（機械的ルール）。

### 未解決 OQ / NITS（項目 8・9・10）
- **項目 8（OQ-005）**: `sessions.json` / scratch codex-review dir の TTL / クリーンアップ契機を確定
  （idempotent 再作成 + mtime 7 日 TTL 掃除、round 1 開始時のみ）。
- **項目 9**: `skills-provenance.md`（+ `.ja.md`）の argument-hint 例に `--tier` / `--spec-context` を反映。
  パス値オプションの空白区切り許容を canonical shape ルールに追記。
- **項目 10**: trigger keyword「3ツールレビュー」と description を tier-aware roster + Codex offload の実態へ更新。

## テスト

- `make lint`: pass（shellcheck / shfmt / zsh 構文）
- `bats tests/codex_stream_fmt.bats`: 22/22 pass（うち項目 6 の無害化 3 件は RED→GREEN で確認）
- `bats tests/files.bats`: 173/173 pass

## 補足

- 本 PR は chezmoi source（`home/` 配下）の変更のみで、`chezmoi apply` による deploy は含まない。
- スコープ外: multi-review 引数パーサの構文変更（`--spec-context=<dir>` への正規化等の behavior change）。
  doc 例は実態（空白区切り）に合わせるに留めた。
